### PR TITLE
Fix errors caused by line breaking

### DIFF
--- a/dnatracing.py
+++ b/dnatracing.py
@@ -223,18 +223,18 @@ class dnaTrace(object):
                     # prevents negative number indexing
                     # i.e. stops (trace_coordinate - index_width) < 0
                     trace_coordinate[0] = index_width
-                elif trace_coordinate[0] >= self.number_of_rows -
-                                                        index_width:
+                elif trace_coordinate[0] >= (self.number_of_rows -
+                                                        index_width):
                     # prevents indexing above image range causing IndexError
-                    trace_coordinate[0] = self.number_of_rows -
-                                                        index_width
+                    trace_coordinate[0] = (self.number_of_rows -
+                                                        index_width)
                 # do same for y coordinate
                 elif trace_coordinate[1] < 0:
                     trace_coordinate[1] = index_width
-                elif trace_coordinate[1] >= self.number_of_columns -
-                                                        index_width:
-                    trace_coordinate[1] = self.number_of_columns -
-                                                        index_width
+                elif trace_coordinate[1] >= (self.number_of_columns -
+                                                        index_width):
+                    trace_coordinate[1] = (self.number_of_columns -
+                                                        index_width)
 
 
                 # calculate vector to n - 2 coordinate in trace
@@ -307,8 +307,7 @@ class dnaTrace(object):
 
                 # Use the perp array to index the guassian filtered image
                 perp_array = np.column_stack((x_coords, y_coords))
-                height_values =
-                            self.gauss_image[perp_array[:,1], perp_array[:,0]]
+                height_values = self.gauss_image[perp_array[:,1], perp_array[:,0]]
 
                 '''
                 # Old code that interpolated the height profile for "sub-pixel


### PR DESCRIPTION
During the previous update, some lines were broken into two. I just realised that this would cause errors, so I fixed it by adding brackets.