### PR TITLE
Relative File Path & Wrong Filename Bug Fixes

### DIFF
--- a/dnatracing.py
+++ b/dnatracing.py
@@ -678,7 +678,7 @@ class traceStats(object):
 
         data_dict = {}
 
-        trace_directory_file = self.trace_object.afm_image_name
+        trace_directory_file = new_traces.afm_image_name
         trace_directory = os.path.dirname(trace_directory_file)
         img_name = os.path.basename(trace_directory_file)
 

--- a/pygwytracing.py
+++ b/pygwytracing.py
@@ -715,7 +715,7 @@ if __name__ == '__main__':
     # path = '/Volumes/GoogleDrive/My Drive/AFM research group /Methods paper/Data/Fortracing'
     # path = '/Volumes/GoogleDrive/My Drive/AFM research group /Methods paper/Data/Fortracing'
     path = './'
-    
+    path = os.path.abspath(path)
     # Set sample type here
     sample_type = 'DNA'
     # sample_type = 'MAC'


### PR DESCRIPTION
The relative file path made it so certain files were not created - resolved by amending to fullpath.
Incorrect reference to self made it so all image names and image paths in the tracestats.json files were the same regardless of different files being used.