### PR TITLE
118 | Adds a factory method to make thresholding flexible

### DIFF
--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,0 +1,148 @@
+"""Test of thresholds"""
+import pytest
+import numpy as np
+from skimage.filters import threshold_mean, threshold_minimum, threshold_otsu, threshold_yen, threshold_triangle
+
+from topostats.thresholds import threshold
+
+OPTIONS = {
+    'nbins': 10,
+}
+
+
+def test_threshold_invalid_method(image_random: np.array) -> None:
+    """Test exceptions is raised when invalid method supplied.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    with pytest.raises(ValueError):
+        threshold_invalid = threshold(image_random, method='shoes')
+
+
+def test_threshold_otsu(image_random: np.array) -> None:
+    """Test the Otsu threshold method.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='otsu')
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_otsu(image_random)
+
+
+def test_threshold_otsu_keywords(image_random: np.array) -> None:
+    """Test the Otsu threshold method with additional keywords.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='otsu', **OPTIONS)
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_otsu(image_random, **OPTIONS)
+
+
+def test_threshold_minimum(image_random: np.array) -> None:
+    """Test the Minimum threshold method.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='minimum')
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_minimum(image_random)
+
+
+# def test__threshold_keywords(image_random: np.array) -> None:
+#     """Test the Minimum threshold method with additional keywords.
+
+#     Parameters
+#     ----------
+#     image_random : np.array
+#         Numpy array representing an image.
+#     """
+#     _threshold = threshold(image_random, method='minimum', **OPTIONS)
+
+#     assert isinstance(_threshold, float)
+#     assert _threshold == threshold_minimum(image_random, **OPTIONS)
+
+
+def test_threshold_mean(image_random: np.array) -> None:
+    """Test the Mean threshold method.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='mean')
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_mean(image_random)
+
+
+def test_threshold_yen(image_random: np.array) -> None:
+    """Test the Yen threshold method.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='yen')
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_yen(image_random)
+
+
+def test_threshold_yen_keywords(image_random: np.array) -> None:
+    """Test the Yen threshold method with additional keywords.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='yen', **OPTIONS)
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_yen(image_random, **OPTIONS)
+
+
+def test_threshold_triangle(image_random: np.array) -> None:
+    """Test the Triangle threshold method.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='triangle')
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_triangle(image_random)
+
+
+def test_threshold_triangle_keywords(image_random: np.array) -> None:
+    """Test the Triangle threshold method with additional keywords.
+
+    Parameters
+    ----------
+    image_random : np.array
+        Numpy array representing an image.
+    """
+    _threshold = threshold(image_random, method='triangle', **OPTIONS)
+
+    assert isinstance(_threshold, float)
+    assert _threshold == threshold_triangle(image_random, **OPTIONS)

--- a/topostats/thresholds.py
+++ b/topostats/thresholds.py
@@ -27,7 +27,7 @@ def threshold(image: np.array, method: str = 'otsu', **kwargs: dict) -> float:
     return thresholder(image, **kwargs)
 
 
-def _get_threshold(method: str = 'otsu') -> np.array:
+def _get_threshold(method: str = 'otsu'):
     """Creator component which determines which threshold method to use.
 
     Parameters
@@ -37,7 +37,7 @@ def _get_threshold(method: str = 'otsu') -> np.array:
 
     Returns
     -------
-    np.array
+    function
         Returns function appropriate for the required threshold method.
 
     Raises

--- a/topostats/thresholds.py
+++ b/topostats/thresholds.py
@@ -1,0 +1,84 @@
+"""Functions for calculating thresholds."""
+import numpy as np
+from skimage.filters import threshold_mean, threshold_minimum, threshold_otsu, threshold_yen, threshold_triangle
+
+
+def threshold(image: np.array, method: str = 'otsu', **kwargs: dict) -> float:
+    """Factory method for thresholding.
+
+    Parameters
+    ----------
+    method : str
+        Method to use for thresholding, currently supported methods are otsu (default), mean and minimum.
+    **kwargs : dict
+        Additional keyword arguments to pass to skimage methods.
+
+    Returns
+    -------
+    float
+        Threshold of image using specified method.
+
+    Examples
+    --------
+    FIXME: Add docs.
+
+    """
+    thresholder = _get_threshold(method)
+    return thresholder(image, **kwargs)
+
+
+def _get_threshold(method: str = 'otsu') -> np.array:
+    """Creator component which determines which threshold method to use.
+
+    Parameters
+    ----------
+    method : str
+        Threshold method to use, currently supports otsu (default), minimum, mean and yen.
+
+    Returns
+    -------
+    np.array
+        Returns function appropriate for the required threshold method.
+
+    Raises
+    ------
+    ValueError
+        Unsupported methods result in ValueError.
+
+    Examples
+    --------
+    FIXME: Add docs.
+
+    """
+    if method == 'otsu':
+        return _threshold_otsu
+    elif method == 'mean':
+        return _threshold_mean
+    elif method == 'minimum':
+        return _threshold_minimum
+    elif method == 'yen':
+        return _threshold_yen
+    elif method == 'triangle':
+        return _threshold_triangle
+    else:
+        raise ValueError(method)
+
+
+def _threshold_otsu(image: np.array, **kwargs) -> float:
+    return threshold_otsu(image, **kwargs)
+
+
+def _threshold_mean(image: np.array) -> float:
+    return threshold_mean(image)
+
+
+def _threshold_minimum(image: np.array, **kwargs) -> float:
+    return threshold_minimum(image, **kwargs)
+
+
+def _threshold_yen(image: np.array, **kwargs) -> float:
+    return threshold_yen(image, **kwargs)
+
+
+def _threshold_triangle(image: np.array, **kwargs) -> float:
+    return threshold_triangle(image, **kwargs)


### PR DESCRIPTION
resolves #118 

This adds a simple [factory design pattern](https://realpython.com/factory-method-python/) to perform the threshold calculation on images.

It includes tests which show how to use it (and validate) and it should be easy to add additional methods.

To use it in `dev-remove-gwyddion` it would be necessary to [cherry-pick](https://rse.shef.ac.uk/blog/2021-04-23-cherry-pick/) commit `8f0542b` to get it into the branch (or possibly a `rebase` but I'm unsure how divergent `dev` and `dev-remove-gwyddion` are and that may cause lots of problems).

It can then be used with...

```
from topostats.thresholds import threshold

image_threshold = threshold(<image>, method='otsu')
```

...where `<image>` is the `np.ndarray` representation of the image at whatever stage of the processing.