### PR TITLE
Aligns grainstats output with dnatracing input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ is included in the directory `config/example.yml` under the `dev` branch and you
 `minicircle.spm` (found under `tests/resources/minicircle.spm`) with the following...
 
 ``` bash
-./run_topostats.py --config config/example.yaml
+./run_topostats --config config/example.yaml
 ```
 
 This version takes command line arguments, and you _have_ to include `--config path/to/valid/config.yaml` option. You

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ is included in the directory `config/example.yml` under the `dev` branch and you
 `minicircle.spm` (found under `tests/resources/minicircle.spm`) with the following...
 
 ``` bash
-python topostats/topotracing.py --config config/example.yaml
+./run_topostats.py --config config/example.yaml
 ```
 
 This version takes command line arguments, and you _have_ to include `--config path/to/valid/config.yaml` option. You
 can see what other options are available with...
 
 ``` bash
-python topostats/topotracing.py --help
+./run_topostats --help
 ```
 
 Any options specified on the command line will over-ride those in the configuration file, for example to suppress log
 messages and just have a progress bar you can over-ride the `quiet: false` option on the command line with.
 
 ``` bash
-python topostats/topotracing.py --config config/example.yaml --quiet True
+./run_topostats --config config/example.yaml --quiet True
 ```
 
 ## Contributing

--- a/run_topostats
+++ b/run_topostats
@@ -170,15 +170,6 @@ def process_scan(
     grain_statistics = grainstats.calculate_stats()
 
     # Run dnatracing
-    # np.savetxt(Path("/home/neil/tmp/TopoStats/TOPOSTATS_PIXELS.csv"), filtered_image.images["pixels"], delimiter=",")
-    # np.savetxt(Path("/home/neil/tmp/TopoStats/TOPOSTATS_GRAINS.csv"), grains.images["labelled_regions"], delimiter=",")
-    # np.savetxt(
-    #     Path("/home/neil/tmp/TopoStats/TOPOSTATS_GAUSSIAN_FILTERED.csv"),
-    #     grains.images["gaussian_filtered"],
-    #     delimiter=",",
-    # )
-    print(f"FROM run_topostats : {grains.images['labelled_regions']}")
-    #    print(f"FROM run_topostats : {grains.images['labelled_regions'].tolist()}")
     dna_traces = dnaTrace(
         full_image_data=grains.images["gaussian_filtered"].T,
         grains=grains.images["labelled_regions"],
@@ -226,10 +217,10 @@ def main():
     config = read_yaml(args.config_file)
     config = update_config(config, args)
 
-    LOGGER.info(f"Configuration file loaded from    : {args.config_file}")
-    LOGGER.info(f'Scanning for images in            : {config["base_dir"]}')
-    LOGGER.info(f'Output directory                  : {config["output_dir"]}')
-    LOGGER.info(f'Looking for images with extension : {config["file_ext"]}')
+    LOGGER.info(f"Configuration file loaded from      : {args.config_file}")
+    LOGGER.info(f'Scanning for images in              : {config["base_dir"]}')
+    LOGGER.info(f'Output directory                    : {config["output_dir"]}')
+    LOGGER.info(f'Looking for images with extension   : {config["file_ext"]}')
     img_files = find_images(config["base_dir"])
     LOGGER.info(f'Images with extension {config["file_ext"]} in {config["base_dir"]} : {len(img_files)}')
 

--- a/run_topostats
+++ b/run_topostats
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Topotracing"""
 import argparse as arg
 from functools import partial
@@ -5,6 +6,7 @@ from multiprocessing import Pool
 from pathlib import Path
 from typing import Union, Dict
 from tqdm import tqdm
+import numpy as np
 
 from topostats.filters import Filters
 from topostats.grains import Grains
@@ -13,6 +15,7 @@ from topostats.io import read_yaml
 from topostats.logs.logs import setup_logger, LOGGER_NAME
 from topostats.plottingfuncs import plot_and_save
 from topostats.thresholds import threshold
+from topostats.tracing.dnatracing import dnaTrace
 from topostats.utils import convert_path, find_images, update_config
 
 LOGGER = setup_logger(LOGGER_NAME)
@@ -165,6 +168,25 @@ def process_scan(
         output_dir=output_dir,
     )
     grain_statistics = grainstats.calculate_stats()
+
+    # Run dnatracing
+    # np.savetxt(Path("/home/neil/tmp/TopoStats/TOPOSTATS_PIXELS.csv"), filtered_image.images["pixels"], delimiter=",")
+    # np.savetxt(Path("/home/neil/tmp/TopoStats/TOPOSTATS_GRAINS.csv"), grains.images["labelled_regions"], delimiter=",")
+    # np.savetxt(
+    #     Path("/home/neil/tmp/TopoStats/TOPOSTATS_GAUSSIAN_FILTERED.csv"),
+    #     grains.images["gaussian_filtered"],
+    #     delimiter=",",
+    # )
+    print(f"FROM run_topostats : {grains.images['labelled_regions']}")
+    #    print(f"FROM run_topostats : {grains.images['labelled_regions'].tolist()}")
+    dna_traces = dnaTrace(
+        full_image_data=grains.images["gaussian_filtered"].T,
+        grains=grains.images["labelled_regions"],
+        afm_image_name=filtered_image.filename,
+        pixel_size=filtered_image.pixel_to_nm_scaling,
+        number_of_columns=grains.images["labelled_regions"].shape[0],
+        number_of_rows=grains.images["labelled_regions"].shape[1],
+    )
 
     # Optionally plot all stages
     if save_plots:

--- a/run_topostats
+++ b/run_topostats
@@ -178,7 +178,7 @@ def process_scan(
         number_of_columns=grains.images["labelled_regions"].shape[0],
         number_of_rows=grains.images["labelled_regions"].shape[1],
     )
-
+    # dna_traces.updateTraceStats()
     # Optionally plot all stages
     if save_plots:
         # Filtering stage
@@ -206,6 +206,13 @@ def process_scan(
             )
         # Grainstats
         # FIXME : Include this
+        dna_traces.saveTraceFigures(
+            filename=filtered_image.filename,
+            channel_name=channel,
+            minheightscale=-0e-9,
+            maxheightscale=3e-9,
+            directory_name=Path(output_dir) / filtered_image.filename,
+        )
 
 
 def main():

--- a/run_topostats.py
+++ b/run_topostats.py
@@ -1,5 +1,6 @@
 """Topotracing"""
 import argparse as arg
+from collections import defaultdict
 from functools import partial
 from multiprocessing import Pool
 from pathlib import Path
@@ -183,11 +184,12 @@ def process_scan(
     tracing_stats.saveTraceStats(Path(output_dir) / filtered_image.filename)
 
     # Combine grainstats and tracingstats
-    results = grain_statistics["statistics"].merge(tracing_stats.pd_dataframe, on="Molecule Number", indicator=True)
+    results = grain_statistics["statistics"].merge(tracing_stats.pd_dataframe, on="Molecule Number")
     results.to_csv(output_dir / filtered_image.filename / "all_statistics.csv")
 
     # Optionally plot all stages
     if save_plots:
+        LOGGER.info("Saving plots of images at all stages of processing.")
         # Filtering stage
         for plot_name, array in filtered_image.images.items():
             if plot_name not in ["scan_raw", "extracted_channel"]:
@@ -195,6 +197,7 @@ def process_scan(
                 plot_and_save(array, **PLOT_DICT[plot_name])
         # Grain stage - only if we have grains
         if len(grains.region_properties) > 0:
+            LOGGER.info("Grains found, saving individual images and bounding boxes.")
             for plot_name, array in grains.images.items():
                 PLOT_DICT[plot_name]["output_dir"] = Path(output_dir) / filtered_image.filename
                 plot_and_save(array, **PLOT_DICT[plot_name])
@@ -220,7 +223,7 @@ def process_scan(
         #     maxheightscale=3e-9,
         #     directory_name=Path(output_dir) / filtered_image.filename,
         # )
-    return results
+    return image_path, results
 
 
 def main():
@@ -267,16 +270,21 @@ def main():
     )
 
     with Pool(processes=config["cores"]) as pool:
+        results = defaultdict()
         with tqdm(
             total=len(img_files),
             desc=f'Processing images from {config["base_dir"]}, results are under {config["output_dir"]}',
         ) as pbar:
-            for _ in pool.imap_unordered(processing_function, img_files):
+            for img, result in pool.imap_unordered(processing_function, img_files):
+                results[str(img)] = result
                 pbar.update()
-    results = pool.join()
 
-    print("ALL RESULTS :\n{results}")
-    results.to_csv()
+    results = pd.concat(results.values())
+    results.reset_index()
+    results.to_csv(config["output_dir"] / "all_statistics.csv", index=False)
+    LOGGER.info(
+        f"All statistics combined for {len(img_files)} are saved to : {str(config['output_dir'] / 'all_statistics.csv')}"
+    )
 
 
 if __name__ == "__main__":

--- a/run_topostats.py
+++ b/run_topostats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Topotracing"""
 import argparse as arg
 from functools import partial
@@ -15,7 +14,7 @@ from topostats.io import read_yaml
 from topostats.logs.logs import setup_logger, LOGGER_NAME
 from topostats.plottingfuncs import plot_and_save
 from topostats.thresholds import threshold
-from topostats.tracing.dnatracing import dnaTrace
+from topostats.tracing.dnatracing import dnaTrace, traceStats
 from topostats.utils import convert_path, find_images, update_config
 
 LOGGER = setup_logger(LOGGER_NAME)
@@ -178,7 +177,10 @@ def process_scan(
         number_of_columns=grains.images["labelled_regions"].shape[0],
         number_of_rows=grains.images["labelled_regions"].shape[1],
     )
-    # dna_traces.updateTraceStats()
+    tracing_stats = traceStats(dna_traces)
+    # tracing_stats
+    tracing_stats.saveTraceStats(Path(output_dir) / filtered_image.filename)
+
     # Optionally plot all stages
     if save_plots:
         # Filtering stage
@@ -206,13 +208,13 @@ def process_scan(
             )
         # Grainstats
         # FIXME : Include this
-        dna_traces.saveTraceFigures(
-            filename=filtered_image.filename,
-            channel_name=channel,
-            minheightscale=-0e-9,
-            maxheightscale=3e-9,
-            directory_name=Path(output_dir) / filtered_image.filename,
-        )
+        # dna_traces.saveTraceFigures(
+        #     filename=filtered_image.filename,
+        #     channel_name=channel,
+        #     minheightscale=-0e-9,
+        #     maxheightscale=3e-9,
+        #     directory_name=Path(output_dir) / filtered_image.filename,
+        # )
 
 
 def main():

--- a/run_topostats.py
+++ b/run_topostats.py
@@ -4,8 +4,10 @@ from functools import partial
 from multiprocessing import Pool
 from pathlib import Path
 from typing import Union, Dict
-from tqdm import tqdm
+
 import numpy as np
+import pandas as pd
+from tqdm import tqdm
 
 from topostats.filters import Filters
 from topostats.grains import Grains
@@ -164,7 +166,7 @@ def process_scan(
         labelled_data=grains.images["labelled_regions"],
         pixel_to_nanometre_scaling=filtered_image.pixel_to_nm_scaling,
         img_name=filtered_image.filename,
-        output_dir=output_dir,
+        output_dir=output_dir / filtered_image.filename,
     )
     grain_statistics = grainstats.calculate_stats()
 
@@ -177,9 +179,12 @@ def process_scan(
         number_of_columns=grains.images["labelled_regions"].shape[0],
         number_of_rows=grains.images["labelled_regions"].shape[1],
     )
-    tracing_stats = traceStats(dna_traces)
-    # tracing_stats
+    tracing_stats = traceStats(trace_object=dna_traces, image_path=image_path)
     tracing_stats.saveTraceStats(Path(output_dir) / filtered_image.filename)
+
+    # Combine grainstats and tracingstats
+    results = grain_statistics["statistics"].merge(tracing_stats.pd_dataframe, on="Molecule Number", indicator=True)
+    results.to_csv(output_dir / filtered_image.filename / "all_statistics.csv")
 
     # Optionally plot all stages
     if save_plots:
@@ -215,6 +220,7 @@ def process_scan(
         #     maxheightscale=3e-9,
         #     directory_name=Path(output_dir) / filtered_image.filename,
         # )
+    return results
 
 
 def main():
@@ -267,6 +273,10 @@ def main():
         ) as pbar:
             for _ in pool.imap_unordered(processing_function, img_files):
                 pbar.update()
+    results = pool.join()
+
+    print("ALL RESULTS :\n{results}")
+    results.to_csv()
 
 
 if __name__ == "__main__":

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -156,8 +156,8 @@ class GrainStats:
             # from pixel units to nanometres.
             # Removed formatting, better to keep accurate until the end, including in CSV, then shorten display
             stats = {
-                'centre_x': centre_x * self.pixel_to_nanometre_scaling,
-                'centre_y': centre_y * self.pixel_to_nanometre_scaling,
+                "centre_x": centre_x * self.pixel_to_nanometre_scaling,
+                "centre_y": centre_y * self.pixel_to_nanometre_scaling,
                 "radius_min": radius_stats["min"] * self.pixel_to_nanometre_scaling,
                 "radius_max": radius_stats["max"] * self.pixel_to_nanometre_scaling,
                 "radius_mean": radius_stats["mean"] * self.pixel_to_nanometre_scaling,
@@ -187,6 +187,7 @@ class GrainStats:
             ax.add_patch(rectangle)
 
         grainstats = pd.DataFrame(data=stats_array)
+        grainstats.index.name = "Molecule Number"
         grainstats.to_csv(self.output_dir / "grainstats.csv")
 
         return {"statistics": grainstats, "plot": ax}
@@ -201,14 +202,14 @@ class GrainStats:
     @staticmethod
     def calculate_points(grain_mask: np.ndarray):
         """Class method that takes a 2D boolean numpy array image of a grain and returns a list containing the co-ordinates of the points in the grain.
-        
-            Parameters:
-                grain_mask : np.ndarray
-                    A 2D numpy array image of a grain. Data in the array must be boolean.
-                    
-            Returns:
-                edges : list
-                    A python list containing the coordinates of the pixels in the grain. """
+
+        Parameters:
+            grain_mask : np.ndarray
+                A 2D numpy array image of a grain. Data in the array must be boolean.
+
+        Returns:
+            edges : list
+                A python list containing the coordinates of the pixels in the grain."""
 
         nonzero_coordinates = grain_mask.nonzero()
         points = []

--- a/topostats/logs/logs.py
+++ b/topostats/logs/logs.py
@@ -10,7 +10,7 @@ import logging
 
 start = datetime.now()
 LOG_CONFIG = logging.basicConfig(
-    filename=str(str(Path().cwd()) + "-" + start.strftime("%Y-%m-%d-%H-%M-%S") + ".log"), filemode="w"
+    filename=Path().cwd().stem + f"-{start.strftime('%Y-%m-%d-%H-%M-%S')}.log", filemode="w"
 )
 LOG_FORMATTER = logging.Formatter(
     fmt="[%(asctime)s] [%(levelname)-8s] [%(name)s] %(message)s", datefmt="%a, %d %b %Y %H:%M:%S"

--- a/topostats/logs/logs.py
+++ b/topostats/logs/logs.py
@@ -9,15 +9,18 @@ import logging
 # pylint: disable=assignment-from-no-return
 
 start = datetime.now()
-LOG_CONFIG = logging.basicConfig(filename=str(str(Path().cwd()) + start.strftime('%Y-%m-%d-%H-%M-%S') + '.log'),
-                                 filemode='w')
-LOG_FORMATTER = logging.Formatter(fmt='[%(asctime)s] [%(levelname)-8s] [%(name)s] %(message)s',
-                                  datefmt='%a, %d %b %Y %H:%M:%S')
+LOG_CONFIG = logging.basicConfig(
+    filename=str(str(Path().cwd()) + "-" + start.strftime("%Y-%m-%d-%H-%M-%S") + ".log"), filemode="w"
+)
+LOG_FORMATTER = logging.Formatter(
+    fmt="[%(asctime)s] [%(levelname)-8s] [%(name)s] %(message)s", datefmt="%a, %d %b %Y %H:%M:%S"
+)
 LOG_ERROR_FORMATTER = logging.Formatter(
-    fmt='[%(asctime)s] [%(levelname)-8s] [%(name)s] [%(filename)s] [%(lineno)s] %(message)s',
-    datefmt='%a, %d %b %Y %H:%M:%S')
+    fmt="[%(asctime)s] [%(levelname)-8s] [%(name)s] [%(filename)s] [%(lineno)s] %(message)s",
+    datefmt="%a, %d %b %Y %H:%M:%S",
+)
 
-LOGGER_NAME = 'topostats'
+LOGGER_NAME = "topostats"
 
 
 def setup_logger(log_name: str = LOGGER_NAME) -> logging.Logger:

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -73,7 +73,7 @@ class dnaTrace(object):
         # supresses scipy splining warnings
         warnings.filterwarnings("ignore")
 
-        LOGGER.info("Processing.....................................")
+        LOGGER.info("Performing DNA Tracing")
 
         self.getNumpyArraysfromGwyddion()
         self.getDisorderedTrace()
@@ -213,7 +213,9 @@ class dnaTrace(object):
 
     def reportBasicStats(self):
         # self.determineLinearOrCircular()
-        print(f"There are {self.num_circular} circular and {self.num_linear} linear DNA molecules found in the image")
+        LOGGER.info(
+            f"There are {self.num_circular} circular and {self.num_linear} linear DNA molecules found in the image"
+        )
 
     def getFittedTraces(self):
         """
@@ -905,19 +907,10 @@ class traceStats(object):
 
         self.pd_dataframe = self.pd_dataframe.append(pd_new_traces_dframe, ignore_index=True)
 
-    def saveTraceStats(self, save_path):
-        save_file_name = ""
-        # FIXME : Replace with Path()
-        if save_path[-1] == "/":
-            pass
-        else:
-            save_path = save_path + "/"
-
-        for i in self.trace_object.afm_image_name.split("/")[:-1]:
-            save_file_name = save_file_name + i + "/"
-        print(save_file_name)
-
-        self.pd_dataframe.to_json("%stracestats.json" % save_path)
-        self.pd_dataframe.to_csv("%stracestats.csv" % save_path)
-
-        print("Saved trace info for all analysed images into: %stracestats.json" % save_path)
+    def saveTraceStats(self, save_path: Union[str, Path], json: bool = True, csv: bool = True):
+        if json:
+            self.pd_dataframe.to_json(save_path / "tracestats.json")
+            LOGGER.info(f"Saved trace info for all analysed images to: {str(save_path / 'tracestats.json')}")
+        if csv:
+            self.pd_dataframe.to_csv(save_path / "tracestats.csv")
+            LOGGER.info(f"Saved trace info for all analysed images to: {str(save_path / 'tracestats.csv')}")

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -1,7 +1,9 @@
 """Perform DNA Tracing"""
 import logging
+from pathlib import Path
 import math
 import os
+from typing import Union
 import warnings
 
 import numpy as np
@@ -524,19 +526,23 @@ class dnaTrace(object):
         plt.show()
         plt.close()
 
-    def saveTraceFigures(self, filename_with_ext, channel_name, vmaxval, vminval, directory_name=None):
+    # def saveTraceFigures(self, filename_with_ext, channel_name, vmaxval, vminval, directory_name=None):
+    def saveTraceFigures(
+        self, filename: Union[str, Path], channel_name: str, vmaxval, vminval, output_dir: Union[str, Path] = None
+    ):
 
-        if directory_name:
-            filename_with_ext = self._checkForSaveDirectory(filename_with_ext, directory_name)
+        # if directory_name:
+        #     filename_with_ext = self._checkForSaveDirectory(filename_with_ext, directory_name)
 
-        save_file = filename_with_ext[:-4]
+        # save_file = filename_with_ext[:-4]
 
         # vmaxval = 20e-9
         # vminval = -10e-9
 
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
-        plt.savefig("%s_%s_originalImage.png" % (save_file, channel_name))
+        # plt.savefig("%s_%s_originalImage.png" % (save_file, channel_name))
+        plt.savefig(output_dir / filename / f"{channel_name}_original.png")
         plt.close()
 
         # plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
@@ -575,7 +581,9 @@ class dnaTrace(object):
         plt.colorbar()
         for dna_num in sorted(self.splined_traces.keys()):
             plt.plot(self.splined_traces[dna_num][:, 0], self.splined_traces[dna_num][:, 1], color="c", linewidth=1.0)
-        plt.savefig("%s_%s_splinedtrace.png" % (save_file, channel_name))
+        # plt.savefig("%s_%s_splinedtrace.png" % (save_file, channel_name))
+        plt.savefig(output_dir / filename / f"{channel_name}_splinedtrace.png")
+        LOGGER.info(f"Splined Trace image saved to : {str(output_dir / filename / f'{channel_name}_splinedtrace.png')}")
         plt.close()
 
         """
@@ -601,16 +609,22 @@ class dnaTrace(object):
                 markersize=0.5,
                 color="c",
             )
-        plt.savefig("%s_%s_disorderedtrace.png" % (save_file, channel_name))
+        # plt.savefig("%s_%s_disorderedtrace.png" % (save_file, channel_name))
+        plt.savefig(output_dir / filename / f"{channel_name}_disordered_trace.png")
         plt.close()
+        LOGGER.info(
+            f"Disordered trace image saved to : {str(output_dir / filename / f'{channel_name}_disordered_trace.png')}"
+        )
 
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
         for dna_num in sorted(self.grains.keys()):
             grain_plt = np.argwhere(self.grains[dna_num] == 1)
             plt.plot(grain_plt[:, 0], grain_plt[:, 1], "o", markersize=2, color="c")
-        plt.savefig("%s_%s_grains.png" % (save_file, channel_name))
+        # plt.savefig("%s_%s_grains.png" % (save_file, channel_name))
+        plt.savefig(output_dir / filename / f"{channel_name}_grains.png")
         plt.close()
+        LOGGER.info(f"Grains image saved to : {str(output_dir / filename / f'{channel_name}_grains.png')}")
 
     # FIXME : Replace with Path() (.mkdir(parent=True, exists=True) negate need to handle errors.)
     def _checkForSaveDirectory(self, filename, new_directory_name):

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -1,18 +1,24 @@
+"""Perform DNA Tracing"""
+import logging
+import math
+import os
+import warnings
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 from scipy import ndimage, spatial, interpolate as interp
 from skimage import morphology, filters
-import math
-import warnings
-import os
 
-from topostats.tracingfuncs import genTracingFuncs, getSkeleton, reorderTrace
+from topostats.logs.logs import LOGGER_NAME
+from topostats.tracing.tracingfuncs import genTracingFuncs, getSkeleton, reorderTrace
+
+LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class dnaTrace(object):
-    '''
+    """
     This class gets all the useful functions from the old tracing code and staples
     them together to create an object that contains the traces for each DNA molecule
     in an image and functions to calculate stats from those traces.
@@ -22,12 +28,13 @@ class dnaTrace(object):
 
     The object also keeps track of the skeletonised plots and other intermediates
     in case these are useful for other things in the future.
-    '''
+    """
 
-    def __init__(self, full_image_data, gwyddion_grains, afm_image_name, pixel_size,
-                 number_of_columns, number_of_rows):
+    def __init__(self, full_image_data, grains, afm_image_name, pixel_size, number_of_columns, number_of_rows):
         self.full_image_data = full_image_data
-        self.gwyddion_grains = gwyddion_grains
+        # FIXME: Gwyddion returned a list, we now have a 2D numpy array, flatten to a single list to fit workflow
+        #        look to replace with array based functions.
+        self.grains_orig = [x for row in grains for x in row]
         self.afm_image_name = afm_image_name
         self.pixel_size = pixel_size
         self.number_of_columns = number_of_columns
@@ -53,7 +60,9 @@ class dnaTrace(object):
         self.neighbours = 5  # The number of neighbours used for the curvature measurement
 
         # supresses scipy splining warnings
-        warnings.filterwarnings('ignore')
+        warnings.filterwarnings("ignore")
+
+        LOGGER.info("Processing.....................................")
 
         self.getNumpyArraysfromGwyddion()
         self.getDisorderedTrace()
@@ -72,7 +81,7 @@ class dnaTrace(object):
 
     def getNumpyArraysfromGwyddion(self):
 
-        ''' Function to get each grain as a numpy array which is stored in a
+        """Function to get each grain as a numpy array which is stored in a
         dictionary
 
         Currently the grains are unnecessarily large (the full image) as I don't
@@ -83,17 +92,18 @@ class dnaTrace(object):
 
         There is some kind of discrepency between the ordering of arrays from
         gwyddion and how they're usually handled in np arrays meaning you need
-        to be careful when indexing from gwyddion derived numpy arrays'''
-
-        for grain_num in set(self.gwyddion_grains):
+        to be careful when indexing from gwyddion derived numpy arrays"""
+        for grain_num in set(self.grains_orig):
             # Skip the background
             if grain_num == 0:
                 continue
 
             # Saves each grain as a multidim numpy array
-            single_grain_1d = np.array([1 if i == grain_num else 0 for i in self.gwyddion_grains])
+            single_grain_1d = np.array([1 if i == grain_num else 0 for i in self.grains_orig])
+            LOGGER.info(f"Grain {grain_num} : {single_grain_1d.mean()}")
             self.grains[int(grain_num)] = np.reshape(single_grain_1d, (self.number_of_columns, self.number_of_rows))
 
+        # FIXME : This should be a method of its own, but strange that apparently Gaussian filtered image is filtered again
         # Get a 7 A gauss filtered version of the original image
         # used in refining the pixel positions in getFittedTraces()
         sigma = 0.7 / (self.pixel_size * 1e9)
@@ -101,23 +111,25 @@ class dnaTrace(object):
 
     def getDisorderedTrace(self):
 
-        '''Function to make a skeleton for each of the grains in the image
+        """Function to make a skeleton for each of the grains in the image
 
         Uses my own skeletonisation function from tracingfuncs module. I will
         eventually get round to editing this function to try to reduce the branching
-        and to try to better trace from looped molecules '''
+        and to try to better trace from looped molecules"""
 
         for grain_num in sorted(self.grains.keys()):
 
             smoothed_grain = ndimage.binary_dilation(self.grains[grain_num], iterations=1).astype(
-                self.grains[grain_num].dtype)
+                self.grains[grain_num].dtype
+            )
 
-            sigma = (0.01 / (self.pixel_size * 1e9))
+            sigma = 0.01 / (self.pixel_size * 1e9)
             very_smoothed_grain = ndimage.gaussian_filter(smoothed_grain, sigma)
 
             try:
-                dna_skeleton = getSkeleton(self.gauss_image, smoothed_grain, self.number_of_columns,
-                                           self.number_of_rows, self.pixel_size)
+                dna_skeleton = getSkeleton(
+                    self.gauss_image, smoothed_grain, self.number_of_columns, self.number_of_rows, self.pixel_size
+                )
                 self.disordered_trace[grain_num] = dna_skeleton.output_skeleton
             except IndexError:
                 # Some gwyddion grains touch image border causing IndexError
@@ -135,11 +147,11 @@ class dnaTrace(object):
 
     def determineLinearOrCircular(self, traces):
 
-        ''' Determines whether each molecule is circular or linear based on the
+        """Determines whether each molecule is circular or linear based on the
         local environment of each pixel from the trace
 
         This function is sensitive to branches from the skeleton so might need
-        to implement a function to remove them'''
+        to implement a function to remove them"""
 
         self.num_circular = 0
         self.num_linear = 0
@@ -173,7 +185,8 @@ class dnaTrace(object):
             if self.mol_is_circular[dna_num]:
 
                 self.ordered_traces[dna_num], trace_completed = reorderTrace.circularTrace(
-                    self.disordered_trace[dna_num])
+                    self.disordered_trace[dna_num]
+                )
 
                 if not trace_completed:
                     self.mol_is_circular[dna_num] = False
@@ -190,12 +203,14 @@ class dnaTrace(object):
 
     def reportBasicStats(self):
         # self.determineLinearOrCircular()
-        print('There are %i circular and %i linear DNA molecules found in the image' % (
-            self.num_circular, self.num_linear))
+        print(
+            "There are %i circular and %i linear DNA molecules found in the image"
+            % (self.num_circular, self.num_linear)
+        )
 
     def getFittedTraces(self):
 
-        '''
+        """
         Creates self.fitted_traces dictonary which contains trace
         coordinates (for each identified molecule) that are adjusted to lie
         along the highest points of each traced molecule
@@ -206,7 +221,7 @@ class dnaTrace(object):
 
         :return: no direct output but instance variable self.fitted_traces
                 is populated with adjusted x,y coordinates
-        '''
+        """
 
         for dna_num in sorted(self.ordered_traces.keys()):
 
@@ -227,18 +242,14 @@ class dnaTrace(object):
                     # prevents negative number indexing
                     # i.e. stops (trace_coordinate - index_width) < 0
                     trace_coordinate[0] = index_width
-                elif trace_coordinate[0] >= (self.number_of_rows -
-                                             index_width):
+                elif trace_coordinate[0] >= (self.number_of_rows - index_width):
                     # prevents indexing above image range causing IndexError
-                    trace_coordinate[0] = (self.number_of_rows -
-                                           index_width)
+                    trace_coordinate[0] = self.number_of_rows - index_width
                 # do same for y coordinate
                 elif trace_coordinate[1] < 0:
                     trace_coordinate[1] = index_width
-                elif trace_coordinate[1] >= (self.number_of_columns -
-                                             index_width):
-                    trace_coordinate[1] = (self.number_of_columns -
-                                           index_width)
+                elif trace_coordinate[1] >= (self.number_of_columns - index_width):
+                    trace_coordinate[1] = self.number_of_columns - index_width
 
                 # calculate vector to n - 2 coordinate in trace
                 if self.mol_is_circular[dna_num]:
@@ -258,61 +269,40 @@ class dnaTrace(object):
 
                 # if  angle is closest to 45 degrees
                 if 67.5 > vector_angle >= 22.5:
-                    perp_direction = 'negative diaganol'
+                    perp_direction = "negative diaganol"
                     # positive diagonal (change in x and y)
                     # Take height values at the inverse of the positive diaganol
                     # (i.e. the negative diaganol)
-                    y_coords = np.arange(
-                        trace_coordinate[1] - index_width,
-                        trace_coordinate[1] + index_width
-                    )[::-1]
-                    x_coords = np.arange(
-                        trace_coordinate[0] - index_width,
-                        trace_coordinate[0] + index_width
-                    )
+                    y_coords = np.arange(trace_coordinate[1] - index_width, trace_coordinate[1] + index_width)[::-1]
+                    x_coords = np.arange(trace_coordinate[0] - index_width, trace_coordinate[0] + index_width)
 
                 # if angle is closest to 135 degrees
                 elif 157.5 >= vector_angle >= 112.5:
-                    perp_direction = 'positive diaganol'
-                    y_coords = np.arange(
-                        trace_coordinate[1] - index_width,
-                        trace_coordinate[1] + index_width
-                    )
-                    x_coords = np.arange(
-                        trace_coordinate[0] - index_width,
-                        trace_coordinate[0] + index_width
-                    )
+                    perp_direction = "positive diaganol"
+                    y_coords = np.arange(trace_coordinate[1] - index_width, trace_coordinate[1] + index_width)
+                    x_coords = np.arange(trace_coordinate[0] - index_width, trace_coordinate[0] + index_width)
 
                 # if angle is closest to 90 degrees
                 if 112.5 > vector_angle >= 67.5:
-                    perp_direction = 'horizontal'
-                    x_coords = np.arange(
-                        trace_coordinate[0] - index_width,
-                        trace_coordinate[0] + index_width
-                    )
+                    perp_direction = "horizontal"
+                    x_coords = np.arange(trace_coordinate[0] - index_width, trace_coordinate[0] + index_width)
                     y_coords = np.full(len(x_coords), trace_coordinate[1])
 
                 elif 22.5 > vector_angle:  # if angle is closest to 0 degrees
-                    perp_direction = 'vertical'
-                    y_coords = np.arange(
-                        trace_coordinate[1] - index_width,
-                        trace_coordinate[1] + index_width
-                    )
+                    perp_direction = "vertical"
+                    y_coords = np.arange(trace_coordinate[1] - index_width, trace_coordinate[1] + index_width)
                     x_coords = np.full(len(y_coords), trace_coordinate[0])
 
                 elif vector_angle >= 157.5:  # if angle is closest to 180 degrees
-                    perp_direction = 'vertical'
-                    y_coords = np.arange(
-                        trace_coordinate[1] - index_width,
-                        trace_coordinate[1] + index_width
-                    )
+                    perp_direction = "vertical"
+                    y_coords = np.arange(trace_coordinate[1] - index_width, trace_coordinate[1] + index_width)
                     x_coords = np.full(len(y_coords), trace_coordinate[0])
 
                 # Use the perp array to index the guassian filtered image
                 perp_array = np.column_stack((x_coords, y_coords))
                 height_values = self.gauss_image[perp_array[:, 1], perp_array[:, 0]]
 
-                '''
+                """
                 # Old code that interpolated the height profile for "sub-pixel
                 # accuracy" - probably slow and not necessary, can delete
 
@@ -350,7 +340,7 @@ class dnaTrace(object):
                 elif perp_direction == 'horizontal':
                     fine_x_coords = np.arange(perp_array[0,0], perp_array[-1,0], 0.1)
                     fine_y_coords = np.full(len(fine_x_coords), trace_coordinate[1], dtype = 'float')
-                '''
+                """
                 # Grab x,y coordinates for highest point
                 # fine_coords = np.column_stack((fine_x_coords, fine_y_coords))
                 sorted_array = perp_array[np.argsort(height_values)]
@@ -358,10 +348,7 @@ class dnaTrace(object):
 
                 try:
                     # could use np.append() here
-                    fitted_coordinate_array = np.vstack((
-                        fitted_coordinate_array,
-                        highest_point
-                    ))
+                    fitted_coordinate_array = np.vstack((fitted_coordinate_array, highest_point))
                 except UnboundLocalError:
                     fitted_coordinate_array = highest_point
 
@@ -369,15 +356,17 @@ class dnaTrace(object):
             del fitted_coordinate_array  # cleaned up by python anyway?
 
     def getSplinedTraces(self):
+        """Gets a splined version of the fitted trace - useful for finding the radius of gyration etc
 
-        '''Gets a splined version of the fitted trace - useful for finding the
-        radius of gyration etc
+        This function actually calculates the average of several splines which is important for getting a good fit on
+        the lower res data"""
 
-        This function actually calculates the average of several splines which
-        is important for getting a good fit on the lower res data'''
-
+        # FIXME : Don't understand this 3nm is 3e-9 m so why is 7 used here?
         step_size = int(7e-9 / (self.pixel_size))  # 3 nm step size
         interp_step = int(1e-10 / self.pixel_size)
+        # Lets see if we just got with the pixel_to_nm_scaling
+        step_size = self.pixel_size
+        interp_step = self.pixel_size
 
         for dna_num in sorted(self.fitted_traces.keys()):
 
@@ -390,23 +379,35 @@ class dnaTrace(object):
                 continue
 
             # The degree of spline fit used is 3 so there cannot be less than 3 points in the splined trace
+            LOGGER.info(f"DNA Number      : {dna_num}")
+            LOGGER.info(f"nbr             : {nbr}")
+            LOGGER.info(f"step_size       : {step_size}")
+            LOGGER.info(f"self.pixel_size : {self.pixel_size}")
             while nbr / step_size < 4:
                 if step_size <= 1:
                     step_size = 1
                     break
-                step_size = - 1
-
+                step_size = -1
             if self.mol_is_circular[dna_num]:
 
                 # if nbr/step_size > 4: #the degree of spline fit is 3 so there cannot be less than 3 points in splined trace
 
-                ev_array = np.linspace(0, 1, nbr * step_size)
+                # ev_array = np.linspace(0, 1, nbr * step_size)
+                ev_array = np.linspace(0, 1, int(nbr * step_size))
 
                 for i in range(step_size):
-                    x_sampled = np.array([self.fitted_traces[dna_num][:, 0][j] for j in
-                                          range(i, len(self.fitted_traces[dna_num][:, 0]), step_size)])
-                    y_sampled = np.array([self.fitted_traces[dna_num][:, 1][j] for j in
-                                          range(i, len(self.fitted_traces[dna_num][:, 1]), step_size)])
+                    x_sampled = np.array(
+                        [
+                            self.fitted_traces[dna_num][:, 0][j]
+                            for j in range(i, len(self.fitted_traces[dna_num][:, 0]), step_size)
+                        ]
+                    )
+                    y_sampled = np.array(
+                        [
+                            self.fitted_traces[dna_num][:, 1][j]
+                            for j in range(i, len(self.fitted_traces[dna_num][:, 1]), step_size)
+                        ]
+                    )
 
                     try:
                         tck, u = interp.splprep([x_sampled, y_sampled], s=0, per=2, quiet=1, k=3)
@@ -415,10 +416,18 @@ class dnaTrace(object):
                     except ValueError:
                         # Value error occurs when the "trace fitting" really messes up the traces
 
-                        x = np.array([self.ordered_traces[dna_num][:, 0][j] for j in
-                                      range(i, len(self.ordered_traces[dna_num][:, 0]), step_size)])
-                        y = np.array([self.ordered_traces[dna_num][:, 1][j] for j in
-                                      range(i, len(self.ordered_traces[dna_num][:, 1]), step_size)])
+                        x = np.array(
+                            [
+                                self.ordered_traces[dna_num][:, 0][j]
+                                for j in range(i, len(self.ordered_traces[dna_num][:, 0]), step_size)
+                            ]
+                        )
+                        y = np.array(
+                            [
+                                self.ordered_traces[dna_num][:, 1][j]
+                                for j in range(i, len(self.ordered_traces[dna_num][:, 1]), step_size)
+                            ]
+                        )
 
                         try:
                             tck, u = interp.splprep([x, y], s=0, per=2, quiet=1)
@@ -463,7 +472,7 @@ class dnaTrace(object):
                 #        self.ordered_traces.pop(dna_num)
 
             else:
-                '''
+                """
                 start_x = self.fitted_traces[dna_num][0, 0]
                 end_x = self.fitted_traces[dna_num][-1, 0]
 
@@ -491,7 +500,7 @@ class dnaTrace(object):
 
                 spline_average = spline_running_total
                 self.splined_traces[dna_num] = spline_average
-                '''
+                """
 
                 # can't get splining of linear molecules to work yet
                 self.splined_traces[dna_num] = self.fitted_traces[dna_num]
@@ -522,7 +531,7 @@ class dnaTrace(object):
 
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
-        plt.savefig('%s_%s_originalImage.png' % (save_file, channel_name))
+        plt.savefig("%s_%s_originalImage.png" % (save_file, channel_name))
         plt.close()
 
         # plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
@@ -560,11 +569,11 @@ class dnaTrace(object):
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
         for dna_num in sorted(self.splined_traces.keys()):
-            plt.plot(self.splined_traces[dna_num][:, 0], self.splined_traces[dna_num][:, 1], color='c', linewidth=1.0)
-        plt.savefig('%s_%s_splinedtrace.png' % (save_file, channel_name))
+            plt.plot(self.splined_traces[dna_num][:, 0], self.splined_traces[dna_num][:, 1], color="c", linewidth=1.0)
+        plt.savefig("%s_%s_splinedtrace.png" % (save_file, channel_name))
         plt.close()
 
-        '''
+        """
         plt.pcolormesh(self.full_image_data)
         plt.colorbar()
         for dna_num in sorted(self.ordered_traces.keys()):
@@ -573,24 +582,29 @@ class dnaTrace(object):
             plt.plot(self.ordered_traces[dna_num][:,0], self.ordered_traces[dna_num][:,1])
         plt.savefig('%s_%s_splinedtrace.png' % (save_file, channel_name))
         plt.close()
-        '''
+        """
 
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
         for dna_num in sorted(self.disordered_trace.keys()):
             # disordered_trace_list = self.disordered_trace[dna_num].tolist()
             # less_dense_trace = np.array([disordered_trace_list[i] for i in range(0,len(disordered_trace_list),5)])
-            plt.plot(self.disordered_trace[dna_num][:, 0], self.disordered_trace[dna_num][:, 1], 'o', markersize=0.5,
-                     color='c')
-        plt.savefig('%s_%s_disorderedtrace.png' % (save_file, channel_name))
+            plt.plot(
+                self.disordered_trace[dna_num][:, 0],
+                self.disordered_trace[dna_num][:, 1],
+                "o",
+                markersize=0.5,
+                color="c",
+            )
+        plt.savefig("%s_%s_disorderedtrace.png" % (save_file, channel_name))
         plt.close()
 
         plt.pcolormesh(self.full_image_data, vmax=vmaxval, vmin=vminval)
         plt.colorbar()
         for dna_num in sorted(self.grains.keys()):
             grain_plt = np.argwhere(self.grains[dna_num] == 1)
-            plt.plot(grain_plt[:, 0], grain_plt[:, 1], 'o', markersize=2, color='c')
-        plt.savefig('%s_%s_grains.png' % (save_file, channel_name))
+            plt.plot(grain_plt[:, 0], grain_plt[:, 1], "o", markersize=2, color="c")
+        plt.savefig("%s_%s_grains.png" % (save_file, channel_name))
         plt.close()
 
     def _checkForSaveDirectory(self, filename, new_directory_name):
@@ -621,19 +635,24 @@ class dnaTrace(object):
             for i, (x, y) in enumerate(self.splined_traces[dna_num]):
                 # Extracts the coordinates for the required number of points and puts them in an array
                 if self.mol_is_circular[dna_num] or (
-                        self.neighbours < i < len(self.splined_traces[dna_num]) - self.neighbours):
+                    self.neighbours < i < len(self.splined_traces[dna_num]) - self.neighbours
+                ):
                     for j in range(self.neighbours * 2 + 1):
                         coordinates[0][j] = self.splined_traces[dna_num][i - j][0]
                         coordinates[1][j] = self.splined_traces[dna_num][i - j][1]
 
                     # Calculates the angles for the tangent lines to the left and the right of the point
-                    theta1 = math.atan((coordinates[1][self.neighbours] - coordinates[1][0]) / (
-                            coordinates[0][self.neighbours] - coordinates[0][0]))
-                    theta2 = math.atan((coordinates[1][-1] - coordinates[1][self.neighbours]) / (
-                            coordinates[0][-1] - coordinates[0][self.neighbours]))
+                    theta1 = math.atan(
+                        (coordinates[1][self.neighbours] - coordinates[1][0])
+                        / (coordinates[0][self.neighbours] - coordinates[0][0])
+                    )
+                    theta2 = math.atan(
+                        (coordinates[1][-1] - coordinates[1][self.neighbours])
+                        / (coordinates[0][-1] - coordinates[0][self.neighbours])
+                    )
 
-                    left = coordinates[:, :self.neighbours + 1]
-                    right = coordinates[:, -(self.neighbours + 1):]
+                    left = coordinates[:, : self.neighbours + 1]
+                    right = coordinates[:, -(self.neighbours + 1) :]
 
                     xa = np.mean(left[0])
                     ya = np.mean(left[1])
@@ -648,7 +667,8 @@ class dnaTrace(object):
 
                     contour = contour + math.hypot(
                         (coordinates[0][self.neighbours] - coordinates[0][self.neighbours - 1]),
-                        (coordinates[1][self.neighbours] - coordinates[1][self.neighbours - 1]))
+                        (coordinates[1][self.neighbours] - coordinates[1][self.neighbours - 1]),
+                    )
                 self.curvature[dna_num] = curve
 
     def saveCurvature(self):
@@ -669,8 +689,8 @@ class dnaTrace(object):
             os.mkdir(os.path.join(os.path.dirname(self.afm_image_name), "Curvature"))
         directory = os.path.join(os.path.dirname(self.afm_image_name), "Curvature")
         savename = os.path.join(directory, os.path.basename(self.afm_image_name)[:-4])
-        roc_stats.to_json(savename + '.json')
-        roc_stats.to_csv(savename + '.csv')
+        roc_stats.to_json(savename + ".json")
+        roc_stats.to_csv(savename + ".csv")
 
     def plotCurvature(self, dna_num):
 
@@ -684,24 +704,24 @@ class dnaTrace(object):
         savename = os.path.join(directory, os.path.basename(self.afm_image_name)[:-4])
 
         plt.figure()
-        sns.lineplot(curvature[:, 1] * self.pixel_size, curvature[:, 2], color='k')
+        sns.lineplot(curvature[:, 1] * self.pixel_size, curvature[:, 2], color="k")
         plt.ylim(-1e9, 1e9)
-        plt.ticklabel_format(axis='both', style='sci', scilimits=(0, 0))
+        plt.ticklabel_format(axis="both", style="sci", scilimits=(0, 0))
         plt.axvline(curvature[0][1], color="#D55E00")
         plt.axvline(curvature[int(length / 6)][1] * self.pixel_size, color="#E69F00")
         plt.axvline(curvature[int(length / 6 * 2)][1] * self.pixel_size, color="#F0E442")
         plt.axvline(curvature[int(length / 6 * 3)][1] * self.pixel_size, color="#009E74")
         plt.axvline(curvature[int(length / 6 * 4)][1] * self.pixel_size, color="#0071B2")
         plt.axvline(curvature[int(length / 6 * 5)][1] * self.pixel_size, color="#CC79A7")
-        plt.savefig('%s_%s_curvature.png' % (savename, dna_num))
+        plt.savefig("%s_%s_curvature.png" % (savename, dna_num))
         plt.close()
 
     def measureContourLength(self):
 
-        '''Measures the contour length for each of the splined traces taking into
+        """Measures the contour length for each of the splined traces taking into
         account whether the molecule is circular or linear
 
-        Contour length units are nm'''
+        Contour length units are nm"""
 
         for dna_num in sorted(self.splined_traces.keys()):
 
@@ -745,10 +765,10 @@ class dnaTrace(object):
         if not self.contour_lengths:
             self.measureContourLength()
 
-        with open('%s_%s_contours.txt' % (filename, channel_name), 'w') as writing_file:
-            writing_file.write('#units: nm\n')
+        with open("%s_%s_contours.txt" % (filename, channel_name), "w") as writing_file:
+            writing_file.write("#units: nm\n")
             for dna_num in sorted(self.contour_lengths.keys()):
-                writing_file.write('%f \n' % self.contour_lengths[dna_num])
+                writing_file.write("%f \n" % self.contour_lengths[dna_num])
 
     def writeCoordinates(self, dna_num):
 
@@ -763,10 +783,10 @@ class dnaTrace(object):
                 coordinates_array = np.array([[x, y]])
 
         coordinates = pd.DataFrame(coordinates_array)
-        coordinates.to_csv('%s_%s.csv' % (savename, dna_num))
+        coordinates.to_csv("%s_%s.csv" % (savename, dna_num))
 
-        plt.plot(coordinates_array[:, 0], coordinates_array[:, 1], 'ko')
-        plt.savefig('%s_%s_coordinates.png' % (savename, dna_num))
+        plt.plot(coordinates_array[:, 0], coordinates_array[:, 1], "ko")
+        plt.savefig("%s_%s_coordinates.png" % (savename, dna_num))
 
     def measureEndtoEndDistance(self):
 
@@ -782,8 +802,8 @@ class dnaTrace(object):
 
 
 class traceStats(object):
-    ''' Class used to report on the stats for all the traced molecules in the
-    given directory '''
+    """Class used to report on the stats for all the traced molecules in the
+    given directory"""
 
     def __init__(self, trace_object):
 
@@ -795,13 +815,13 @@ class traceStats(object):
 
     def createTraceStatsObject(self):
 
-        '''Creates a pandas dataframe with the shape:
+        """Creates a pandas dataframe with the shape:
 
         dna_num     directory       ImageName   contourLength   Circular
         1           exp_dir         img1_name   200             True
         2           exp_dir         img2_name   210             False
         3           exp_dir2        img3_name   100             True
-        '''
+        """
 
         data_dict = {}
 
@@ -813,21 +833,21 @@ class traceStats(object):
         for mol_num, dna_num in enumerate(sorted(self.trace_object.ordered_traces.keys())):
 
             try:
-                data_dict['Molecule number'].append(mol_num)
-                data_dict['Image Name'].append(img_name)
-                data_dict['Experiment Directory'].append(trace_directory)
-                data_dict['Basename'].append(basename)
-                data_dict['Contour Lengths'].append(self.trace_object.contour_lengths[dna_num])
-                data_dict['Circular'].append(self.trace_object.mol_is_circular[dna_num])
-                data_dict['End to End Distance'].append(self.trace_object.end_to_end_distance[dna_num])
+                data_dict["Molecule number"].append(mol_num)
+                data_dict["Image Name"].append(img_name)
+                data_dict["Experiment Directory"].append(trace_directory)
+                data_dict["Basename"].append(basename)
+                data_dict["Contour Lengths"].append(self.trace_object.contour_lengths[dna_num])
+                data_dict["Circular"].append(self.trace_object.mol_is_circular[dna_num])
+                data_dict["End to End Distance"].append(self.trace_object.end_to_end_distance[dna_num])
             except KeyError:
-                data_dict['Molecule number'] = [mol_num]
-                data_dict['Image Name'] = [img_name]
-                data_dict['Experiment Directory'] = [trace_directory]
-                data_dict['Basename'] = [basename]
-                data_dict['Contour Lengths'] = [self.trace_object.contour_lengths[dna_num]]
-                data_dict['Circular'] = [self.trace_object.mol_is_circular[dna_num]]
-                data_dict['End to End Distance'] = [self.trace_object.end_to_end_distance[dna_num]]
+                data_dict["Molecule number"] = [mol_num]
+                data_dict["Image Name"] = [img_name]
+                data_dict["Experiment Directory"] = [trace_directory]
+                data_dict["Basename"] = [basename]
+                data_dict["Contour Lengths"] = [self.trace_object.contour_lengths[dna_num]]
+                data_dict["Circular"] = [self.trace_object.mol_is_circular[dna_num]]
+                data_dict["End to End Distance"] = [self.trace_object.end_to_end_distance[dna_num]]
         self.pd_dataframe = pd.DataFrame(data=data_dict)
 
     def updateTraceStats(self, new_traces):
@@ -842,39 +862,39 @@ class traceStats(object):
         for mol_num, dna_num in enumerate(sorted(new_traces.contour_lengths.keys())):
 
             try:
-                data_dict['Molecule number'].append(mol_num)
-                data_dict['Image Name'].append(img_name)
-                data_dict['Experiment Directory'].append(trace_directory)
-                data_dict['Basename'].append(basename)
-                data_dict['Contour Lengths'].append(new_traces.contour_lengths[dna_num])
-                data_dict['Circular'].append(new_traces.mol_is_circular[dna_num])
-                data_dict['End to End Distance'].append(new_traces.end_to_end_distance[dna_num])
+                data_dict["Molecule number"].append(mol_num)
+                data_dict["Image Name"].append(img_name)
+                data_dict["Experiment Directory"].append(trace_directory)
+                data_dict["Basename"].append(basename)
+                data_dict["Contour Lengths"].append(new_traces.contour_lengths[dna_num])
+                data_dict["Circular"].append(new_traces.mol_is_circular[dna_num])
+                data_dict["End to End Distance"].append(new_traces.end_to_end_distance[dna_num])
             except KeyError:
-                data_dict['Molecule number'] = [mol_num]
-                data_dict['Image Name'] = [img_name]
-                data_dict['Experiment Directory'] = [trace_directory]
-                data_dict['Basename'] = [basename]
-                data_dict['Contour Lengths'] = [new_traces.contour_lengths[dna_num]]
-                data_dict['Circular'] = [new_traces.mol_is_circular[dna_num]]
-                data_dict['End to End Distance'] = [new_traces.end_to_end_distance[dna_num]]
+                data_dict["Molecule number"] = [mol_num]
+                data_dict["Image Name"] = [img_name]
+                data_dict["Experiment Directory"] = [trace_directory]
+                data_dict["Basename"] = [basename]
+                data_dict["Contour Lengths"] = [new_traces.contour_lengths[dna_num]]
+                data_dict["Circular"] = [new_traces.mol_is_circular[dna_num]]
+                data_dict["End to End Distance"] = [new_traces.end_to_end_distance[dna_num]]
 
         pd_new_traces_dframe = pd.DataFrame(data=data_dict)
 
         self.pd_dataframe = self.pd_dataframe.append(pd_new_traces_dframe, ignore_index=True)
 
     def saveTraceStats(self, save_path):
-        save_file_name = ''
+        save_file_name = ""
 
-        if save_path[-1] == '/':
+        if save_path[-1] == "/":
             pass
         else:
-            save_path = save_path + '/'
+            save_path = save_path + "/"
 
-        for i in self.trace_object.afm_image_name.split('/')[:-1]:
-            save_file_name = save_file_name + i + '/'
+        for i in self.trace_object.afm_image_name.split("/")[:-1]:
+            save_file_name = save_file_name + i + "/"
         print(save_file_name)
 
-        self.pd_dataframe.to_json('%stracestats.json' % save_path)
-        self.pd_dataframe.to_csv('%stracestats.csv' % save_path)
+        self.pd_dataframe.to_json("%stracestats.json" % save_path)
+        self.pd_dataframe.to_csv("%stracestats.csv" % save_path)
 
-        print('Saved trace info for all analysed images into: %stracestats.json' % save_path)
+        print("Saved trace info for all analysed images into: %stracestats.json" % save_path)


### PR DESCRIPTION
Resolves #156 

We had to ensure that the output from the new `topotracing` can be passed on and used as input to the `dnaTrace()` class which performs DNA tracing.

This pull request achieves that, although there is still a fair amount of work to be done on the `dnatracing.py` module as a whole as there are no unit tests to check the work done here.

At the same time I have been made aware that the results of DNA tracing are used in the `Plotting` module to simplify the process of visualising results and so I have ensured that the output from `GrainStats()` and `dnaTrace()` are combined for each image (and saved within each images output directory) and that these are then combined across all images that are found and output to a single CSV file in the config/user specified output directory.

The `Plotting.py` module will also need some attention after tests and refactoring of `dnatracing.py`.