### PR TITLE
Run CI tests on Windows 10 and 11 explicitly

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-10", "windows-11"]
         python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I can't see any reason why something that runs on Windows 10 wouldn't run on 11, or vice versa, but it's probably good to check as people are transitioning.