### PR TITLE
159 | Introduces correct "raw_height" plot; adds write_yaml()

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1,11 +1,12 @@
 """Functions for reading and writing data."""
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import Union, Dict
 
 from pySPM.Bruker import Bruker
-import ruamel.yaml
 from ruamel.yaml import YAML, YAMLError
+from ruamel.yaml.main import round_trip_load as yaml_load, round_trip_dump as yaml_dump
 from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
@@ -26,11 +27,41 @@ def read_yaml(filename: Union[str, Path]) -> Dict:
 
     with Path(filename).open() as f:
         try:
-            yaml_file = YAML(typ='safe')
+            yaml_file = YAML(typ="safe")
             return yaml_file.load(f)
         except YAMLError as exception:
             LOGGER.error(exception)
             return {}
+
+
+def write_yaml(config: dict, output_dir: Union[str, Path]) -> None:
+    """Write a configuration (stored as a dictionary) to a YAML file.
+
+    Paraemeters
+    -----------
+    config: dict
+        Configuration dictionary.
+    output_dir: Union[str, Path]
+        Path to save the dictionary to as a YAML file (it will be called 'config.yaml').
+
+    Returns
+    -------
+    None
+    """
+    # Save the configuration to output directory
+    output_config = Path(output_dir) / "config.yaml"
+    # Revert PosixPath items to string
+    config["base_dir"] = str(config["base_dir"])
+    config["output_dir"] = str(config["output_dir"])
+    config_yaml = yaml_load(yaml_dump(config))
+    config_yaml.yaml_set_start_comment(
+        f"Configuration from TopoStats run completed : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+    with output_config.open("w") as f:
+        try:
+            f.write(yaml_dump(config_yaml))
+        except YAMLError as exception:
+            LOGGER.error(exception)
 
 
 def load_scan(img_path: Union[str, Path]) -> Bruker:
@@ -50,5 +81,5 @@ def load_scan(img_path: Union[str, Path]) -> Bruker:
     FIXME: Add docs.
 
     """
-    LOGGER.info(f'Loading image from : {img_path}')
+    LOGGER.info(f"Loading image from : {img_path}")
     return Bruker(Path(img_path))

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from topostats.filters import Filters
 from topostats.grains import Grains
 from topostats.grainstats import GrainStats
-from topostats.io import read_yaml
+from topostats.io import read_yaml, write_yaml
 from topostats.logs.logs import setup_logger, LOGGER_NAME
 from topostats.plottingfuncs import plot_and_save
 from topostats.thresholds import threshold
@@ -23,7 +23,8 @@ from topostats.utils import convert_path, find_images, update_config
 LOGGER = setup_logger(LOGGER_NAME)
 
 PLOT_DICT = {
-    "pixels": {"filename": "01-raw_heightmap.png", "title": "Raw Height"},
+    "extracted_channel": {"filename": "00-raw_heightmap.png", "title": "Raw Height"},
+    "pixels": {"filename": "01-pixels.png", "title": "Pixels"},
     "initial_align": {"filename": "02-initial_align_unmasked.png", "title": "Initial Alignment (Unmasked)"},
     "initial_tilt_removal": {
         "filename": "03-initial_tilt_removal_unmasked.png",
@@ -192,7 +193,9 @@ def process_scan(
         LOGGER.info("Saving plots of images at all stages of processing.")
         # Filtering stage
         for plot_name, array in filtered_image.images.items():
-            if plot_name not in ["scan_raw", "extracted_channel"]:
+            if plot_name not in ["scan_raw"]:
+                if plot_name is "extracted_channel":
+                    array = np.flipud(array.pixels)
                 PLOT_DICT[plot_name]["output_dir"] = Path(output_dir) / filtered_image.filename
                 plot_and_save(array, **PLOT_DICT[plot_name])
         # Grain stage - only if we have grains
@@ -276,6 +279,10 @@ def main():
     LOGGER.info(
         f"All statistics combined for {len(img_files)} are saved to : {str(config['output_dir'] / 'all_statistics.csv')}"
     )
+
+    # Write config to file
+    LOGGER.info(f"Writing configuration to : {config['output_dir']}/config.yaml")
+    write_yaml(config, output_dir=config["output_dir"])
 
 
 if __name__ == "__main__":

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -194,7 +194,7 @@ def process_scan(
         # Filtering stage
         for plot_name, array in filtered_image.images.items():
             if plot_name not in ["scan_raw"]:
-                if plot_name is "extracted_channel":
+                if plot_name == "extracted_channel":
                     array = np.flipud(array.pixels)
                 PLOT_DICT[plot_name]["output_dir"] = Path(output_dir) / filtered_image.filename
                 plot_and_save(array, **PLOT_DICT[plot_name])


### PR DESCRIPTION
Resolves #159 

Plots the `raw_height` of the Bruker image to `00-raw_height.png` resolving #159.
The reason I'd not included this previously is I was confused why the `pySPM.SPM` that the `extract_channel()` plots couldn't be plotted, its because this object has the attribute `pixels` which is what should be plotted.

That said I'm not entirely sure why this, which is the plot of `pySPM.SPM.pixels` differs from the plot of pixels as I can't see why/where the `self.images["pixels"]` is modified in comparison to the extraction and so the two should match. :shrug: 

I've also introduced a short function `topostats.io.write_yaml()` that writes the configuration used to YAML in the output directory which is an interim step to addressing #111 but not an absolute solution.