### PR TITLE
183 | Handling single grains

### DIFF
--- a/tests/test_grains_minicircle.py
+++ b/tests/test_grains_minicircle.py
@@ -57,7 +57,7 @@ def test_clear_border(minicircle_grain_clear_border: np.array, tmpdir) -> None:
 def test_calc_minimum_grain_size_pixels(minicircle_minimum_grain_size) -> None:
     """Test calculation of minimum grain size in pixels."""
     assert isinstance(minicircle_minimum_grain_size.minimum_grain_size, float)
-    assert minicircle_minimum_grain_size.minimum_grain_size == 1553.25
+    assert minicircle_minimum_grain_size.minimum_grain_size == 1529.25
 
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -126,7 +126,10 @@ class Grains:
         """
         self.get_region_properties()
         grain_areas = np.array([grain.area for grain in self.region_properties])
-        grain_areas = grain_areas[grain_areas > threshold(grain_areas, method=self.threshold_method)]
+        print(
+            f"threshold(grain_areas, method=self.threshold_method) : {threshold(grain_areas, method=self.threshold_method)}"
+        )
+        grain_areas = grain_areas[grain_areas >= threshold(grain_areas, method=self.threshold_method)]
         self.minimum_grain_size = np.median(grain_areas) - (
             1.5 * (np.quantile(grain_areas, 0.75) - np.quantile(grain_areas, 0.25))
         )

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -93,7 +93,7 @@ class Grains:
     def label_regions(self, image: np.array) -> np.array:
         """Label regions.
 
-        This method is used twice, once prior to removal of small regions, and again afterwards, hence requiring and
+        This method is used twice, once prior to removal of small regions, and again afterwards, hence requiring an
         argument of what image to label.
 
         Parameters
@@ -190,9 +190,14 @@ class Grains:
         self.get_mask()
         self.tidy_border()
         self.label_regions(self.images["tidied_border"])
-        self.calc_minimum_grain_size(image=self.images["labelled_regions"])
-        self.remove_small_objects()
-        self.label_regions(self.images["objects_removed"])
-        self.get_region_properties()
-        self.colour_regions()
-        self.get_bounding_boxes()
+        try:
+            self.calc_minimum_grain_size(image=self.images["labelled_regions"])
+            self.remove_small_objects()
+            self.label_regions(self.images["objects_removed"])
+            self.get_region_properties()
+            self.colour_regions()
+            self.get_bounding_boxes()
+        # FIXME : Identify what exception is raised with images without grains and replace broad except
+        except Exception as e:
+            LOGGER.info(f"[{self.filename}] : No grains found.")
+            pass

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -126,9 +126,6 @@ class Grains:
         """
         self.get_region_properties()
         grain_areas = np.array([grain.area for grain in self.region_properties])
-        print(
-            f"threshold(grain_areas, method=self.threshold_method) : {threshold(grain_areas, method=self.threshold_method)}"
-        )
         grain_areas = grain_areas[grain_areas >= threshold(grain_areas, method=self.threshold_method)]
         self.minimum_grain_size = np.median(grain_areas) - (
             1.5 * (np.quantile(grain_areas, 0.75) - np.quantile(grain_areas, 0.25))


### PR DESCRIPTION
In investigating #183 I've discovered a problem related to thresholds and filtering when only a single grain is found.

The image `20220601_NDP52_FL_10ng_PLO_HEPES_20mM_NaCl_50mM.0_00021.spm` crashed with the error...

```bash
IndexError: cannot do a non-empty take from an empty axes.
```

This arises from the `Grains` class and is caused when the method `.calc_minimum_grain_size()` is called and only one grain has been detected. The code calculates the minimum grain size by first calculating the area of all grains...

```python
        grain_areas = np.array([grain.area for grain in self.region_properties])
```

Then only a subset of grains were retained when the area exceeded a threshold...

```python
        grain_areas = grain_areas[grain_areas > threshold(grain_areas, method=self.threshold_method)]
```

Finally the `minimum_grain_size` was calculated as the median of the remaining grain sizes minus 1.5 x the Interquartile Range
```python
        self.minimum_grain_size = np.median(grain_areas) - (
            1.5 * (np.quantile(grain_areas, 0.75) - np.quantile(grain_areas, 0.25))
        )

```

The problem is that with only a single grain the threshold is the same size as the one grain that has been detected and because the inequality for retaining grains was that its area had to _exceed_ the threshold (i.e. `>`) then the grain was removed. This in turn meant that `grain_areas` was `None` (empty) and you can't calculate the median of an empty array!

The solution I've gone for here is to change the inequality so that the only grains smaller than the threshold are excluded, those that are equal are retrained, hence the very small change in this Pull Request.

It means I can now process five of the images @derollins shared with me and I've another error to investigate :smiley: 