### PR TITLE
Allowing csv files as input for Plotting.py

### DIFF
--- a/Plotting.py
+++ b/Plotting.py
@@ -74,7 +74,7 @@ def pathman(path):
 
     directory = os.path.dirname(path)
     name = os.path.basename(path)[:-5]
-    savedir = os.path.join(directory, 'Plots_Python3test')
+    savedir = os.path.join(directory, 'Plots')
     if not os.path.exists(savedir):
         os.makedirs(savedir)
     plotname = os.path.join(savedir, name)

--- a/Plotting.py
+++ b/Plotting.py
@@ -47,17 +47,23 @@ colname2label = {
 }
 
 
-def importfromjson(path):
-    """Importing the data needed from the json file specified by the user"""
+def importfromfile(path):
+    """Importing the data needed from the json or csv file specified by the user"""
 
-    print (path)
-    importeddata = pd.read_json(path)
-
-    return importeddata
+    print(path)
+    filename, filextension = os.path.splitext(path)
+    if filextension == '.json':
+        importeddata = pd.read_json(path)
+        return importeddata
+    elif filextension == '.csv':
+        importeddata = pd.read_csv(path)
+        return importeddata
+    else:
+        print('Unsupported file type')
 
 
 def savestats(path, dataframetosave):
-    print 'Saving stats for: ' + str(os.path.basename(path)[:-5]) + '_evaluated'
+    print('Saving stats for: ' + str(os.path.basename(path)[:-5]) + '_evaluated')
 
     dataframetosave.to_json(path[:-5] + '_evaluated.json')
     dataframetosave.to_csv(path[:-5] + '_evaluated.txt')
@@ -68,7 +74,7 @@ def pathman(path):
 
     directory = os.path.dirname(path)
     name = os.path.basename(path)[:-5]
-    savedir = os.path.join(directory, 'Plots')
+    savedir = os.path.join(directory, 'Plots_Python3test')
     if not os.path.exists(savedir):
         os.makedirs(savedir)
     plotname = os.path.join(savedir, name)
@@ -124,7 +130,7 @@ def plotkde(df, plotarg, grouparg=None, xmin=None, xmax=None, nm=False, specpath
     default unit is metre, but this can be changed to nanometre by adding 'nm=True'. The default path is the path under
     the if __name__ == '__main__' line, but this can also be changed using the specpath argument."""
 
-    print 'Plotting kde of %s' % plotarg
+    print('Plotting kde of %s' % plotarg)
 
     # Set the name of the file
     if specpath is None:
@@ -167,41 +173,35 @@ def plotkde2var(df, plotarg, df2=None, plotarg2=None, label1=None, label2=None, 
         df2 = df
     if plotarg2 is None:
         plotarg2 = plotarg
+    if label1 is None:
+        label1 = plotarg
+    if label2 is None:
+        label2 = plotarg2
 
-    print 'Plotting kde of %s and %s' % (plotarg, plotarg2)
+    print('Plotting KDE of %s for %s and %s' % (plotarg, label1, label2))
 
     # Set the name of the file
     if specpath is None:
         specpath = path
-    savename = os.path.join(pathman(specpath) + '_' + plotarg + '_' + plotarg2 + '_KDE' + plotextension)
-
-    dfnew = df.copy()
-    dfnew2 = df2.copy()
+    savename = os.path.join(pathman(specpath) + '_' + plotarg + '_' + label1 + '_' + label2 + '_KDE' + plotextension)
 
     # Convert the unit of the data to nm if specified by the user
-    dfnew[plotarg] = dataunitconversion(df[plotarg], plotarg, nm)
-    dfnew2[plotarg2] = dataunitconversion(df[plotarg2], plotarg2, nm)
+    dfnew = df.copy()
+    dfnew2 = df2.copy()
+    dfnew[plotarg] = dataunitconversion(dfnew[plotarg], plotarg, nm)
+    dfnew2[plotarg2] = dataunitconversion(dfnew2[plotarg2], plotarg2, nm)
+    dfplot = pd.concat([dfnew[plotarg], dfnew2[plotarg2]], axis=1)
+    dfplot.columns = [label1, label2]
 
     # Plot figure
     fig, ax = plt.subplots(figsize=(15, 12))
-    # Simple KDE plot
-
-    # dfplot = pd.merge(df[plotarg], df2[plotarg2])
-    # df = df[[plotarg, plotarg2]]
-    # df.plot.kde(ax=ax, alpha=1, linewidth=7.0)
-
-    dfnew[plotarg].plot.kde(ax=ax, alpha=1, linewidth=7.0)
-    dfnew2[plotarg2].plot.kde(ax=ax, alpha=1, linewidth=7.0)
+    dfplot.plot.kde(ax=ax, alpha=1, linewidth=7.0)
 
     # Label plot and save figure
     plt.xlim(xmin, xmax)
-    # plt.xlabel(labelunitconversion(plotarg1, nm), alpha=1)
     plt.xlabel(labelunitconversion(plotarg, nm), alpha=1)
     plt.ylabel('Probability Density', alpha=1)
     plt.ticklabel_format(axis='both', style='sci', scilimits=(-3, 3))
-    handles, labels = ax.get_legend_handles_labels()
-    # ax.legend(reversed(handles), reversed(labels), , title=grouparg, loc='upper right')
-    ax.legend(handles, labels, title=grouparg, loc='upper right')
     plt.savefig(savename)
 
 
@@ -211,7 +211,7 @@ def plothist(df, plotarg, grouparg=None, xmin=None, xmax=None, bins=20, nm=False
     default unit is metre, but this can be changed to nanometre by adding 'nm=True'. The default path is the path under
     the if __name__ == '__main__' line, but this can also be changed using the specpath argument."""
 
-    print 'Plotting histogram of %s' % plotarg
+    print('Plotting histogram of %s' % plotarg)
 
     # Set  the name of the file
     if specpath is None:
@@ -244,46 +244,49 @@ def plothist(df, plotarg, grouparg=None, xmin=None, xmax=None, bins=20, nm=False
     plt.ticklabel_format(axis='both', style='sci', scilimits=(-3, 3))
     plt.savefig(savename)
 
+
 def plothist2var(df, plotarg, df2=None, plotarg2=None, label1=None, label2=None, xmin=None, xmax=None, nm=False,
                 specpath=None, plotextension=defextension):
     """Creating a histogram for the chosen variable. Grouping optional. The x axis range can be defined by the user. The
     default unit is metre, but this can be changed to nanometre by adding 'nm=True'. The default path is the path under
     the if __name__ == '__main__' line, but this can also be changed using the specpath argument."""
 
-    if label1 is None:
-        label1 = plotarg
-    if label2 is None:
-        label2 = plotarg2
     if df2 is None:
         df2 = df
     if plotarg2 is None:
         plotarg2 = plotarg
+    if label1 is None:
+        label1 = plotarg
+    if label2 is None:
+        label2 = plotarg2
 
-    print 'Plotting histogram of %s and %s' % (label1, label2)
+    print('Plotting histogram of %s for %s and %s' % (plotarg, label1, label2))
 
     # Set the name of the file
     if specpath is None:
         specpath = path
-    savename = os.path.join(pathman(specpath) + '_' + label1 + '_' + label2 + '_histogram' + plotextension)
+    savename = os.path.join(
+        pathman(specpath) + '_' + plotarg + '_' + label1 + '_' + label2 + '_histogram' + plotextension)
 
     # Convert the unit of the data to nm if specified by the user
     dfnew = df.copy()
     dfnew2 = df2.copy()
-    dfnew[plotarg] = dataunitconversion(df[plotarg], plotarg, nm)
-    dfnew2[plotarg2] = dataunitconversion(df[plotarg2], plotarg2, nm)
+    dfnew[plotarg] = dataunitconversion(dfnew[plotarg], plotarg, nm)
+    dfnew2[plotarg2] = dataunitconversion(dfnew2[plotarg2], plotarg2, nm)
+    dfplot = pd.concat([dfnew[plotarg], dfnew2[plotarg2]], axis=1)
+    dfplot.columns = [label1, label2]
 
     # Plot figure
     fig, ax = plt.subplots(figsize=(15, 12))
-    dfnew[plotarg].plot.hist(ax=ax, alpha=1, linewidth=3.0, bins=bins)
-    dfnew2[plotarg2].plot.hist(ax=ax, alpha=1, linewidth=3.0, bins=bins, histtype='barstacked')
+    # dfnew[plotarg].plot.hist(ax=ax, alpha=1, linewidth=3.0, bins=bins, color='orange')
+    # dfnew2[plotarg2].plot.hist(ax=ax, alpha=1, linewidth=3.0, bins=bins, histtype='barstacked', color='blue')
+    dfplot.plot.hist(ax=ax, alpha=0.5, linewidth=3.0, bins=bins, stacked=False)
 
     # Label plot and save figure
     plt.xlim(xmin, xmax)
     plt.xlabel(labelunitconversion(plotarg, nm), alpha=1)
-    plt.ylabel('Probability Density', alpha=1)
+    plt.ylabel('Count', alpha=1)
     plt.ticklabel_format(axis='both', style='sci', scilimits=(-3, 3))
-    handles, labels = ax.get_legend_handles_labels()
-    ax.legend(handles, labels)
     plt.savefig(savename)
 
 
@@ -321,7 +324,7 @@ def plotdist2var(plotarg, plotarg2, df, df2=None, xmin=None, xmax=None, bins=20,
                  plotextension=defextension, plotname=None, c1=None, c2=None):
     """Dist plot for 2 variables"""
 
-    print 'Plotting dist plot of %s and %s' % (plotarg, plotarg2)
+    print('Plotting dist plot of %s and %s' % (plotarg, plotarg2))
 
     if plotname is None:
         plotname = plotarg + '_and_' + plotarg2
@@ -362,7 +365,7 @@ def plotviolin(df, plotarg, grouparg=None, ymin=None, ymax=None, nm=False, specp
     The default unit is metre, but this can be changed to nanometre by adding 'nm=True'. The default path is the path
     under the if __name__ == '__main__' line, but this can also be changed using the specpath argument."""
 
-    print 'Plotting violin of %s' % plotarg
+    print('Plotting violin of %s' % plotarg)
 
     # Set the name of the file
     if specpath is None:
@@ -397,7 +400,7 @@ def plotjoint(df, arg1, arg2, xmin=None, xmax=None, ymin=None, ymax=None, nm=Fal
     The default unit is metre, but this can be changed to nanometre by adding 'nm=True'. The default path is the path
     under the if __name__ == '__main__' line, but this can also be changed using the specpath argument."""
 
-    print 'Plotting joint plot for %s and %s' % (arg1, arg2)
+    print('Plotting joint plot for %s and %s' % (arg1, arg2))
 
     # Set the name of the file
     if specpath is None:
@@ -453,15 +456,15 @@ if __name__ == '__main__':
     # Path to the json file, e.g. C:\\Users\\username\\Documents\\Data\\Data.json
 
     path = ''
-    path2 = ''
+    # path2 = ''
 
     # Set the name of the json file to import here
     # name = 'Non-incubation'
-    bins = 50
+    bins = 20
 
     # import data form the json file specified as a dataframe
-    df = importfromjson(path)
-    df2 = importfromjson(path2)
+    df = importfromfile(path)
+    # df2 = importfromfile(path2)
 
     # df = df[df['End to End Distance'] != 0]
     # df = df[df['Contour Lengths'] > 100]
@@ -511,11 +514,11 @@ if __name__ == '__main__':
 # grouparg = 'Experiment Directory'
 # grouparg = 'Basename'
 # grouparg = 'directory'
-# grouparg = None
+grouparg = None
 
 # Setting a continuous colour palette; useful for certain grouped plots, but can be commented out if unsuitable.
 # sns.set_palette(sns.color_palette('BuPu', n_colors=len(df.groupby(grouparg))))
-# print df.pivot(columns=grouparg, values='grain_median')
+# print(df.pivot(columns=grouparg, values='grain_median'))
 
 
 # Plot one column of the dataframe e.g. 'grain_mean_radius'; grouparg can be specified for plotkde, plothist and


### PR DESCRIPTION
Allowing csv files as input for Plotting.py and fixing print statments so that they work with Python3.
The rest of Plotting.py still needs refactoring since it's based on the assumption that the stats from all the spm files are combined in one file, which isn't the case with new TopoStats. 