### PR TITLE
207 | Use bounding boxes for layer; exclude small grains prior to min…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -485,10 +485,9 @@ def minicircle_grain_labelled_post_removal(minicircle_small_objects_removed: np.
 @pytest.fixture
 def minicircle_grain_region_properties_post_removal(minicircle_grain_labelled_post_removal: np.array) -> np.array:
     """Region properties."""
-    minicircle_grain_labelled_post_removal.get_region_properties(
+    return minicircle_grain_labelled_post_removal.get_region_properties(
         minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"]
     )
-    return minicircle_grain_labelled_post_removal
 
 
 @pytest.fixture

--- a/tests/test_grains_minicircle.py
+++ b/tests/test_grains_minicircle.py
@@ -109,7 +109,7 @@ def test_remove_small_objects(minicircle_small_objects_removed: np.array, tmpdir
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_label_regions(minicircle_grain_labelled_post_removal: np.array, tmpdir) -> None:
-    """Test removal of small objects."""
+    """Test labelling of regions."""
     assert isinstance(minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"], np.ndarray)
     assert minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"].shape == (1024, 1024)
     assert minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"].sum() == 465604
@@ -124,15 +124,15 @@ def test_label_regions(minicircle_grain_labelled_post_removal: np.array, tmpdir)
 
 def test_region_properties(minicircle_grain_region_properties_post_removal: np.array) -> None:
     """Test removal of small objects."""
-    assert isinstance(minicircle_grain_region_properties_post_removal.region_properties, list)
-    assert len(minicircle_grain_region_properties_post_removal.region_properties) == 22
-    for x in minicircle_grain_region_properties_post_removal.region_properties:
+    assert isinstance(minicircle_grain_region_properties_post_removal, list)
+    assert len(minicircle_grain_region_properties_post_removal) == 22
+    for x in minicircle_grain_region_properties_post_removal:
         assert isinstance(x, RegionProperties)
 
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_colour_regions(minicircle_grain_coloured: np.array, tmpdir) -> None:
-    """Test removal of small objects."""
+    """Test colouring of regions."""
     assert isinstance(minicircle_grain_coloured.directions["upper"]["coloured_regions"], np.ndarray)
     assert minicircle_grain_coloured.directions["upper"]["coloured_regions"].shape == (1024, 1024, 3)
     assert minicircle_grain_coloured.directions["upper"]["coloured_regions"].sum() == 59179.71000000001

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -252,7 +252,7 @@ def process_scan(
     if grains.region_properties is not None:
         # Grain Statistics :
         try:
-            LOGGER.info(f"[{filtered_image.filename}] : Grain Statistics")
+            LOGGER.info(f"[{filtered_image.filename}] : *** Grain Statistics ***")
             grainstats = {
                 direction: GrainStats(
                     data=grains.images["gaussian_filtered"],
@@ -277,7 +277,7 @@ def process_scan(
             LOGGER.info(f"[{filtered_image.filename}] : DNA Tracing")
             dna_traces = defaultdict()
             tracing_stats = defaultdict()
-            for direction in grainstats.keys():
+            for direction, grainstat in grainstats.keys():
                 dna_traces[direction] = dnaTrace(
                     full_image_data=grains.images["gaussian_filtered"].T,
                     grains=grains.directions[direction]["labelled_regions_02"],
@@ -288,11 +288,10 @@ def process_scan(
                 tracing_stats[direction] = traceStats(trace_object=dna_traces[direction], image_path=image_path)
                 tracing_stats[direction].save_trace_stats(_output_dir / filtered_image.filename / direction)
 
-            for direction, grainstat in grainstats.items():
                 LOGGER.info(
                     f"[{filtered_image.filename}] : Combining {direction} grain statistics and dnatracing statistics"
                 )
-                results = grainstat["statistics"].merge(tracing_stats[direction].df, on="Molecule Number")
+                results = grainstat[direction]["statistics"].merge(tracing_stats[direction].df, on="Molecule Number")
                 results.to_csv(_output_dir / filtered_image.filename / direction / "all_statistics.csv")
                 LOGGER.info(
                     f"[{filtered_image.filename}] : Combined statistics saved to {str(_output_dir)}/{filtered_image.filename}/{direction}/all_statistics.csv"
@@ -335,13 +334,13 @@ def process_scan(
                 plot_and_save(
                     grains.directions[direction]["coloured_regions"],
                     **PLOT_DICT["bounding_boxes"],
-                    region_properties=grains.region_properties,
+                    region_properties=grains.region_properties[direction],
                 )
                 PLOT_DICT["coloured_boxes"]["output_dir"] = output_dir
                 plot_and_save(
                     grains.directions[direction]["labelled_regions_02"],
                     **PLOT_DICT["coloured_boxes"],
-                    region_properties=grains.region_properties,
+                    region_properties=grains.region_properties[direction],
                 )
 
     return image_path, results


### PR DESCRIPTION
I think I've found what was causing the problem here and its two fold.

## Bounding Boxes

This is straight-forward, the `Grains.find_grains()` method didn't save the `region_properties` nor the `bounding_boxes` in dictionaries with keys for each layer. Changing this means tweaking the `Grains.get_region_properties()` and `Grains.get_bounding_boxes()` to return properties/bounding boxes respectively and these are saved to dictionaries in `Grains.region_properties[direction]` and `Grains.bounding_boxes[direction]` respectively.

## Failing to find grains

This is more complicated.

In the `Grains()` class (see `topostats/grains.py` the method `calc_minimum_grain_size()` is defined as such...

```python
    def calc_minimum_grain_size(self, image: np.ndarray, direction: str) -> float:
        """Calculate the minimum grain size.

        Very small objects are first removed via thresholding before calculating the lower extreme.
        """
        # self.get_region_properties(image)
        # grain_areas = np.array([grain.area for grain in self.region_properties[direction]])
        region_properties = self.get_region_properties(image)
        grain_areas = np.array([grain.area for grain in region_properties])
        if len(grain_areas > 0):
            # Exclude small objects less than a given threshold first
            grain_areas = grain_areas[
                grain_areas >= threshold(grain_areas, method=threshold_method, otsu_threshold_multiplier=1.0)
            ]
            self.minimum_grain_size = np.median(grain_areas) - (
                1.5 * (np.quantile(grain_areas, 0.75) - np.quantile(grain_areas, 0.25))
            )
        else:
            self.minimum_grain_size = -1
```
I reinstated the line...

```
grain_areas = grain_areas[grain_areas >= threshold(grain_areas, method=threshold_method, otsu_threshold_multiplier=1.0)]
```

...yesterday because, despite removing noise with the `Grains.remove_noise()` which excludes grains that are < the value `absolute_smallest_grain_size` (from the configuration and carried through with the same name) the tests failed as there were now more grains in the subsequent steps where the `median - 1.5 * IQR` (IQR = Inter-Quartile Range) was calculated and the value of `Grains.minimum_grain_size` was in turn smaller.

However...

In doing so a call is made to the `threshold()` function directly from `topostats.threshold` rather than using the `get_threshold()` method from `topostats.utils` which is the behaviour we want because we are processing a specific `lower` or `upper` threshold and wish to find the minimum grain size to exclude grains from the list `grain_areas`.  But thresholding methods in scikit-image, which does the work in `topostats.threshold`, do not include a `std_dev` method, rather when TopoStats wants to use the `mean -/+ std_dev` it uses `get_thresholds()` and gets the `mean` threshold (from `topostats.threshold`) for the image using scikit-image method and then calculates the standard deviation for the image, scales it by the desired `std_dev` value and -/+ it from the mean. 

Thus, the problem is that `threshold()` was being called with `method=self.threshold_method` which when using `std_dev` it could not handle and instead raised a `ValueError`. This was captured broadly and returned a `[<image-name>] : No grains found.` message in the logger.

This is again the situation where there are lots of small grains and some large (despite noise removal) and the small need removing _before_ the `minimum_grain_size` is calculated. To which end the Otsu method is in my view most appropriate, and because this aligns with the previous steps taken the tests pass. Another option might be to adjust the `absolute_minimum_grain_size` to be larger so that the `Grains.remove_noise()` method removes more of the smaller grains.

I'm still unsure about then calculating the `minimum_grain_size` as being the `median - 1.5 * IQR`, it would probably be okay if what is left is grains that roughly follow a Gaussian distribution but if that is the case why not use the `mean - a * std_dev`?