### PR TITLE
Added colorbar into plot options

### DIFF
--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -313,7 +313,7 @@ def process_scan(
     if save_plots:
         LOGGER.info(f"[{filtered_image.filename}] : Plotting Filtering Images")
         # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
-        plot_opts = {"pixel_to_nm_scaling_factor": filtered_image.pixel_to_nm_scaling}
+        plot_opts = {"pixel_to_nm_scaling_factor": filtered_image.pixel_to_nm_scaling, "colorbar": colorbar}
         for image, options in PLOT_DICT.items():
             PLOT_DICT[image] = {**options, **plot_opts}
 


### PR DESCRIPTION
Solves issue where changing `colorbar : False` in the config file did nothing.

I've changed one line to add it into the `plot_opts` where it now works as intended and removes the colourbar completely from all images. 

There may be a better place but as it was similar to the `px_to_nm_scaling` I thought it might fit here.