### PR TITLE
Maxgamill sheffield/224 output file dir structure

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from topostats.utils import convert_path, find_images, update_config, get_thresholds
+from topostats.utils import convert_path, find_images, get_out_path, update_config, get_thresholds
 
 
 THRESHOLD_OPTIONS = {"otsu_threshold_multiplier": 1.7, "deviation_from_mean": 1, "absolute": (-1.5, 1.5)}
@@ -27,6 +27,16 @@ def test_find_images() -> None:
     assert len(found_images) == 1
     assert isinstance(found_images[0], Path)
     assert "minicircle.spm" in str(found_images[0])
+
+
+def test_get_out_path() -> None:
+    """Test output directories"""
+    image_path = Path('heres/some/rand/path/test.spm')
+    base_dir = Path('heres/some/rand')
+    output_dir = Path('output/here')
+    out_path = get_out_path(image_path, base_dir, output_dir)
+    assert isinstance(out_path, Path)
+    assert out_path == Path("output/here/path/test.spm")
 
 
 def test_update_config(caplog) -> None:

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -206,7 +206,9 @@ def process_scan(
     """
     LOGGER.info(f"Processing : {image_path}")
 
-    _output_dir = output_dir
+    parts = list(image_path.parts)
+    parts[0] = output_dir
+    _output_dir = Path(*parts).parent
     _output_dir.mkdir(parents=True, exist_ok=True)
     # Filter Image :
     #

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -17,7 +17,7 @@ from topostats.io import read_yaml, write_yaml
 from topostats.logs.logs import setup_logger, LOGGER_NAME
 from topostats.plottingfuncs import plot_and_save
 from topostats.tracing.dnatracing import dnaTrace, traceStats
-from topostats.utils import find_images, update_config, convert_path, create_empty_dataframe
+from topostats.utils import find_images, get_out_path, update_config, convert_path, create_empty_dataframe
 
 LOGGER = setup_logger(LOGGER_NAME)
 
@@ -144,6 +144,7 @@ def create_parser() -> arg.ArgumentParser:
 
 def process_scan(
     image_path: Union[str, Path] = None,
+    base_dir: Union[str, Path] = None,
     channel: str = "Height",
     amplify_level: float = 1.0,
     filter_threshold_method: str = "otsu",
@@ -206,9 +207,7 @@ def process_scan(
     """
     LOGGER.info(f"Processing : {image_path}")
 
-    parts = list(image_path.parts)
-    parts[0] = output_dir
-    _output_dir = Path(*parts).parent
+    _output_dir = get_out_path(image_path, base_dir, output_dir).parent
     _output_dir.mkdir(parents=True, exist_ok=True)
     # Filter Image :
     #
@@ -413,6 +412,7 @@ def main():
     #     )
     processing_function = partial(
         process_scan,
+        base_dir=config["base_dir"],
         channel=config["channel"],
         amplify_level=config["amplify_level"],
         filter_threshold_method=config["filter"]["threshold"]["method"],

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -172,6 +172,8 @@ def process_scan(
     ----------
     image_path : Union[str, Path]
         Path to image to process.
+    base_dir : Union[str, Path]
+        Directory to recursively search for files, if not specified the current directory is scanned.
     channel : str
         Channel to extract and process, default 'height'.
     amplify_level : float

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -84,7 +84,7 @@ def get_out_path(image_path: Union[str, Path] = None, base_dir: Union[str, Path]
     image_path: Union[str, Path]
         The path of the current image.
     base_dir: Union[str, Path]
-        The directory which recursively searched for files.
+        Directory to recursively search for files, if not specified the current directory is scanned.
     output_dir: Union[str, Path]
         The output directory specified in the configuration file.
 

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -95,12 +95,7 @@ def get_out_path(image_path: Union[str, Path] = None, base_dir: Union[str, Path]
     """
     pathparts = list(image_path.parts)
     inparts = list(base_dir.parts)
-
-    for inpart in inparts:
-        for pathpart in pathparts:
-            if inpart == pathpart:
-                pathparts.remove(inpart)
-    return output_dir / Path(*pathparts)
+    return output_dir / Path(*pathparts[len(inparts):])
 
 def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
     """Update the configuration with any arguments

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -76,7 +76,7 @@ def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> Li
     return list(base_dir.glob("**/*" + file_ext))
 
 
-def get_out_path(image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None):
+def get_out_path(image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None) -> Path:
     """Replaces the base directory part of the image path with the output directory.
 
     Parameters

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -76,6 +76,32 @@ def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> Li
     return list(base_dir.glob("**/*" + file_ext))
 
 
+def get_out_path(image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None):
+    """Replaces the base directory part of the image path with the output directory.
+
+    Parameters
+    ----------
+    image_path: Union[str, Path]
+        The path of the current image.
+    base_dir: Union[str, Path]
+        The directory which recursively searched for files.
+    output_dir: Union[str, Path]
+        The output directory specified in the configuration file.
+
+    Returns
+    -------
+    Path
+        The output path that mirrors the input path structure.
+    """
+    pathparts = list(image_path.parts)
+    inparts = list(base_dir.parts)
+
+    for inpart in inparts:
+        for pathpart in pathparts:
+            if inpart == pathpart:
+                pathparts.remove(inpart)
+    return output_dir / Path(*pathparts)
+
 def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
     """Update the configuration with any arguments
 


### PR DESCRIPTION
This PR orders the output directories into a structure similar to how the files are found.

Here, using "./data/" as the `base_dir` in the config file, we have multiple directories containing multiple files, i.e:
<img width="962" alt="Screenshot 2022-07-21 at 12 41 14" src="https://user-images.githubusercontent.com/91465918/180205295-159d4f45-3a5d-4bb9-a82e-8af8c1c7ee7b.png">

The PR replaces the `base_dir` of the `image_path` with the `output_dir`, keeping the subsequent directory structure after.
This creates an output mirroring the inputs, i.e:
<img width="1210" alt="Screenshot 2022-07-21 at 12 43 36" src="https://user-images.githubusercontent.com/91465918/180205736-56f5b489-0a72-4c35-a586-1708594bf911.png">

Further work will be done to remove the `minicircle<#>` directories but this should only happen after:
1) The output files are truncated.
2) The output files are re-named to reflect the file they originated from
In order to avoid overwriting output files.