### PR TITLE
pixel to nm scaling no longer assumes xy in nm

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -74,7 +74,6 @@ def test_extract_pixel_to_nm_scaling(test_filters_random: Filters, unit, x, y , 
     'x': x,
     'y': y
     }
-    #test_filters_random.images["extracted_channel"].pxs()
     test_filters_random.extract_pixel_to_nm_scaling()
     assert test_filters_random.pixel_to_nm_scaling == expected
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -63,6 +63,22 @@ def test_extract_pixels(test_filters: Filters) -> None:
     assert test_filters.images["pixels"].shape == (1024, 1024)
 
 
+@pytest.mark.parametrize("unit, x, y, expected", [
+    ('um', 100, 100, 97.65625),
+    ('nm', 50, 50, 0.048828125),
+    ])
+def test_extract_pixel_to_nm_scaling(test_filters_random: Filters, unit, x, y , expected) -> None:
+    """Test extraction of pixels to nanometer scaling."""
+    test_filters_random.images["extracted_channel"].size['real'] = {
+    'unit': unit,
+    'x': x,
+    'y': y
+    }
+    #test_filters_random.images["extracted_channel"].pxs()
+    test_filters_random.extract_pixel_to_nm_scaling()
+    assert test_filters_random.pixel_to_nm_scaling == expected
+
+
 def test_row_col_medians_no_mask(
     test_filters_random: Filters, image_random_row_medians: np.array, image_random_col_medians: np.array
 ) -> None:

--- a/tests/test_grainstats.py
+++ b/tests/test_grainstats.py
@@ -15,7 +15,7 @@ POINT4 = (0, 1)
 EDGES = np.array([POINT1, POINT2, POINT3, POINT4])
 
 
-def test_get_angle(grainstats) -> None:
+def test_get_angle(grainstats: GrainStats) -> None:
     """Test calculation of angle."""
     angle = grainstats.get_angle(POINT1, POINT3)
     target = np.arctan2(POINT1[1] - POINT3[1], POINT1[0] - POINT3[0])
@@ -24,7 +24,7 @@ def test_get_angle(grainstats) -> None:
     assert angle == target
 
 
-def test_is_clockwise_clockwise(grainstats) -> None:
+def test_is_clockwise_clockwise(grainstats: GrainStats) -> None:
     """Test calculation of whether three points make a clockwise turn"""
     clockwise = grainstats.is_clockwise(POINT3, POINT2, POINT1)
 
@@ -32,7 +32,7 @@ def test_is_clockwise_clockwise(grainstats) -> None:
     assert clockwise
 
 
-def test_is_clockwise_anti_clockwise(grainstats) -> None:
+def test_is_clockwise_anti_clockwise(grainstats: GrainStats) -> None:
     """Test calculation of whether three points make a clockwise turn"""
     clockwise = grainstats.is_clockwise(POINT1, POINT2, POINT3)
 
@@ -40,7 +40,7 @@ def test_is_clockwise_anti_clockwise(grainstats) -> None:
     assert not clockwise
 
 
-def test_calculate_edges(grainstats) -> None:
+def test_calculate_edges(grainstats: GrainStats) -> None:
     """Test calculation of edges."""
     grain_mask = np.array(
         [
@@ -88,7 +88,7 @@ def test_calculate_edges(grainstats) -> None:
     np.testing.assert_array_equal(edges, target)
 
 
-def test_calculate_centroid(grainstats) -> None:
+def test_calculate_centroid(grainstats: GrainStats) -> None:
     """Test calculation of centroid."""
     centroid = grainstats._calculate_centroid(EDGES)
     target = (0.5, 0.5)
@@ -97,7 +97,7 @@ def test_calculate_centroid(grainstats) -> None:
     assert centroid == target
 
 
-def test_calculate_displacement(grainstats) -> None:
+def test_calculate_displacement(grainstats: GrainStats) -> None:
     """Test calculation of displacement of points from centroid."""
     centroid = grainstats._calculate_centroid(EDGES)
     displacement = grainstats._calculate_displacement(EDGES, centroid)
@@ -108,7 +108,7 @@ def test_calculate_displacement(grainstats) -> None:
     np.testing.assert_array_equal(displacement, target)
 
 
-def test_calculate_radius(grainstats) -> None:
+def test_calculate_radius(grainstats: GrainStats) -> None:
     """Calculate the radius of each point from the centroid."""
     centroid = grainstats._calculate_centroid(EDGES)
     displacement = grainstats._calculate_displacement(EDGES, centroid)
@@ -120,7 +120,7 @@ def test_calculate_radius(grainstats) -> None:
     np.testing.assert_array_equal(radii, target)
 
 
-def test_calculate_squared_distance(grainstats) -> None:
+def test_calculate_squared_distance(grainstats: GrainStats) -> None:
     """Test the calculation of displacement between two points."""
     displacement_1_2 = grainstats.calculate_squared_distance(POINT2, POINT1)
     displacement_1_3 = grainstats.calculate_squared_distance(POINT3, POINT1)
@@ -169,7 +169,7 @@ def test_get_shift(coords, shape, expected):
     (3,np.asarray([1,20]),21,[1,6]),
     (8,np.asarray([18,6]),21,[14,6])
     ])
-def test_get_cropped_region(grainstats, length, centre, img_len, expected):
+def test_get_cropped_region(grainstats: GrainStats, length, centre, img_len, expected):
     """Tests the Grainstats.get_cropped_region function's shape and center postition are correct."""
     image = np.random.rand(img_len, img_len)
     image[centre[0],centre[1]] = 5

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -135,7 +135,6 @@ class Filters:
     def extract_pixels(self) -> None:
         """Flatten the scan to a Numpy Array."""
         self.images["pixels"] = np.flipud(np.array(self.images["extracted_channel"].pixels))
-        print(self.images['pixels'])
         LOGGER.info(f"[{self.filename}] : Pixels extracted")
 
     def amplify(self) -> None:

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -120,14 +120,22 @@ class Filters:
 
     def extract_pixel_to_nm_scaling(self) -> float:
         """Extract the pixel to nanometer scaling from the image metadata."""
-        self.pixel_to_nm_scaling = self.images["extracted_channel"].get_extent()[1] / len(
-            self.images["extracted_channel"].pixels
-        )
+        unit_dict = {
+            'nm' : 1,
+            'um' : 1e3,
+        }
+        px_to_real = self.images["extracted_channel"].pxs()
+        # Has potential for non-square images but not yet implimented
+        self.pixel_to_nm_scaling = (
+            px_to_real[0][0]*unit_dict[px_to_real[0][1]],
+            px_to_real[1][0]*unit_dict[px_to_real[1][1]],
+        )[0]
         LOGGER.info(f"[{self.filename}] : Pixels to nm scaling : {self.pixel_to_nm_scaling}")
 
     def extract_pixels(self) -> None:
         """Flatten the scan to a Numpy Array."""
         self.images["pixels"] = np.flipud(np.array(self.images["extracted_channel"].pixels))
+        print(self.images['pixels'])
         LOGGER.info(f"[{self.filename}] : Pixels extracted")
 
     def amplify(self) -> None:


### PR DESCRIPTION
.spm data seems like it is encoded as a value and a unit. This change adds a dictionary to the `extract_pixel_to_nm_scaling` function in the `Filters` class and uses the units to rescale produced value of `self.pixel_to_nm_scaling`.

Tests have also been added via `parameterize` so there is room for non-square tests too.

Currently, this is only a quick fix but has a framework in place to address some other issues I've found associated with this:
- It is currently all in reference to "nm" where it may be best to have SI units which can then propagate to the grainstats and dnatracing stats.
- Framework is present within the function to obtain px-to-nm values for non-square images but further changes would be needed to propagate these values through to later functions as the output would differ (no longer one value).
- Always using nm in plots looks weird for large values (10000's of nm) so would ideally pull the units through to the plots.
- Pixel values (heights) have no units that I can see, a similar issue may occur like above but for the height scale of images.

What are people's thoughts on making the above changes in other branches/PR's? Or just waiting until my other PR is merged to then make changes on this branch because of the merge conflicts with changing so much function input/output?