### PR TITLE
271 | Handle multiple periods in filenames

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -52,47 +52,47 @@ plotting:
   # | core_set     | Boolean | Whether a plot is considered part of the core set of images that are plotted.|
   plot_dict:
     extracted_channel:
-      filename: "00-raw_heightmap.png"
+      filename: "00-raw_heightmap"
       title: "Raw Height"
       type: "non-binary"
       core_set: false
     pixels:
-      filename: "01-pixels.png"
+      filename: "01-pixels"
       title: "Pixels"
       type: "non-binary"
       core_set: false
     initial_align:
-      filename: "02-initial_align_unmasked.png"
+      filename: "02-initial_align_unmasked"
       title: "Initial Alignment (Unmasked)"
       type: "non-binary"
       core_set: false
     initial_tilt_removal:
-      filename: "03-initial_tilt_removal_unmasked.png"
+      filename: "03-initial_tilt_removal_unmasked"
       title: "Initial Tilt Removal (Unmasked)"
       type: "non-binary"
       core_set: false
     mask:
-      filename: "04-binary_mask.png"
+      filename: "04-binary_mask"
       title: "Binary Mask"
       type: "binary"
       core_set: false
     masked_align:
-      filename: "05-secondary_align_masked.png"
+      filename: "05-secondary_align_masked"
       title: "Secondary Alignment (Masked)"
       type: "non-binary"
       core_set: false
     masked_tilt_removal:
-      filename: "06-secondary_tilt_removal_masked.png"
+      filename: "06-secondary_tilt_removal_masked"
       title: "Secondary Tilt Removal (Masked)"
       type: "non-binary"
       core_set: false
     zero_averaged_background:
-      filename: "07-zero_average_background.png"
+      filename: "07-zero_average_background"
       title: "Zero Average Background"
       type: "non-binary"
       core_set: false
     gaussian_filtered:
-      filename: "08-gaussian_filtered.png"
+      filename: "08-gaussian_filtered"
       title: "Gaussian Filtered"
       type: "non-binary"
       core_set: false
@@ -101,27 +101,27 @@ plotting:
       type: "non-binary"
       core_set: true
     mask_grains:
-      filename: "09-mask_grains.png"
+      filename: "09-mask_grains"
       title: "Mask for Grains"
       type: "binary"
       core_set: false
     tidied_border:
-      filename: "10-tidy_borders.png"
+      filename: "10-tidy_borders"
       title: "Tidied Borders"
       type: "binary"
       core_set: false
     removed_noise:
-      filename: "11-noise_removed.png"
+      filename: "11-noise_removed"
       title: "Noise removed"
       type: "binary"
       core_set: false
     labelled_regions_01:
-      filename: "12-labelled_regions.png"
+      filename: "12-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     removed_small_objects:
-      filename: "13-small_objects_removed.png"
+      filename: "13-small_objects_removed"
       title: "Small Objects Removed"
       type: "binary"
       core_set: false
@@ -130,22 +130,22 @@ plotting:
       type: "non-binary"
       core_set: true
     labelled_regions_02:
-      filename: "14-labelled_regions.png"
+      filename: "14-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     coloured_regions:
-      filename: "15-coloured_regions.png"
+      filename: "15-coloured_regions"
       title: "Coloured Regions"
       type: "binary"
       core_set: false
     bounding_boxes:
-      filename: "16-bounding_boxes.png"
+      filename: "16-bounding_boxes"
       title: "Bounding Boxes"
       type: "binary"
       core_set: false
     coloured_boxes:
-      filename: "17-labelled_image_bboxes.png"
+      filename: "17-labelled_image_bboxes"
       title: "Labelled Image with Bounding Boxes"
       type: "binary"
       core_set: false

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,6 +551,7 @@ def minicircle_grainstats(
         pixel_to_nanometre_scaling=minicircle_pixels.pixel_to_nm_scaling,
         base_output_dir=tmpdir,
         image_set=plotting_config["image_set"],
+        filename=minicircle_filename.filename,
         **grainstats_config,
     )
 

--- a/tests/resources/process_scan_config.yaml
+++ b/tests/resources/process_scan_config.yaml
@@ -52,47 +52,47 @@ plotting:
   # | core_set     | Boolean | Whether a plot is considered part of the core set of images that are plotted.|
   plot_dict:
     extracted_channel:
-      filename: "00-raw_heightmap.png"
+      filename: "00-raw_heightmap"
       title: "Raw Height"
       type: "non-binary"
       core_set: false
     pixels:
-      filename: "01-pixels.png"
+      filename: "01-pixels"
       title: "Pixels"
       type: "non-binary"
       core_set: false
     initial_align:
-      filename: "02-initial_align_unmasked.png"
+      filename: "02-initial_align_unmasked"
       title: "Initial Alignment (Unmasked)"
       type: "non-binary"
       core_set: false
     initial_tilt_removal:
-      filename: "03-initial_tilt_removal_unmasked.png"
+      filename: "03-initial_tilt_removal_unmasked"
       title: "Initial Tilt Removal (Unmasked)"
       type: "non-binary"
       core_set: false
     mask:
-      filename: "04-binary_mask.png"
+      filename: "04-binary_mask"
       title: "Binary Mask"
       type: "binary"
       core_set: false
     masked_align:
-      filename: "05-secondary_align_masked.png"
+      filename: "05-secondary_align_masked"
       title: "Secondary Alignment (Masked)"
       type: "non-binary"
       core_set: false
     masked_tilt_removal:
-      filename: "06-secondary_tilt_removal_masked.png"
+      filename: "06-secondary_tilt_removal_masked"
       title: "Secondary Tilt Removal (Masked)"
       type: "non-binary"
       core_set: false
     zero_averaged_background:
-      filename: "07-zero_average_background.png"
+      filename: "07-zero_average_background"
       title: "Zero Average Background"
       type: "non-binary"
       core_set: false
     gaussian_filtered:
-      filename: "08-gaussian_filtered.png"
+      filename: "08-gaussian_filtered"
       title: "Gaussian Filtered"
       type: "non-binary"
       core_set: false
@@ -101,27 +101,27 @@ plotting:
       type: "non-binary"
       core_set: true
     mask_grains:
-      filename: "09-mask_grains.png"
+      filename: "09-mask_grains"
       title: "Mask for Grains"
       type: "binary"
       core_set: false
     tidied_border:
-      filename: "10-tidy_borders.png"
+      filename: "10-tidy_borders"
       title: "Tidied Borders"
       type: "binary"
       core_set: false
     removed_noise:
-      filename: "11-noise_removed.png"
+      filename: "11-noise_removed"
       title: "Noise removed"
       type: "binary"
       core_set: false
     labelled_regions_01:
-      filename: "12-labelled_regions.png"
+      filename: "12-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     removed_small_objects:
-      filename: "13-small_objects_removed.png"
+      filename: "13-small_objects_removed"
       title: "Small Objects Removed"
       type: "binary"
       core_set: false
@@ -130,22 +130,22 @@ plotting:
       type: "non-binary"
       core_set: true
     labelled_regions_02:
-      filename: "14-labelled_regions.png"
+      filename: "14-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     coloured_regions:
-      filename: "15-coloured_regions.png"
+      filename: "15-coloured_regions"
       title: "Coloured Regions"
       type: "binary"
       core_set: false
     bounding_boxes:
-      filename: "16-bounding_boxes.png"
+      filename: "16-bounding_boxes"
       title: "Bounding Boxes"
       type: "binary"
       core_set: false
     coloured_boxes:
-      filename: "17-labelled_image_bboxes.png"
+      filename: "17-labelled_image_bboxes"
       title: "Labelled Image with Bounding Boxes"
       type: "binary"
       core_set: false

--- a/tests/resources/sample_config.yaml
+++ b/tests/resources/sample_config.yaml
@@ -40,47 +40,47 @@ plotting:
   cmap: nanoscope # Options : nanoscope, afmhot
   plot_dict:
     extracted_channel:
-      filename: "00-raw_heightmap.png"
+      filename: "00-raw_heightmap"
       title: "Raw Height"
       type: "non-binary"
       core_set: false
     pixels:
-      filename: "01-pixels.png"
+      filename: "01-pixels"
       title: "Pixels"
       type: "non-binary"
       core_set: false
     initial_align:
-      filename: "02-initial_align_unmasked.png"
+      filename: "02-initial_align_unmasked"
       title: "Initial Alignment (Unmasked)"
       type: "non-binary"
       core_set: false
     initial_tilt_removal:
-      filename: "03-initial_tilt_removal_unmasked.png"
+      filename: "03-initial_tilt_removal_unmasked"
       title: "Initial Tilt Removal (Unmasked)"
       type: "non-binary"
       core_set: false
     mask:
-      filename: "04-binary_mask.png"
+      filename: "04-binary_mask"
       title: "Binary Mask"
       type: "binary"
       core_set: false
     masked_align:
-      filename: "05-secondary_align_masked.png"
+      filename: "05-secondary_align_masked"
       title: "Secondary Alignment (Masked)"
       type: "non-binary"
       core_set: false
     masked_tilt_removal:
-      filename: "06-secondary_tilt_removal_masked.png"
+      filename: "06-secondary_tilt_removal_masked"
       title: "Secondary Tilt Removal (Masked)"
       type: "non-binary"
       core_set: false
     zero_averaged_background:
-      filename: "07-zero_average_background.png"
+      filename: "07-zero_average_background"
       title: "Zero Average Background"
       type: "non-binary"
       core_set: false
     gaussian_filtered:
-      filename: "08-gaussian_filtered.png"
+      filename: "08-gaussian_filtered"
       title: "Gaussian Filtered"
       type: "non-binary"
       core_set: false
@@ -89,27 +89,27 @@ plotting:
       type: "non-binary"
       core_set: true
     mask_grains:
-      filename: "09-mask_grains.png"
+      filename: "09-mask_grains"
       title: "Mask for Grains"
       type: "binary"
       core_set: false
     tidied_border:
-      filename: "10-tidy_borders.png"
+      filename: "10-tidy_borders"
       title: "Tidied Borders"
       type: "binary"
       core_set: false
     removed_noise:
-      filename: "11-noise_removed.png"
+      filename: "11-noise_removed"
       title: "Noise removed"
       type: "binary"
       core_set: false
     labelled_regions_01:
-      filename: "12-labelled_regions.png"
+      filename: "12-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     removed_small_objects:
-      filename: "13-small_objects_removed.png"
+      filename: "13-small_objects_removed"
       title: "Small Objects Removed"
       type: "binary"
       core_set: false
@@ -118,22 +118,22 @@ plotting:
       type: "non-binary"
       core_set: true
     labelled_regions_02:
-      filename: "14-labelled_regions.png"
+      filename: "14-labelled_regions"
       title: "Labelled Regions"
       type: "binary"
       core_set: false
     coloured_regions:
-      filename: "15-coloured_regions.png"
+      filename: "15-coloured_regions"
       title: "Coloured Regions"
       type: "binary"
       core_set: false
     bounding_boxes:
-      filename: "16-bounding_boxes.png"
+      filename: "16-bounding_boxes"
       title: "Bounding Boxes"
       type: "binary"
       core_set: false
     coloured_boxes:
-      filename: "17-labelled_image_bboxes.png"
+      filename: "17-labelled_image_bboxes"
       title: "Labelled Image with Bounding Boxes"
       type: "binary"
       core_set: false

--- a/tests/test_grainstats.py
+++ b/tests/test_grainstats.py
@@ -145,7 +145,7 @@ def test_random_grain_stats(caplog, tmpdir) -> None:
         data=None,
         labelled_data=None,
         pixel_to_nanometre_scaling=0.5,
-        image_name="random",
+        filename="random",
         direction="upper",
         base_output_dir=tmpdir,
     )

--- a/tests/test_grainstats_minicircle.py
+++ b/tests/test_grainstats_minicircle.py
@@ -18,7 +18,6 @@ RESOURCES = BASE_DIR / "tests" / "resources"
 def test_grainstats_regression(regtest, minicircle_grainstats: GrainStats) -> None:
     """Regression tests for grainstats."""
     statistics = minicircle_grainstats.calculate_stats()
-    print(statistics["statistics"].to_string(), file=regtest)
 
 
 @pytest.mark.parametrize(
@@ -29,7 +28,7 @@ def test_grainstats_regression(regtest, minicircle_grainstats: GrainStats) -> No
     ],
 )
 def test_save_cropped_grains(minicircle_grainstats: GrainStats, tmpdir, value):
-    # need to run grainstats with config option True and see if it is there.
+    """Test if save_cropped_grains option creates target directory."""
     minicircle_grainstats.save_cropped_grains = value
     minicircle_grainstats.base_output_dir = Path(tmpdir) / "grains"
     minicircle_grainstats.calculate_stats()
@@ -44,19 +43,19 @@ def test_save_cropped_grains(minicircle_grainstats: GrainStats, tmpdir, value):
     ],
 )
 def test_image_set(minicircle_grainstats: GrainStats, tmpdir, value, expected):
-    # need to run grainstats with config option True and see if it is there.
+    """Test saving of cropped grains based on the image need to run grainstats with config option True and see if it is there."""
     minicircle_grainstats.save_cropped_grains = True
     minicircle_grainstats.image_set = value
     minicircle_grainstats.base_output_dir = Path(tmpdir) / "grains"
     minicircle_grainstats.calculate_stats()
-    assert Path.exists(Path(tmpdir) / "grains/upper/None_processed_grain_0.png") == True
-    assert Path.exists(Path(tmpdir) / "grains/upper/None_grain_image_0.png") == expected
-    assert Path.exists(Path(tmpdir) / "grains/upper/None_grainmask_0.png") == expected
+    assert Path.exists(Path(tmpdir) / "grains/upper/minicircle_processed_grain_0.png") == True
+    assert Path.exists(Path(tmpdir) / "grains/upper/minicircle_grain_image_0.png") == expected
+    assert Path.exists(Path(tmpdir) / "grains/upper/minicircle_grainmask_0.png") == expected
 
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_cropped_image(minicircle_grainstats: GrainStats, tmpdir):
-    "Tests that produced cropped images have not changed."
+    """Tests that produced cropped images have not changed."""
     grain_centre = 547, 794  # centre of grain 7
     length = int(minicircle_grainstats.cropped_size / (2 * minicircle_grainstats.pixel_to_nanometre_scaling))
     cropped_grain_image = minicircle_grainstats.get_cropped_region(

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -60,7 +60,7 @@ class GrainStats:
         pixel_to_nanometre_scaling: float,
         direction: str,
         base_output_dir: Union[str, Path],
-        image_name: str = None,
+        filename: str = None,
         zrange: list = [None, None],
         image_set: str = "core",
         save_cropped_grains: bool = False,
@@ -78,7 +78,7 @@ class GrainStats:
             Floating point value that defines the scaling factor between nanometres and pixels.
         base_output_dir : Path
             Path to the folder that will store the grain stats output images and data.
-        image_name : str
+        filename : str
             The name of the file being processed.
         zrange : list
             Low and high height values for the cropped grain zscale.
@@ -96,7 +96,7 @@ class GrainStats:
         self.direction = direction
         self.base_output_dir = Path(base_output_dir)
         self.start_point = None
-        self.image_name = image_name
+        self.filename = filename
         self.zrange = zrange
         self.image_set = image_set
         self.save_cropped_grains = save_cropped_grains
@@ -138,10 +138,13 @@ class GrainStats:
         -------
         boolean
             Indicator of whether turn is clockwise.
+
+        Notes
+        -----
+
+        If the determinant of the rotation matrix is > 0 then the rotation is counter-clockwise, otherwise it is
+        clockwise.
         """
-        # Determine if three points form a clockwise or counter-clockwise turn.
-        # I use the method of calculating the determinant of the following rotation matrix here. If the determinant
-        # is > 0 then the rotation is counter-clockwise.
         rotation_matrix = np.array(((p_1[0], p_1[1], 1), (p_2[0], p_2[1], 1), (p_3[0], p_3[1], 1)))
         return not np.linalg.det(rotation_matrix) > 0
 
@@ -150,7 +153,7 @@ class GrainStats:
 
         if self.labelled_data is None:
             LOGGER.info(
-                f"[{self.image_name}] : No labelled regions for this image, grain statistics can not be calculated."
+                f"[{self.filename}] : No labelled regions for this image, grain statistics can not be calculated."
             )
             return {"statistics": pd.DataFrame(columns=GRAIN_STATS_COLUMNS), "plot": None}
 
@@ -165,7 +168,7 @@ class GrainStats:
         stats_array = []
         for index, region in enumerate(region_properties):
 
-            LOGGER.info(f"[{self.image_name}] : Processing grain: {index}")
+            LOGGER.info(f"[{self.filename}] : Processing grain: {index}")
             # Create directory for each grain's plots
             output_grain = self.base_output_dir / self.direction
 
@@ -183,7 +186,7 @@ class GrainStats:
                     plot_and_save(
                         grain_image,
                         output_grain,
-                        f"{self.image_name}_processed_grain_{index}.png",
+                        f"{self.filename}_processed_grain_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="non-binary",
                         image_set=self.image_set,
@@ -194,7 +197,7 @@ class GrainStats:
                     plot_and_save(
                         grain_mask,
                         output_grain,
-                        f"{self.image_name}_grainmask_{index}.png",
+                        f"{self.filename}_grainmask_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="binary",
                         image_set=self.image_set,
@@ -204,7 +207,7 @@ class GrainStats:
                     plot_and_save(
                         masked_grain_image,
                         output_grain,
-                        f"{self.image_name}_grain_image_{index}.png",
+                        f"{self.filename}_grain_image_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="non-binary",
                         image_set=self.image_set,
@@ -229,7 +232,7 @@ class GrainStats:
                     plot_and_save(
                         cropped_grain_image,
                         output_grain,
-                        f"{self.image_name}_processed_grain_{index}.png",
+                        f"{self.filename}_processed_grain_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="non-binary",
                         image_set=self.image_set,
@@ -240,7 +243,7 @@ class GrainStats:
                     plot_and_save(
                         cropped_grain_mask,
                         output_grain,
-                        f"{self.image_name}_grainmask_{index}.png",
+                        f"{self.filename}_grainmask_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="binary",
                         image_set=self.image_set,
@@ -249,7 +252,7 @@ class GrainStats:
                     plot_and_save(
                         cropped_masked_grain_image,
                         output_grain,
-                        f"{self.image_name}_grain_image_{index}.png",
+                        f"{self.filename}_grain_image_{index}",
                         pixel_to_nm_scaling_factor=self.pixel_to_nanometre_scaling,
                         type="non-binary",
                         image_set=self.image_set,
@@ -323,10 +326,10 @@ class GrainStats:
         grainstats.index.name = "Molecule Number"
 
         # if self.save_cropped_grains:
-        # savename = f"{self.image_name}_{self.direction}_grainstats.csv"
+        # savename = f"{self.filename}_{self.direction}_grainstats.csv"
         # grainstats.to_csv(self.base_output_dir / self.direction / savename)
         # LOGGER.info(
-        #    f"[{self.image_name}] : Grain statistics saved to {str(self.base_output_dir)}/{str(self.direction)}/{savename}"
+        #    f"[{self.filename}] : Grain statistics saved to {str(self.base_output_dir)}/{str(self.direction)}/{savename}"
         # )
 
         return {"statistics": grainstats, "plot": ax}

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -1,5 +1,6 @@
 """Plotting data."""
 from pathlib import Path
+import re
 from typing import Union
 import logging
 
@@ -10,6 +11,7 @@ import numpy as np
 
 from topostats.logs.logs import LOGGER_NAME
 from topostats.theme import Colormap
+from topostats.utils import clean_filename
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -89,9 +91,10 @@ def plot_and_save(
 
         if save:
             if image_set == "all" or core_set:
-                plt.savefig(output_dir / filename)
+                outfile = clean_filename(filename)
+                plt.savefig(output_dir / outfile)
                 if "_processed" in filename:
-                    LOGGER.info(f"[{filename.split('_processed')[0]}] : Image saved to : {str(output_dir / filename)}")
+                    LOGGER.info(f"[{filename.split('_processed')[0]}] : Image saved to : {outfile}")
     else:
         plt.xlabel("Nanometres")
         plt.ylabel("Nanometres")

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -219,7 +219,7 @@ def process_scan(
                         pixel_to_nanometre_scaling=filtered_image.pixel_to_nm_scaling,
                         direction=direction,
                         base_output_dir=_output_dir / "grains",
-                        image_name=filtered_image.filename,
+                        filename=filtered_image.filename,
                         image_set=plotting_config["image_set"],
                         **grainstats_config,
                     ).calculate_stats()

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -299,7 +299,6 @@ def process_scan(
             plot_name = "gaussian_filtered"
             plotting_config["plot_dict"][plot_name]["output_dir"] = filter_out_path
             plot_and_save(grains.images["gaussian_filtered"], **plotting_config["plot_dict"][plot_name])
-
             plot_name = "z_threshed"
             plotting_config["plot_dict"][plot_name]["output_dir"] = Path(_output_dir)
             plot_and_save(

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -2,6 +2,7 @@
 from argparse import Namespace
 import logging
 from pathlib import Path
+import re
 from typing import Union, List, Dict
 from collections import defaultdict
 
@@ -74,6 +75,22 @@ def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> Li
     """
     base_dir = Path("./") if base_dir is None else Path(base_dir)
     return list(base_dir.glob("**/*" + file_ext))
+
+
+def clean_filename(filename: str):
+    """Removes multiple periods from filenames leaving just the final extensions. Replaces '.' with '_'.
+
+    Parameters
+    ----------
+    file_list: list
+        List of Path objects to be cleaned.
+
+    Returns
+    -------
+    list
+        List of file Path objects with all but the last '.' replaced with '_'.
+    """
+    return re.sub("\.", "_", str(filename))
 
 
 def get_out_path(


### PR DESCRIPTION
Resolves #271 

We experienced crashes when input filenames had multiple periods (`.`) when it came to plotting images because Matplotlib was trying to save it with the extension/type following the period, which is often nonsense.

Instead we now clean this up and replace `.` with `_`.