### PR TITLE
Maxgamill sheffield/hotfix overwriting plots

### DIFF
--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -26,7 +26,7 @@ def test_save_figure(
     fig, ax = Images(
         data=image_random,
         output_dir=tmp_path,
-        filename="result.png",
+        filename="result",
         data2=data2,
         colorbar=axes_colorbar,
         axes=axes_colorbar,
@@ -42,7 +42,7 @@ def test_save_array_figure(tmp_path: Path):
     Images(
         data=np.random.rand(10,10),
         output_dir=tmp_path,
-        filename="result.png",
+        filename="result",
     ).save_array_figure()
     assert Path(tmp_path / "result.png").exists()
 
@@ -53,7 +53,7 @@ def test_plot_and_save_no_colorbar(minicircle_pixels: Filters, tmp_path: Path) -
     fig, _ = Images(
         data=minicircle_pixels.images["pixels"],
         output_dir=tmp_path,
-        filename="01-raw_heightmap.png",
+        filename="01-raw_heightmap",
         pixel_to_nm_scaling_factor=minicircle_pixels.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=False,
@@ -69,7 +69,7 @@ def test_plot_and_save_colorbar(minicircle_pixels: Filters, tmp_path: Path) -> N
     fig, _ = Images(
         data=minicircle_pixels.images["pixels"],
         output_dir=tmp_path,
-        filename="01-raw_heightmap.png",
+        filename="01-raw_heightmap",
         pixel_to_nm_scaling_factor=minicircle_pixels.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=True,
@@ -87,7 +87,7 @@ def test_plot_and_save_no_axes(minicircle_pixels: Filters, plotting_config: dict
     fig, _ = Images(
         data=minicircle_pixels.images["pixels"],
         output_dir=tmp_path,
-        filename="01-raw_heightmap.png",
+        filename="01-raw_heightmap",
         title="Raw Height", 
         **plotting_config
     ).plot_and_save()
@@ -101,7 +101,7 @@ def test_plot_and_save_no_axes_no_colorbar(minicircle_pixels: Filters, plotting_
     Images(
         data=minicircle_pixels.images["pixels"],
         output_dir=tmp_path,
-        filename="01-raw_heightmap.png",
+        filename="01-raw_heightmap",
         title="Raw Height",
         **plotting_config
     ).plot_and_save()
@@ -118,7 +118,7 @@ def test_plot_and_save_colorbar_afmhot(minicircle_pixels: Filters, tmp_path: Pat
     fig, _ = Images(
         data=minicircle_pixels.images["pixels"],
         output_dir=tmp_path,
-        filename="01-raw_heightmap.png",
+        filename="01-raw_heightmap",
         pixel_to_nm_scaling_factor=minicircle_pixels.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=True,
@@ -141,7 +141,7 @@ def test_plot_and_save_bounding_box(
     fig, _ = Images(
         data=minicircle_grain_coloured.directions["upper"]["coloured_regions"],
         output_dir=tmp_path,
-        filename="15-coloured_regions.png",
+        filename="15-coloured_regions",
         pixel_to_nm_scaling_factor=minicircle_grain_coloured.pixel_to_nm_scaling,
         title="Coloured Regions",
         **plotting_config,
@@ -158,7 +158,7 @@ def test_plot_and_save_zrange(minicircle_grain_gaussian_filter: Grains, plotting
     fig, _ = Images(
         data=minicircle_grain_gaussian_filter.images["gaussian_filtered"],
         output_dir=tmp_path,
-        filename="08_5-z_threshold.png",
+        filename="08_5-z_threshold",
         pixel_to_nm_scaling_factor=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
         title="Raw Height",
         **plotting_config,

--- a/topostats/plotting_dictionary.yaml
+++ b/topostats/plotting_dictionary.yaml
@@ -11,22 +11,22 @@
 # | type         | String  | Whether the plot includes the height (non-binary) or the outline (binary)    |
 # | core_set     | Boolean | Whether a plot is considered part of the core set of images that are plotted.|
 extracted_channel:
-  filename: "00-raw_heightmap.png"
+  filename: "00-raw_heightmap"
   title: "Raw Height"
   type: "non-binary"
   core_set: false
 pixels:
-  filename: "01-pixels.png"
+  filename: "01-pixels"
   title: "Pixels"
   type: "non-binary"
   core_set: false
 initial_align:
-  filename: "02-initial_align_unmasked.png"
+  filename: "02-initial_align_unmasked"
   title: "Initial Alignment (Unmasked)"
   type: "non-binary"
   core_set: false
 initial_tilt_removal:
-  filename: "03-initial_tilt_removal_unmasked.png"
+  filename: "03-initial_tilt_removal_unmasked"
   title: "Initial Tilt Removal (Unmasked)"
   type: "non-binary"
   core_set: false
@@ -36,22 +36,22 @@ mask:
   type: "binary"
   core_set: false
 masked_align:
-  filename: "05-secondary_align_masked.png"
+  filename: "05-secondary_align_masked"
   title: "Secondary Alignment (Masked)"
   type: "non-binary"
   core_set: false
 masked_tilt_removal:
-  filename: "06-secondary_tilt_removal_masked.png"
+  filename: "06-secondary_tilt_removal_masked"
   title: "Secondary Tilt Removal (Masked)"
   type: "non-binary"
   core_set: false
 zero_averaged_background:
-  filename: "07-zero_average_background.png"
+  filename: "07-zero_average_background"
   title: "Zero Average Background"
   type: "non-binary"
   core_set: false
 gaussian_filtered:
-  filename: "08-gaussian_filtered.png"
+  filename: "08-gaussian_filtered"
   title: "Gaussian Filtered"
   type: "non-binary"
   core_set: false
@@ -60,27 +60,27 @@ z_threshed:
   type: "non-binary"
   core_set: true
 mask_grains:
-  filename: "09-mask_grains.png"
+  filename: "09-mask_grains"
   title: "Mask for Grains"
   type: "binary"
   core_set: false
 tidied_border:
-  filename: "10-tidy_borders.png"
+  filename: "10-tidy_borders"
   title: "Tidied Borders"
   type: "binary"
   core_set: false
 removed_noise:
-  filename: "11-noise_removed.png"
+  filename: "11-noise_removed"
   title: "Noise removed"
   type: "binary"
   core_set: false
 labelled_regions_01:
-  filename: "12-labelled_regions.png"
+  filename: "12-labelled_regions"
   title: "Labelled Regions"
   type: "binary"
   core_set: false
 removed_small_objects:
-  filename: "13-small_objects_removed.png"
+  filename: "13-small_objects_removed"
   title: "Small Objects Removed"
   type: "binary"
   core_set: false
@@ -89,22 +89,22 @@ mask_overlay:
   type: "non-binary"
   core_set: true
 labelled_regions_02:
-  filename: "14-labelled_regions.png"
+  filename: "14-labelled_regions"
   title: "Labelled Regions"
   type: "binary"
   core_set: false
 coloured_regions:
-  filename: "15-coloured_regions.png"
+  filename: "15-coloured_regions"
   title: "Coloured Regions"
   type: "binary"
   core_set: false
 bounding_boxes:
-  filename: "16-bounding_boxes.png"
+  filename: "16-bounding_boxes"
   title: "Bounding Boxes"
   type: "binary"
   core_set: false
 coloured_boxes:
-  filename: "17-labelled_image_bboxes.png"
+  filename: "17-labelled_image_bboxes"
   title: "Labelled Image with Bounding Boxes"
   type: "binary"
   core_set: false

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -169,13 +169,13 @@ class Images:
                         plt.title("")
                         fig.frameon=False
                         plt.savefig(
-                            (self.output_dir / self.filename).with_suffix(f".{self.save_format}"), 
+                            (self.output_dir / f"{self.filename}.{self.save_format}"), 
                             format=self.save_format, 
                             bbox_inches="tight", 
                             pad_inches = 0
                         )
             else:
-                plt.savefig((self.output_dir / self.filename).with_suffix(f".{self.save_format}"), format=self.save_format)
+                plt.savefig((self.output_dir / f"{self.filename}.{self.save_format}"), format=self.save_format)
         else:
             plt.xlabel("Nanometres")
             plt.ylabel("Nanometres")
@@ -191,7 +191,7 @@ class Images:
     def save_array_figure(self) -> None:
         """This function saves only the image array as an image using plt.imsave"""
         plt.imsave(
-            (self.output_dir / self.filename).with_suffix(f".{self.save_format}"), 
+            (self.output_dir / f"{self.filename}.{self.save_format}"),
             self.data,
             cmap=Colormap(self.cmap).get_cmap(),
             vmin=self.zrange[0],


### PR DESCRIPTION
This fixes an issues where image overwriting can occur due to the filenames containing an extension i.e:

`abc.0_001.spm` is passed into the filename argument as `abc.0_001`.
So in `plottingfuncs.py`, the `<path>.with_suffix(<ext>)` replaces the `.0_001` with `<ext>`.
This replaces the image if an image for `abc.0_000.spm` already exists.

The fix is to ensure no file extensions are input into filename, hence the removal from `plotting_dictionary.yaml` and in the tests.