### PR TITLE
Fix run_topostats crash

### DIFF
--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -1,4 +1,4 @@
-base_dir: ./
+base_dir: ./tests
 output_dir: ./output
 warnings: ignore
 cores: 4
@@ -13,10 +13,10 @@ filter:
   threshold_std_dev: 1.0
   threshold_absolute_lower: -1.0
   threshold_absolute_upper: 1.0
+  gaussian_size: 0.5
+  gaussian_mode: nearest
 grains:
   run: true # Options : true, false
-  gaussian_size: 2.0
-  gaussian_mode: nearest
   absolute_smallest_grain_size: 100
   threshold_method: std_dev # Options : otsu, std_dev, absolute
   otsu_threshold_multiplier: 1.0
@@ -34,7 +34,7 @@ dnatracing:
 plotting:
   run: true # Options : true, false
   save_format: png # Options : see https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
-  image_set: core  # Options : all, core
+  image_set: all  # Options : all, core
   zrange: [0, 3] # low and high height range for core images (can take [null, null])
   colorbar: true  # Options : true, false
   axes: true # Options : true, false (due to off being a bool when parsed)

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -34,7 +34,7 @@ dnatracing:
 plotting:
   run: true # Options : true, false
   save_format: png # Options : see https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
-  image_set: all  # Options : all, core
+  image_set: core  # Options : all, core
   zrange: [0, 3] # low and high height range for core images (can take [null, null])
   colorbar: true  # Options : true, false
   axes: true # Options : true, false (due to off being a bool when parsed)


### PR DESCRIPTION
resolves #296 

This PR simply fixes the issue documented in #296 where `run_topostats` would fail if not given a config file. The problem was merely that in a previous commit, the `default_config.yaml` was not updated alongside `example.yaml`. 
