### PR TITLE
Maxgamill sheffield/#243 si units

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -13,11 +13,11 @@ filter:
   threshold_std_dev: 1.0
   threshold_absolute_lower: -1.0
   threshold_absolute_upper: 1.0
-  gaussian_size: 0.5
+  gaussian_size: 0.5e-9 # extent of blurring in m
   gaussian_mode: nearest
 grains:
   run: true # Options : true, false
-  absolute_smallest_grain_size: 100
+  absolute_smallest_grain_size: 50e-18 # in m^2
   threshold_method: std_dev # Options : otsu, std_dev, absolute
   otsu_threshold_multiplier: 1.0
   threshold_std_dev: 1.0
@@ -27,7 +27,7 @@ grains:
   background: 0.0
 grainstats:
   run: true # Options : true, false
-  cropped_size: 40 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
+  cropped_size: 40e-9 # Length (in m) of square cropped images (can take -1 for grain-sized box)
   save_cropped_grains: true # Options : true, false
 dnatracing:
   run: true # Options : true, false
@@ -35,7 +35,7 @@ plotting:
   run: true # Options : true, false
   save_format: png # Options : see https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
   image_set: all  # Options : all, core
-  zrange: [0, 3] # low and high height range for core images (can take [null, null])
+  zrange: [0, 3e-9] # low and high height range for core images (can take [null, null])
   colorbar: true  # Options : true, false
   axes: true # Options : true, false (due to off being a bool when parsed)
   cmap: nanoscope # Options : nanoscope, afmhot

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -56,7 +56,7 @@ class Filters:
         amplify_level : float
             Factor by which to amplify pixel values within the image.
         gaussian_size: float
-            Size of the gaussian to blur the image in nm.
+            Size of the gaussian to blur the image in m.
         gaussian_mode: str
             Method of gaussian interpolation.
         output_dir: Union[str, Path]
@@ -94,7 +94,7 @@ class Filters:
             "gaussian_filtered": None,
         }
         self.thresholds = None
-        self.pixel_to_nm_scaling = None
+        self.pixel_to_m_scaling = None
         self.medians = {"rows": None, "cols": None}
         LOGGER.info(f"Filename : {self.filename}")
         self.results = {
@@ -136,19 +136,20 @@ class Filters:
         except Exception as exception:
             LOGGER.error(f"[{self.filename}] : {exception}")
 
-    def extract_pixel_to_nm_scaling(self) -> float:
-        """Extract the pixel to nanometer scaling from the image metadata."""
+    def extract_pixel_to_m_scaling(self) -> float:
+        """Extract the pixel to meter scaling from the image metadata."""
         unit_dict = {
-            "nm": 1,
-            "um": 1e3,
+            "nm": 1e-9,
+            "um": 1e-6,
+            "mm": 1e-3,
         }
         px_to_real = self.images["extracted_channel"].pxs()
         # Has potential for non-square images but not yet implimented
-        self.pixel_to_nm_scaling = (
+        self.pixel_to_m_scaling = (
             px_to_real[0][0] * unit_dict[px_to_real[0][1]],
             px_to_real[1][0] * unit_dict[px_to_real[1][1]],
         )[0]
-        LOGGER.info(f"[{self.filename}] : Pixels to nm scaling : {self.pixel_to_nm_scaling}")
+        LOGGER.info(f"[{self.filename}] : Pixels to m scaling : {self.pixel_to_m_scaling}")
 
     def extract_pixels(self) -> None:
         """Flatten the scan to a Numpy Array."""
@@ -331,7 +332,7 @@ class Filters:
         )
         return gaussian(
             image,
-            sigma=(self.gaussian_size / self.pixel_to_nm_scaling),
+            sigma=(self.gaussian_size / self.pixel_to_m_scaling),
             mode=self.gaussian_mode,
             **kwargs,
         )
@@ -354,7 +355,7 @@ class Filters:
         self.make_output_directory()
         self.extract_channel()
         self.extract_pixels()
-        self.extract_pixel_to_nm_scaling()
+        self.extract_pixel_to_m_scaling()
         if self.amplify_level != 1.0:
             self.amplify()
         self.images["initial_align"] = self.align_rows(self.images["pixels"], mask=None)

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -233,7 +233,7 @@ class Filters:
         medians = self.row_col_medians(image_cp, mask)
         row_medians = medians["rows"]
         median_row_height = self._median_row_height(row_medians)
-        LOGGER.info(f"[{self.filename}] : Median Row Height: {median_row_height}")
+        LOGGER.info(f"[{self.filename}] : Median Row Height (m): {median_row_height}")
 
         # Calculate the differences between the row medians and the median row height
         row_median_diffs = self._row_median_diffs(row_medians, median_row_height)
@@ -329,7 +329,7 @@ class Filters:
             
         """
         LOGGER.info(
-            f"[{self.filename}] : Applying Gaussian filter (mode : {self.gaussian_mode}; Gaussian blur (nm) : {self.gaussian_size})."
+            f"[{self.filename}] : Applying Gaussian filter (mode : {self.gaussian_mode}; Gaussian blur (m) : {self.gaussian_size})."
         )
         return gaussian(
             image,

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -153,7 +153,8 @@ class Filters:
 
     def extract_pixels(self) -> None:
         """Flatten the scan to a Numpy Array."""
-        self.images["pixels"] = np.flipud(np.array(self.images["extracted_channel"].pixels))
+        # I have assumed all AFM image pixels are in nm. But maybe this should be in io.py?
+        self.images["pixels"] = np.flipud(np.array(self.images["extracted_channel"].pixels * 1e-9))
         LOGGER.info(f"[{self.filename}] : Pixels extracted")
 
     def amplify(self) -> None:

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -23,12 +23,12 @@ class Filters:
     def __init__(
         self,
         img_path: Union[str, Path],
+        channel: str = "Height",
         threshold_method: str = "otsu",
         otsu_threshold_multiplier: float = 1.7,
         threshold_std_dev: float = None,
         threshold_absolute_lower: float = None,
         threshold_absolute_upper: float = None,
-        channel: str = "Height",
         amplify_level: float = None,
         gaussian_size: float = None,
         gaussian_mode: str = "nearest",
@@ -42,15 +42,27 @@ class Filters:
         img_path: Union[str, Path]
             Path to a valid image to load.
         channel: str
-            Channel to extract from the image.
-        amplify_level : float
-            Factor by which to amplify the image.
+            Channel to extract from the image. Must match that in the AFM file.
         threshold_method: str
             Method for thresholding, default 'otsu'.
-        quiet: bool
-            Whether to silence output.
+        otsu_threshold_multiplier: float
+            Value to used to shift the threshold obtained by otsu for masking.
+        threshold_std_dev: float
+            The number of standard deviations away from the mean pixel value to use as a threshold for masking.
+        threshold_absolute_lower:
+            Absolute value to use as a lower threshold for masking.
+        threshold_absolute_upper: float
+            Absolute value to use as a lower threshold for masking.
+        amplify_level : float
+            Factor by which to amplify pixel values within the image.
+        gaussian_size: float
+            Size of the gaussian to blur the image in nm.
+        gaussian_mode: str
+            Method of gaussian interpolation.
         output_dir: Union[str, Path]
             Directory to save output to, if it does not exist it will be created.
+        quiet: bool
+            Whether to silence output.
 
         Notes
         -----

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -163,10 +163,10 @@ class Grains:
         Returns
         -------
         np.ndarray
-            2D Numpy array of image with objects > absolute_smallest_grain_size removed.
+            2D Numpy array of image with objects < absolute_smallest_grain_size removed.
         """
-        LOGGER.info(f"[{self.filename}] : Removing noise (< {self.absolute_smallest_grain_size})")
-        return remove_small_objects(image, min_size=self.absolute_smallest_grain_size)
+        LOGGER.info(f"[{self.filename}] : Removing noise (< {self.absolute_smallest_grain_size}m^2)")
+        return remove_small_objects(image, min_size=self.absolute_smallest_grain_size / (self.pixel_to_m_scaling ** 2))
 
     def remove_small_objects(self, image: np.array, **kwargs):
         """Remove small objects."""
@@ -178,7 +178,7 @@ class Grains:
                 **kwargs,
             )
             LOGGER.info(
-                f"[{self.filename}] : Removed small objects (< {self.minimum_grain_size * (self.pixel_to_m_scaling**2)}m^2)"
+                f"[{self.filename}] : Removed small objects (< {self.minimum_grain_size * (self.pixel_to_m_scaling ** 2)}m^2)"
             )
             return small_objects_removed > 0.0
         return image
@@ -245,7 +245,7 @@ class Grains:
         try:
             region_props_count = 0
             for direction in self.direction:
-                LOGGER.info(f"[{self.filename}] : Processing {direction} threshold ({self.thresholds[direction]})")
+                LOGGER.info(f"[{self.filename}] : Processing {direction} threshold")
                 self.directions[direction] = defaultdict()
                 self.directions[direction]["mask_grains"] = _get_mask(
                     self.image,

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -30,7 +30,7 @@ class Grains:
         self,
         image: np.ndarray,
         filename: str,
-        pixel_to_nm_scaling: float,
+        pixel_to_m_scaling: float,
         threshold_method: str = None,
         otsu_threshold_multiplier: float = None,
         threshold_std_dev: float = None,
@@ -49,7 +49,7 @@ class Grains:
             2D Numpy array of image
         filename: str
             File being processed
-        pixel_to_nm_scaling: float
+        pixel_to_m_scaling: float
             Sacling of pixels to nanometre.
         threshold_multiplier : Union[int, float]
             Factor by which lower threshold is to be scaled prior to masking.
@@ -70,7 +70,7 @@ class Grains:
         """
         self.image = image
         self.filename = filename
-        self.pixel_to_nm_scaling = pixel_to_nm_scaling
+        self.pixel_to_m_scaling = pixel_to_m_scaling
         self.threshold_method = threshold_method
         self.otsu_threshold_multiplier = otsu_threshold_multiplier
         self.threshold_std_dev = threshold_std_dev
@@ -174,11 +174,11 @@ class Grains:
         if self.minimum_grain_size != -1:
             small_objects_removed = remove_small_objects(
                 image,
-                min_size=(self.minimum_grain_size * self.pixel_to_nm_scaling),
+                min_size=(self.minimum_grain_size),
                 **kwargs,
             )
             LOGGER.info(
-                f"[{self.filename}] : Removed small objects (< {self.minimum_grain_size * self.pixel_to_nm_scaling})"
+                f"[{self.filename}] : Removed small objects (< {self.minimum_grain_size * (self.pixel_to_m_scaling**2)}m^2)"
             )
             return small_objects_removed > 0.0
         return image

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -57,7 +57,7 @@ class GrainStats:
         self,
         data: np.ndarray,
         labelled_data: np.ndarray,
-        pixel_to_nanometre_scaling: float,
+        pixel_to_m_scaling: float,
         direction: str,
         base_output_dir: Union[str, Path],
         image_name: str = None,
@@ -73,8 +73,8 @@ class GrainStats:
             2D Numpy array containing the flattened afm image. Data in this 2D array is floating point.
         labelled_data : np.ndarray
             2D Numpy array containing all the grain masks in the image. Data in this 2D array is boolean.
-        pixel_to_nanometre_scaling : float
-            Floating point value that defines the scaling factor between nanometres and pixels.
+        pixel_to_m_scaling : float
+            Floating point value that defines the scaling factor between metres and pixels.
         direction: str
             Direction for which grains have been detected ("upper" or "lower").
         base_output_dir : Path
@@ -91,7 +91,7 @@ class GrainStats:
 
         self.data = data
         self.labelled_data = labelled_data
-        self.pixel_to_nanometre_scaling = pixel_to_nanometre_scaling
+        self.pixel_to_m_scaling = pixel_to_m_scaling
         self.direction = direction
         self.base_output_dir = Path(base_output_dir)
         self.start_point = None
@@ -190,7 +190,7 @@ class GrainStats:
                 else:
                     # Get cropped image and mask
                     grain_centre = int((minr + maxr) / 2), int((minc + maxc) / 2)
-                    length = int(self.cropped_size / (2 * self.pixel_to_nanometre_scaling))
+                    length = int(self.cropped_size / (2 * self.pixel_to_m_scaling))
                     solo_mask = self.labelled_data.copy()
                     solo_mask[solo_mask != index + 1] = 0
                     solo_mask[solo_mask == index + 1] = 1
@@ -237,28 +237,28 @@ class GrainStats:
             # from pixel units to nanometres.
             # Removed formatting, better to keep accurate until the end, including in CSV, then shorten display
             stats = {
-                "centre_x": centre_x * self.pixel_to_nanometre_scaling,
-                "centre_y": centre_y * self.pixel_to_nanometre_scaling,
-                "radius_min": radius_stats["min"] * self.pixel_to_nanometre_scaling,
-                "radius_max": radius_stats["max"] * self.pixel_to_nanometre_scaling,
-                "radius_mean": radius_stats["mean"] * self.pixel_to_nanometre_scaling,
-                "radius_median": radius_stats["median"] * self.pixel_to_nanometre_scaling,
+                "centre_x": centre_x * self.pixel_to_m_scaling,
+                "centre_y": centre_y * self.pixel_to_m_scaling,
+                "radius_min": radius_stats["min"] * self.pixel_to_m_scaling,
+                "radius_max": radius_stats["max"] * self.pixel_to_m_scaling,
+                "radius_mean": radius_stats["mean"] * self.pixel_to_m_scaling,
+                "radius_median": radius_stats["median"] * self.pixel_to_m_scaling,
                 "height_min": np.nanmin(masked_grain_image),
                 "height_max": np.nanmax(masked_grain_image),
                 "height_median": np.nanmedian(masked_grain_image),
                 "height_mean": np.nanmean(masked_grain_image),
-                "volume": np.nansum(masked_grain_image) * self.pixel_to_nanometre_scaling**2,
-                "area": region.area * self.pixel_to_nanometre_scaling**2,
-                "area_cartesian_bbox": region.area_bbox * self.pixel_to_nanometre_scaling**2,
-                "smallest_bounding_width": smallest_bounding_width * self.pixel_to_nanometre_scaling,
-                "smallest_bounding_length": smallest_bounding_length * self.pixel_to_nanometre_scaling,
+                "volume": np.nansum(masked_grain_image) * self.pixel_to_m_scaling**2,
+                "area": region.area * self.pixel_to_m_scaling**2,
+                "area_cartesian_bbox": region.area_bbox * self.pixel_to_m_scaling**2,
+                "smallest_bounding_width": smallest_bounding_width * self.pixel_to_m_scaling,
+                "smallest_bounding_length": smallest_bounding_length * self.pixel_to_m_scaling,
                 "smallest_bounding_area": smallest_bounding_length
                 * smallest_bounding_width
-                * self.pixel_to_nanometre_scaling**2,
+                * self.pixel_to_m_scaling**2,
                 "aspect_ratio": aspect_ratio,
                 "threshold": self.direction,
-                "max_feret": max_feret * self.pixel_to_nanometre_scaling,
-                "min_feret": min_feret * self.pixel_to_nanometre_scaling,
+                "max_feret": max_feret * self.pixel_to_m_scaling,
+                "min_feret": min_feret * self.pixel_to_m_scaling,
             }
 
             stats_array.append(stats)

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -91,7 +91,10 @@ class Images:
         self.interpolation=interpolation
         self.cmap=cmap
         self.region_properties=region_properties
-        self.zrange = zrange/1e-9 if zrange[0] is not None and zrange[1] is not None # Linked to hard 1e-9 in Filters
+        if zrange[0] is None and zrange[1] is None:
+            self.zrange=zrange
+        else:
+            self.zrange = [i/1e-9 for i in zrange] # Linked to hard 1e-9 in Filters
         self.colorbar=colorbar
         self.axes=axes
         self.save=save
@@ -139,7 +142,6 @@ class Images:
         extent2 = shape[0] * self.pixel_to_m_scaling_factor
         _, unit, unit_scale = units(max(extent1, extent2))
         if isinstance(self.data, np.ndarray):
-            LOGGER.info(f"Zrange = {self.zrange}")
             im = ax.imshow(
                 self.data / 1e-9, # Linked to hard 1e-9 in Filters
                 extent=(0, extent1/unit_scale, 0, extent2/unit_scale),
@@ -167,7 +169,7 @@ class Images:
             if self.colorbar and self.type == "non-binary":
                 divider = make_axes_locatable(ax)
                 cax = divider.append_axes("right", size="5%", pad=0.05)
-                plt.colorbar(im, cax=cax, label=f"Height (Nanometres)")
+                plt.colorbar(im, cax=cax, label=f"Height (nm)") # also linked to hard-coded filters value
             if self.region_properties:
                 fig, ax = add_bounding_boxes_to_plot(fig, ax, shape, self.region_properties, self.pixel_to_m_scaling_factor)
             if not self.axes and not self.colorbar:

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -22,7 +22,7 @@ class Images:
         data: np.array,
         output_dir: Union[str, Path],
         filename: str,
-        pixel_to_nm_scaling_factor: float = 1.,
+        pixel_to_m_scaling_factor: float = 1.5e-9,
         data2: np.array = None,
         title: str = None,
         type: str = "non-binary",
@@ -48,8 +48,8 @@ class Images:
             Output directory to save the file to.
         filename : Union[str, Path]
             Filename to save image as.
-        pixel_to_nm_scaling_factor : float
-            The scaling factor showing the real length of 1 pixel, in nm.
+        pixel_to_m_scaling_factor : float
+            The scaling factor showing the real length of 1 pixel, in m.
         data2 : np.ndarray
             Optional mask array to overlay onto an image.
         title : str
@@ -81,7 +81,7 @@ class Images:
         self.data=data
         self.output_dir=Path(output_dir)
         self.filename=filename
-        self.pixel_to_nm_scaling_factor=pixel_to_nm_scaling_factor
+        self.pixel_to_m_scaling_factor=pixel_to_m_scaling_factor
         self.data2=data2
         self.title=title
         self.type=type
@@ -137,7 +137,7 @@ class Images:
         if isinstance(self.data, np.ndarray):
             im = ax.imshow(
                 self.data,
-                extent=(0, shape[1] * self.pixel_to_nm_scaling_factor, 0, shape[0] * self.pixel_to_nm_scaling_factor),
+                extent=(0, shape[1] * self.pixel_to_m_scaling_factor, 0, shape[0] * self.pixel_to_m_scaling_factor),
                 interpolation=self.interpolation,
                 cmap=Colormap(self.cmap).get_cmap(),
                 vmin=self.zrange[0],
@@ -148,7 +148,7 @@ class Images:
                 ax.imshow(
                     mask,
                     "jet_r",
-                    extent=(0, shape[1] * self.pixel_to_nm_scaling_factor, 0, shape[0] * self.pixel_to_nm_scaling_factor),
+                    extent=(0, shape[1] * self.pixel_to_m_scaling_factor, 0, shape[0] * self.pixel_to_m_scaling_factor),
                     interpolation=self.interpolation,
                     alpha=0.7,
                 )
@@ -156,15 +156,15 @@ class Images:
                 plt.legend(handles=patch, loc="upper right", bbox_to_anchor=(1, 1.06))
 
             plt.title(self.title)
-            plt.xlabel("Nanometres")
-            plt.ylabel("Nanometres")
+            plt.xlabel("Metres")
+            plt.ylabel("Metres")
             plt.axis(self.axes)
             if self.colorbar and self.type == "non-binary":
                 divider = make_axes_locatable(ax)
                 cax = divider.append_axes("right", size="5%", pad=0.05)
                 plt.colorbar(im, cax=cax, label="Height (Nanometres)")
             if self.region_properties:
-                fig, ax = add_bounding_boxes_to_plot(fig, ax, shape, self.region_properties, self.pixel_to_nm_scaling_factor)
+                fig, ax = add_bounding_boxes_to_plot(fig, ax, shape, self.region_properties, self.pixel_to_m_scaling_factor)
             if not self.axes and not self.colorbar:
                         plt.title("")
                         fig.frameon=False
@@ -181,7 +181,7 @@ class Images:
             plt.ylabel("Nanometres")
             self.data.show(
                 ax=ax,
-                extent=(0, shape[1] * self.pixel_to_nm_scaling_factor, 0, shape[0] * self.pixel_to_nm_scaling_factor),
+                extent=(0, shape[1] * self.pixel_to_m_scaling_factor, 0, shape[0] * self.pixel_to_m_scaling_factor),
                 interpolation=self.interpolation,
                 cmap=Colormap(self.cmap).get_cmap(),
             )
@@ -200,7 +200,7 @@ class Images:
         )
         plt.close()
 
-def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to_nm_scaling_factor: float) -> None:
+def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to_m_scaling_factor: float) -> None:
     """Add the bounding boxes to a plot.
 
     Parameters
@@ -213,8 +213,8 @@ def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to
         Tuple of the image-to-be-plot's shape.
     region_properties:
         Region properties to add bounding boxes from.
-    pixel_to_nm_scaling_factor: float
-        The scaling factor from px to nm.
+    pixel_to_m_scaling_factor: float
+        The scaling factor from px to m.
     
     Returns
     -------
@@ -224,10 +224,10 @@ def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to
         Matplotlib.pyplot axes object.
     """
     for region in region_properties:
-        min_y, min_x, max_y, max_x = [x * pixel_to_nm_scaling_factor for x in region.bbox]
+        min_y, min_x, max_y, max_x = [x * pixel_to_m_scaling_factor for x in region.bbox]
         # Correct y-axis
-        min_y = (shape[0] * pixel_to_nm_scaling_factor) - min_y
-        max_y = (shape[0] * pixel_to_nm_scaling_factor) - max_y
+        min_y = (shape[0] * pixel_to_m_scaling_factor) - min_y
+        max_y = (shape[0] * pixel_to_m_scaling_factor) - max_y
         rectangle = Rectangle((min_x, min_y), max_x - min_x, max_y - min_y, fill=False, edgecolor="white", linewidth=2)
         ax.add_patch(rectangle)
     return fig, ax

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -188,9 +188,9 @@ def process_scan(
         if plotting_config["run"]:
             plotting_config.pop("run")
             LOGGER.info(f"[{filtered_image.filename}] : Plotting Filtering Images")
-            # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
+            # Update PLOT_DICT with pixel_to_m_scaling (can't add _output_dir since it changes)
             plot_opts = {
-                "pixel_to_nm_scaling_factor": filtered_image.pixel_to_nm_scaling,
+                "pixel_to_m_scaling_factor": filtered_image.pixel_to_m_scaling,
             }
             for image, options in plotting_config["plot_dict"].items():
                 plotting_config["plot_dict"][image] = {**options, **plot_opts}
@@ -222,7 +222,7 @@ def process_scan(
             grains = Grains(
                 image=filtered_image.images["gaussian_filtered"],
                 filename=filtered_image.filename,
-                pixel_to_nm_scaling=filtered_image.pixel_to_nm_scaling,
+                pixel_to_nm_scaling=filtered_image.pixel_to_m_scaling,
                 base_output_dir=grain_out_path,
                 **grains_config,
             )
@@ -286,7 +286,7 @@ def process_scan(
                     grainstats[direction] = GrainStats(
                         data=filtered_image.images["gaussian_filtered"],
                         labelled_data=grains.directions[direction]["labelled_regions_02"],
-                        pixel_to_nanometre_scaling=filtered_image.pixel_to_nm_scaling,
+                        pixel_to_nanometre_scaling=filtered_image.pixel_to_m_scaling,
                         direction=direction,
                         base_output_dir=_output_dir / "grains",
                         image_name=filtered_image.filename,
@@ -312,7 +312,7 @@ def process_scan(
                             full_image_data=filtered_image.images["gaussian_filtered"].T,
                             grains=grains.directions[direction]["labelled_regions_02"],
                             filename=filtered_image.filename,
-                            pixel_size=filtered_image.pixel_to_nm_scaling,
+                            pixel_size=filtered_image.pixel_to_m_scaling,
                             **dnatracing_config,
                         )
                         dna_traces[direction].trace_dna()

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -222,7 +222,7 @@ def process_scan(
             grains = Grains(
                 image=filtered_image.images["gaussian_filtered"],
                 filename=filtered_image.filename,
-                pixel_to_nm_scaling=filtered_image.pixel_to_m_scaling,
+                pixel_to_m_scaling=filtered_image.pixel_to_m_scaling,
                 base_output_dir=grain_out_path,
                 **grains_config,
             )

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -286,7 +286,7 @@ def process_scan(
                     grainstats[direction] = GrainStats(
                         data=filtered_image.images["gaussian_filtered"],
                         labelled_data=grains.directions[direction]["labelled_regions_02"],
-                        pixel_to_nanometre_scaling=filtered_image.pixel_to_m_scaling,
+                        pixel_to_m_scaling=filtered_image.pixel_to_m_scaling,
                         direction=direction,
                         base_output_dir=_output_dir / "grains",
                         image_name=filtered_image.filename,

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -791,7 +791,7 @@ class dnaTrace(object):
                     except NameError:
                         hypotenuse_array = [math.hypot((x1 - x2), (y1 - y2))]
 
-                self.contour_lengths[dna_num] = np.sum(np.array(hypotenuse_array)) * self.pixel_size * 1e9
+                self.contour_lengths[dna_num] = np.sum(np.array(hypotenuse_array)) * self.pixel_size
                 del hypotenuse_array
 
             else:
@@ -807,7 +807,7 @@ class dnaTrace(object):
                         except NameError:
                             hypotenuse_array = [math.hypot((x1 - x2), (y1 - y2))]
                     except IndexError:  # IndexError happens at last point in array
-                        self.contour_lengths[dna_num] = np.sum(np.array(hypotenuse_array)) * self.pixel_size * 1e9
+                        self.contour_lengths[dna_num] = np.sum(np.array(hypotenuse_array)) * self.pixel_size
                         del hypotenuse_array
                         break
 
@@ -854,7 +854,7 @@ class dnaTrace(object):
                 y1 = self.splined_traces[dna_num][0, 1]
                 x2 = self.splined_traces[dna_num][-1, 0]
                 y2 = self.splined_traces[dna_num][-1, 1]
-                self.end_to_end_distance[dna_num] = math.hypot((x1 - x2), (y1 - y2)) * self.pixel_size * 1e9
+                self.end_to_end_distance[dna_num] = math.hypot((x1 - x2), (y1 - y2)) * self.pixel_size
         # self.end_to_end_distance = {
         #     dna_num: math.hypot((trace[0, 0] - trace[-1, 0]), (trace[0, 1] - trace[-1, 1]))
         #     if self.mol_is_circular[dna_num]

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -40,7 +40,7 @@ class dnaTrace(object):
         grains,
         filename,
         pixel_size,
-        convert_nm_to_m: bool = True,
+        convert_nm_to_m: bool = False,
     ):
         self.full_image_data = full_image_data * 1e-9 if convert_nm_to_m else full_image_data
         # self.grains_orig = [x for row in grains for x in row]

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -284,3 +284,41 @@ def folder_grainstats(output_dir: Union[str, Path], base_dir: Union[str, Path], 
             LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/Processed/folder_grainstats.csv")
     except TypeError:
         LOGGER.info(f"Unable to generate folderwise statistics as 'all_statistics.csv' is empty")
+
+def units(number):
+    """Takes a number and finds the most appropriate units for that number.
+
+    Parameters
+    ----------
+    number: float
+        A number
+
+    Returns
+    -------
+    number/unit_val: float
+        The number scaled to the non-SI unit.
+    unit: str
+        The string representing the unit value.
+    unit_val: float
+        The SI value of the unit.
+    """
+    # breaks when number >4 digets due to compression at pm
+    unit_dict = {
+        "m": 1,
+        "mm": 1e-3,
+        "um": 1e-6,
+        "nm": 1e-9,
+        "pm": 1e-12,
+        }
+    sig_figs = []
+    for value in unit_dict.values():
+        val = number/value
+        sig_figs.append(len(str(val).split('.')[0]))
+    arr = np.asarray(sig_figs)
+    arr[arr > 3] = 0
+    if arr.sum() == 0:
+        unit = 'm'
+    else:
+        unit = list(unit_dict.keys())[np.argmax(arr)]
+    unit_value = unit_dict[unit]
+    return number/unit_value, unit, unit_value        

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -150,10 +150,10 @@ def _get_mask(image: np.ndarray, threshold: float, threshold_direction: str, img
         Numpy array of image with objects coloured.
     """
     if threshold_direction == "upper":
-        LOGGER.info(f"[{img_name}] : Masking (upper) Threshold: {threshold}")
+        LOGGER.info(f"[{img_name}] : Masking Upper Threshold (m): {threshold}")
         return image > threshold
     if threshold_direction == "lower":
-        LOGGER.info(f"[{img_name}] : Masking (lower) Threshold: {threshold}")
+        LOGGER.info(f"[{img_name}] : Masking Lower Threshold (m): {threshold}")
         return image < threshold
     # LOGGER.fatal(f"[{img_name}] : Threshold direction invalid: {threshold_direction}")
 


### PR DESCRIPTION
This SI unit PR will be put on hold. 

Currently all statistics are in SI, and the extracted `px_to_m` value is in SI and propagated through to everywhere it needs to be and all looks correct. Additionally, plots use a function which extracts the non-SI units from very small numbers to input into the graphs so they now say "um" on the axis if the image should be in um instead of nm.

The reason for the hold is that when it comes to extracting a unit from the header for the pixel values (width and lengths are fine), I cannot find a function for this in pySPM. As a result, I've hardcoded this into "nm" i.e. 1e-9 but this is not known if this is consistent across different data that may have an image zrange > 1um and as a result it would break.

First I will move io functions to the `topostats_io.py` file to standardise their output and try to implement other file types to see if this is consistent across different file types too.

Note: the tests are also not complete for this PR