### PR TITLE
Validate input configuration

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -23,14 +23,14 @@ grains:
   threshold_std_dev: 1.0
   threshold_absolute_lower: 1.0
   threshold_absolute_upper: 1.0
-  absolute_area_threshold: 
+  absolute_area_threshold:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
   background: 0.0
 grainstats:
   run: true # Options : true, false
-  cropped_size: 40 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
+  cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
   save_cropped_grains: true # Options : true, false
 dnatracing:
   run: true # Options : true, false

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
   pySPM
   pyyaml
   ruamel.yaml
+  schema
   scikit-image==0.19.2
   scipy
   seaborn

--- a/tests/resources/process_scan_config.yaml
+++ b/tests/resources/process_scan_config.yaml
@@ -23,14 +23,14 @@ grains:
   threshold_std_dev: 1.0
   threshold_absolute_lower: 1.0
   threshold_absolute_upper: 1.0
-  absolute_area_threshold: 
+  absolute_area_threshold:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
   background: 0.0
 grainstats:
   run: true # Options : true, false
-  cropped_size: 40 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
+  cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
   save_cropped_grains: true # Options : true, false
 dnatracing:
   run: true # Options : true, false

--- a/tests/resources/sample_config.yaml
+++ b/tests/resources/sample_config.yaml
@@ -23,14 +23,14 @@ grains:
   threshold_std_dev: 1.0
   threshold_absolute_lower: 1.0
   threshold_absolute_upper: 1.0
-  absolute_area_threshold: 
+  absolute_area_threshold:
     upper: [400,600] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
   background: 0.0
 grainstats:
   run: true # Options : true, false
-  cropped_size: 40 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
+  cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
   save_cropped_grains: true # Options : true, false
 dnatracing:
   run: true # Options : true, false

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -23,14 +23,14 @@ grains:
   threshold_std_dev: 1.0
   threshold_absolute_lower: -1.0
   threshold_absolute_upper: 1.0
-  absolute_area_threshold: 
+  absolute_area_threshold:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
   background: 0.0
 grainstats:
   run: true # Options : true, false
-  cropped_size: 40 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
+  cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)
   save_cropped_grains: true # Options : true, false
 dnatracing:
   run: true # Options : true, false

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -362,10 +362,12 @@ def main():
         config = yaml.safe_load(default_config.read())
     config = update_config(config, args)
     config["output_dir"] = convert_path(config["output_dir"])
-    config["output_dir"].mkdir(parents=True, exist_ok=True)
 
     # Validate configuration
     validate_config(config)
+
+    config["output_dir"].mkdir(parents=True, exist_ok=True)
+
 
     # Load plotting_dictionary
     plotting_dictionary = pkg_resources.open_text(__package__, "plotting_dictionary.yaml")

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -1,7 +1,7 @@
 """Validation of configuration."""
 import logging
 from pathlib import Path
-from schema import And, Or, Schema, SchemaError
+from schema import Or, Schema, SchemaError
 
 from topostats.logs.logs import LOGGER_NAME
 
@@ -20,19 +20,23 @@ def validate_config(config: dict):
         {
             "base_dir": Path,
             "output_dir": Path,
-            "warnings": Or("ignore"),
+            "warnings": Or("ignore", error="Invalid value in config for 'warnings', valid values are 'ignore'"),
             "cores": lambda n: 1 <= n <= 16,
-            "quiet": Or(True, False),
-            "file_ext": Or(".spm", ".jpk", error="Invalid value for file_ext, valid values are '.spm' or '.jpk'"),
+            "quiet": Or(True, False, error="Invalid value in config for 'quiet', valid values are 'True' or 'False'"),
+            "file_ext": Or(
+                ".spm", ".jpk", error="Invalid value in config for 'file_ext', valid values are '.spm' or '.jpk'"
+            ),
             "filter": {
-                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "run": Or(
+                    True, False, error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'"
+                ),
                 "channel": Or("Height"),
                 "amplify_level": float,
                 "threshold_method": Or(
                     "absolute",
                     "otsu",
                     "std_dev",
-                    error="Invalid value for filter.threshold_method, valid values are 'absolute', 'otsu' or 'std_dev'",
+                    error="Invalid value in config for 'filter.threshold_method', valid values are 'absolute', 'otsu' or 'std_dev'",  # pylint: disable=line-too-long
                 ),
                 "otsu_threshold_multiplier": float,
                 "threshold_std_dev": lambda n: 0 < n <= 6,
@@ -40,17 +44,19 @@ def validate_config(config: dict):
                 "threshold_absolute_upper": float,
                 "gaussian_size": float,
                 "gaussian_mode": Or(
-                    "nearest", error="Invalid value for filter.gaussian_mode, valid values are 'nearest'"
+                    "nearest", error="Invalid value in config for 'filter.gaussian_mode', valid values are 'nearest'"
                 ),
             },
             "grains": {
-                "run": Or(True, False, error="Invalid value for grains.run, valid values are True or False"),
+                "run": Or(
+                    True, False, error="Invalid value in config for grains.run, valid values are 'True' or 'False'"
+                ),
                 "absolute_smallest_grain_size": int,
                 "threshold_method": Or(
                     "absolute",
                     "otsu",
                     "std_dev",
-                    error="Invalid value for filter.threshold_method, valid values are 'absolute', 'otsu' or 'std_dev'",
+                    error="Invalid value in config for 'grains.threshold_method', valid values are 'absolute', 'otsu' or 'std_dev'",  # pylint: disable=line-too-long
                 ),
                 "otsu_threshold_multiplier": float,
                 "threshold_std_dev": lambda n: 0 < n <= 6,
@@ -61,14 +67,14 @@ def validate_config(config: dict):
                         Or(
                             int,
                             None,
-                            error="Invalid value for grains.absolute_area_threshold.upper, valid values are int or null",
+                            error="Invalid value in config for 'grains.absolute_area_threshold.upper', valid values are int or null",  # pylint: disable=line-too-long
                         )
                     ],
                     "lower": [
                         Or(
                             int,
                             None,
-                            error="Invalid value for grains.absolute_area_threshold.upper, valid values are int or null",
+                            error="Invalid value in config for 'grains.absolute_area_threshold.lower', valid values are int or null",  # pylint: disable=line-too-long
                         )
                     ],
                 },
@@ -81,28 +87,46 @@ def validate_config(config: dict):
                 "background": float,
             },
             "grainstats": {
-                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "run": Or(
+                    True,
+                    False,
+                    error="Invalid value in config for 'grainstats.run', valid values are 'True' or 'False'",
+                ),
                 "cropped_size": float,
                 "save_cropped_grains": Or(
-                    True, False, error="Invalid value for filter.run, valid values are True or False"
+                    True,
+                    False,
+                    error="Invalid value in config for 'grainstats.save_cropped_grains, valid values are 'True' or 'False'",  # pylint: disable=line-too-long
                 ),
             },
             "dnatracing": {
-                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False")
+                "run": Or(
+                    True, False, error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'"
+                )
             },
             "plotting": {
-                "run": Or(True, False),
+                "run": Or(
+                    True, False, error="Invalid value in config for 'plotting.run', valid values are 'True' or 'False'"
+                ),
                 "save_format": str,
                 "image_set": Or(
-                    "all", "core", error="Invalid value for plotting.image_set, valid values are 'all' or 'core'"
+                    "all",
+                    "core",
+                    error="Invalid value in config for 'plotting.image_set', valid values are 'all' or 'core'",
                 ),
                 "zrange": list,
-                "colorbar": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
-                "axes": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "colorbar": Or(
+                    True,
+                    False,
+                    error="Invalid value in config for 'plotting.colorbar', valid values are 'True' or 'False'",
+                ),
+                "axes": Or(
+                    True, False, error="Invalid value in config plotting.for 'axes', valid values are 'True' or 'False'"
+                ),
                 "cmap": Or(
                     "afmhot",
                     "nanoscope",
-                    error="Invalid value for plotting.cmap, valid values are 'afmhot' or 'nanoscope",
+                    error="Invalid value in config for 'plotting.cmap', valid values are 'afmhot' or 'nanoscope",
                 ),
             },
         }
@@ -112,7 +136,6 @@ def validate_config(config: dict):
         config_schema.validate(config)
         LOGGER.info("Configuration is valid.")
     except SchemaError as se:
-        print(f"schemaerror : {se}")
-        for error in se.errors:
-            #            if error:
-            LOGGER.error(error)
+        raise SchemaError(
+            "There is an error in your configuration. Please refer to the first error message above for details"
+        ) from se

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -1,0 +1,108 @@
+"""Validation of configuration."""
+import logging
+from pathlib import Path
+from schema import And, Or, Schema, SchemaError
+
+from topostats.logs.logs import LOGGER_NAME
+
+LOGGER = logging.getLogger(LOGGER_NAME)
+
+
+def validate_config(config: dict):
+    """Validate configuration.
+
+    Parameters
+    ----------
+    config: dict
+        Config dictionary imported by read_yaml() and parsed through clean_config().
+    """
+    config_schema = Schema(
+        {
+            "base_dir": Path,
+            "output_dir": Path,
+            "warnings": Or("ignore"),
+            "cores": lambda n: 1 <= n <= 16,
+            "quiet": Or(True, False),
+            "file_ext": Or(".spm", ".jpk", error="Invalid value for file_ext, valid values are '.spm' or '.jpk'"),
+            "filter": {
+                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "channel": Or("Height"),
+                "amplify_level": float,
+                "threshold_method": Or(
+                    "absolute", "otsu", "std_dev", error="Invalid value for filter.threshold_method"
+                ),
+                "otsu_threshold_multiplier": float,
+                "threshold_std_dev": float,
+                "threshold_absolute_lower": float,
+                "threshold_absolute_upper": float,
+                "gaussian_size": float,
+                "gaussian_mode": str,
+            },
+            "grains": {
+                "run": Or(True, False, error="Invalid value for grains.run, valid values are True or False"),
+                "absolute_smallest_grain_size": int,
+                "threshold_method": str,
+                "otsu_threshold_multiplier": float,
+                "threshold_std_dev": float,
+                "threshold_absolute_lower": float,
+                "threshold_absolute_upper": float,
+                "absolute_area_threshold": {
+                    "upper": [
+                        Or(
+                            int,
+                            None,
+                            error="Invalid value for grains.absolute_area_threshold.upper, valid values are int or null",
+                        )
+                    ],
+                    "lower": [
+                        Or(
+                            int,
+                            None,
+                            error="Invalid value for grains.absolute_area_threshold.upper, valid values are int or null",
+                        )
+                    ],
+                },
+                "direction": Or(
+                    "both",
+                    "lower",
+                    "upper",
+                    error="Invalid direction for grains.direction valid values are 'both', 'lower' or 'upper",
+                ),
+                "background": float,
+            },
+            "grainstats": {
+                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "cropped_size": float,
+                "save_cropped_grains": Or(
+                    True, False, error="Invalid value for filter.run, valid values are True or False"
+                ),
+            },
+            "dnatracing": {
+                "run": Or(True, False, error="Invalid value for filter.run, valid values are True or False")
+            },
+            "plotting": {
+                "run": Or(True, False),
+                "save_format": str,
+                "image_set": Or(
+                    "all", "core", error="Invalid value for plotting.image_set, valid values are 'all' or 'core'"
+                ),
+                "zrange": list,
+                "colorbar": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "axes": Or(True, False, error="Invalid value for filter.run, valid values are True or False"),
+                "cmap": Or(
+                    "afmhot",
+                    "nanoscope",
+                    error="Invalid value for plotting.cmap, valid values are 'afmhot' or 'nanoscope",
+                ),
+            },
+        }
+    )
+
+    try:
+        config_schema.validate(config)
+        LOGGER.info("Configuration is valid.")
+    except SchemaError as se:
+        print(f"schemaerror : {se}")
+        for error in se.errors:
+            #            if error:
+            LOGGER.error(error)

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -1,5 +1,6 @@
 """Validation of configuration."""
 import logging
+import os
 from pathlib import Path
 from schema import Or, Schema, SchemaError
 
@@ -21,7 +22,7 @@ def validate_config(config: dict):
             "base_dir": Path,
             "output_dir": Path,
             "warnings": Or("ignore", error="Invalid value in config for 'warnings', valid values are 'ignore'"),
-            "cores": lambda n: 1 <= n <= 16,
+            "cores": lambda n: 1 <= n <= os.cpu_count(),
             "quiet": Or(True, False, error="Invalid value in config for 'quiet', valid values are 'True' or 'False'"),
             "file_ext": Or(
                 ".spm", ".jpk", error="Invalid value in config for 'file_ext', valid values are '.spm' or '.jpk'"

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -29,21 +29,31 @@ def validate_config(config: dict):
                 "channel": Or("Height"),
                 "amplify_level": float,
                 "threshold_method": Or(
-                    "absolute", "otsu", "std_dev", error="Invalid value for filter.threshold_method"
+                    "absolute",
+                    "otsu",
+                    "std_dev",
+                    error="Invalid value for filter.threshold_method, valid values are 'absolute', 'otsu' or 'std_dev'",
                 ),
                 "otsu_threshold_multiplier": float,
-                "threshold_std_dev": float,
+                "threshold_std_dev": lambda n: 0 < n <= 6,
                 "threshold_absolute_lower": float,
                 "threshold_absolute_upper": float,
                 "gaussian_size": float,
-                "gaussian_mode": str,
+                "gaussian_mode": Or(
+                    "nearest", error="Invalid value for filter.gaussian_mode, valid values are 'nearest'"
+                ),
             },
             "grains": {
                 "run": Or(True, False, error="Invalid value for grains.run, valid values are True or False"),
                 "absolute_smallest_grain_size": int,
-                "threshold_method": str,
+                "threshold_method": Or(
+                    "absolute",
+                    "otsu",
+                    "std_dev",
+                    error="Invalid value for filter.threshold_method, valid values are 'absolute', 'otsu' or 'std_dev'",
+                ),
                 "otsu_threshold_multiplier": float,
-                "threshold_std_dev": float,
+                "threshold_std_dev": lambda n: 0 < n <= 6,
                 "threshold_absolute_lower": float,
                 "threshold_absolute_upper": float,
                 "absolute_area_threshold": {


### PR DESCRIPTION
Resolves #299

Introduces the `topostats.validation` module with a single function `validate_config()` which uses [schema package](https://github.com/keleshev/schema) to validate the YAML configuration input.

This isn't something I've ever done before so I followed the examples [here](https://www.andrewvillazon.com/validate-yaml-python-schema/).

I've no idea what valid values/ranges should be for many of the fields and so have left crude validation of the type in place and created #302 to serve as a place for recording discussion of what valid ranges should be before updating.

For now I haven't introduced tests for `topostats/validation.py` as its seems somewhat circular to test schema validation and whilst it is perfectly feasible to test whether certain exceptions are raised I'm unsure its worth doing so. We could explicitly exclude this file from test coverage reporting.  Any thoughts on this would be appreciated, particularly from @bobturneruk .