### PR TITLE
Maxgamill sheffield/#288 remove background

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -27,6 +27,7 @@ grains:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
+  background: 0.0
 grainstats:
   run: true # Options : true, false
   cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -27,7 +27,6 @@ grains:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
-  background: 0.0
 grainstats:
   run: true # Options : true, false
   cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)

--- a/tests/resources/process_scan_config.yaml
+++ b/tests/resources/process_scan_config.yaml
@@ -26,7 +26,6 @@ grains:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
-  background: 0.0
 grainstats:
   run: true # Options : true, false
   cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)

--- a/tests/resources/sample_config.yaml
+++ b/tests/resources/sample_config.yaml
@@ -26,7 +26,6 @@ grains:
     upper: [400,600] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
-  background: 0.0
 grainstats:
   run: true # Options : true, false
   cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -26,7 +26,6 @@ grains:
     upper: [500,800] # above surface [Low, High] in nm^2 (also takes null)
     lower: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   direction: upper # Options: upper, lower, both (defines whether to look for grains above or below thresholds or both)
-  background: 0.0
 grainstats:
   run: true # Options : true, false
   cropped_size: 40.0 # Length (in nm) of square cropped images (can take -1 for grain-sized box)

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -42,7 +42,6 @@ class Grains:
             },
         direction: str = None,
         absolute_smallest_grain_size: float = None,
-        background: float = 0.0,
         base_output_dir: Union[str, Path] = ".",
     ):
         """Initialise the class.
@@ -85,7 +84,6 @@ class Grains:
         self.absolute_area_threshold = absolute_area_threshold
         # Only detect grains for the desired direction
         self.direction = [direction] if direction != "both" else ["upper", "lower"]
-        self.background = background
         self.base_output_dir = Path(base_output_dir)
         self.absolute_smallest_grain_size = absolute_smallest_grain_size
         self.thresholds = None
@@ -137,7 +135,7 @@ class Grains:
             Numpy array of image with objects coloured.
         """
         LOGGER.info(f"[{self.filename}] : Labelling Regions")
-        return label(image, background=self.background)
+        return label(image, background=0)
 
     def calc_minimum_grain_size(self, image: np.ndarray) -> float:
         """Calculate the minimum grain size.

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -84,7 +84,6 @@ def validate_config(config: dict):
                     "upper",
                     error="Invalid direction for grains.direction valid values are 'both', 'lower' or 'upper",
                 ),
-                "background": float,
             },
             "grainstats": {
                 "run": Or(


### PR DESCRIPTION
This work removes `background` from the config files. 

I have not updated the example.yaml file as this is in the process of being removed.

This is because it is unnecessary because its used in the [skimage.morphology.labels](https://scikit-image.org/docs/stable/api/skimage.morphology.html#skimage.morphology.label) function where the input image to this is either the `mask` (in which the background is 0 by design) or a labelled image from `area_threshold` (which has a 0 background) or `remove_small_objects` (which also has 0 background by default)