### PR TITLE
Remove libasd from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,9 +30,6 @@ install_requires =
 packages = find:
 
 [options.extras_require]
-libasd =
-  libasd
-
 tests =
   pytest
   pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ zip_safe = False
 
 install_requires =
   afmformats
-  libasd
   matplotlib
   numpy
   pandas
@@ -31,6 +30,9 @@ install_requires =
 packages = find:
 
 [options.extras_require]
+libasd =
+  libasd
+
 tests =
   pytest
   pytest-cov


### PR DESCRIPTION
Currently `libasd` is _not_ imported in `topostats/io.py` as work is on-going to support reading such files.

For now, so that `dev` branch will install on non-x86_64 architectures this dependency has been removed. See #304 for possible solutions.