### PR TITLE
Housekeeping and tidying up

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,7 +242,6 @@ def random_grains(grains_config: dict, random_filters: Filters, tmp_path) -> Gra
         image=random_filters.images["zero_averaged_background"],
         filename="random",
         pixel_to_nm_scaling=0.5,
-        base_output_dir=Path(tmp_path),
         **grains_config,
     )
     grains.find_grains()
@@ -396,7 +395,6 @@ def minicircle_grains(minicircle_grain_gaussian_filter: Filters, grains_config: 
         image=minicircle_grain_gaussian_filter.images["gaussian_filtered"],
         filename=minicircle_grain_gaussian_filter.filename,
         pixel_to_nm_scaling=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
-        base_output_dir=Path(tmp_path),
         **grains_config,
     )
     return grains

--- a/tests/test_filters_minicircle.py
+++ b/tests/test_filters_minicircle.py
@@ -23,7 +23,7 @@ def test_align_rows_unmasked(
     fig, _ = Images(
         data=minicircle_initial_align.images["initial_align"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_initial_align.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_initial_align.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -41,7 +41,7 @@ def test_remove_x_y_tilt_unmasked(
     fig, _ = Images(
         data=minicircle_initial_tilt_removal.images["initial_tilt_removal"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_initial_tilt_removal.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_initial_tilt_removal.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -68,7 +68,7 @@ def test_get_threshold_abs(minicircle_threshold_abs: np.array) -> None:
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_get_mask(minicircle_mask: Filters, plotting_config: dict, plot_dict: dict, tmp_path) -> None:
     """Test derivation of mask."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_mask.images["mask"], np.ndarray)
     assert minicircle_mask.images["mask"].shape == (1024, 1024)
     assert minicircle_mask.images["mask"].sum() == 82159
@@ -76,7 +76,7 @@ def test_get_mask(minicircle_mask: Filters, plotting_config: dict, plot_dict: di
     fig, _ = Images(
         data=minicircle_mask.images["mask"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_mask.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_mask.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -92,7 +92,7 @@ def test_align_rows_masked(minicircle_masked_align: Filters, plotting_config: di
     fig, _ = Images(
         data=minicircle_masked_align.images["masked_align"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_masked_align.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_masked_align.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -110,7 +110,7 @@ def test_remove_x_y_tilt_masked(
     fig, _ = Images(
         data=minicircle_masked_tilt_removal.images["masked_tilt_removal"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_masked_tilt_removal.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_masked_tilt_removal.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -128,7 +128,7 @@ def test_average_background(
     fig, _ = Images(
         data=minicircle_zero_average_background.images["zero_averaged_background"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_zero_average_background.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_zero_average_background.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -146,7 +146,7 @@ def test_gaussian_filter(
     fig, _ = Images(
         data=minicircle_grain_gaussian_filter.images["gaussian_filtered"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig

--- a/tests/test_grains_minicircle.py
+++ b/tests/test_grains_minicircle.py
@@ -32,7 +32,7 @@ def test_threshold_abs(minicircle_grain_threshold_abs: Grains) -> None:
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_mask_minicircle(minicircle_grain_mask: Grains, plotting_config: dict, plot_dict: dict, tmp_path) -> None:
     """Test creation of boolean array for clearing borders."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_grain_mask.directions["upper"]["mask_grains"], np.ndarray)
     assert minicircle_grain_mask.directions["upper"]["mask_grains"].shape == (1024, 1024)
     assert minicircle_grain_mask.directions["upper"]["mask_grains"].sum() == 55648
@@ -40,7 +40,7 @@ def test_mask_minicircle(minicircle_grain_mask: Grains, plotting_config: dict, p
     fig, _ = Images(
         data=minicircle_grain_mask.directions["upper"]["mask_grains"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_mask.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_mask.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -49,7 +49,7 @@ def test_mask_minicircle(minicircle_grain_mask: Grains, plotting_config: dict, p
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_clear_border(minicircle_grain_clear_border: Grains, plotting_config: dict, plot_dict: dict, tmp_path) -> None:
     """Test creation of boolean array for clearing borders."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_grain_clear_border.directions["upper"]["tidied_border"], np.ndarray)
     assert minicircle_grain_clear_border.directions["upper"]["tidied_border"].shape == (1024, 1024)
     assert minicircle_grain_clear_border.directions["upper"]["tidied_border"].sum() == 51457
@@ -57,7 +57,7 @@ def test_clear_border(minicircle_grain_clear_border: Grains, plotting_config: di
     fig, _ = Images(
         data=minicircle_grain_clear_border.directions["upper"]["tidied_border"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_clear_border.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_clear_border.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -66,7 +66,7 @@ def test_clear_border(minicircle_grain_clear_border: Grains, plotting_config: di
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_remove_noise(minicircle_grain_remove_noise: Grains, plotting_config: dict, plot_dict: dict, tmp_path) -> None:
     """Test creation of boolean array for clearing borders."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_grain_remove_noise.directions["upper"]["removed_noise"], np.ndarray)
     assert minicircle_grain_remove_noise.directions["upper"]["removed_noise"].shape == (1024, 1024)
     assert minicircle_grain_remove_noise.directions["upper"]["removed_noise"].sum() == 46484
@@ -74,7 +74,7 @@ def test_remove_noise(minicircle_grain_remove_noise: Grains, plotting_config: di
     fig, _ = Images(
         data=minicircle_grain_remove_noise.directions["upper"]["removed_noise"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_remove_noise.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_remove_noise.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -91,7 +91,7 @@ def test_remove_small_objects(
     minicircle_small_objects_removed: Grains, plotting_config: dict, plot_dict: dict, tmp_path
 ) -> None:
     """Test removal of small objects."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_small_objects_removed.directions["upper"]["removed_small_objects"], np.ndarray)
     assert minicircle_small_objects_removed.directions["upper"]["removed_small_objects"].shape == (1024, 1024)
     assert minicircle_small_objects_removed.directions["upper"]["removed_small_objects"].sum() == 42378
@@ -99,7 +99,7 @@ def test_remove_small_objects(
     fig, _ = Images(
         data=minicircle_small_objects_removed.directions["upper"]["removed_small_objects"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_small_objects_removed.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_small_objects_removed.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -110,7 +110,7 @@ def test_area_thresholding(
     minicircle_area_thresholding: Grains, plotting_config: dict, plot_dict: dict, tmp_path
 ) -> None:
     """Test removal of small objects via absolute area thresholding."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_area_thresholding.directions["upper"]["removed_small_objects"], np.ndarray)
     assert minicircle_area_thresholding.directions["upper"]["removed_small_objects"].shape == (1024, 1024)
     assert minicircle_area_thresholding.directions["upper"]["removed_small_objects"].sum() == 442441
@@ -118,7 +118,7 @@ def test_area_thresholding(
     fig, _ = Images(
         data=minicircle_area_thresholding.directions["upper"]["removed_small_objects"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_area_thresholding.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_area_thresholding.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -129,7 +129,7 @@ def test_label_regions(
     minicircle_grain_labelled_post_removal: Grains, plotting_config: dict, plot_dict: dict, tmp_path
 ) -> None:
     """Test removal of small objects."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"], np.ndarray)
     assert minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"].shape == (1024, 1024)
     assert minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"].sum() == 484819
@@ -137,7 +137,7 @@ def test_label_regions(
     fig, _ = Images(
         data=minicircle_grain_labelled_post_removal.directions["upper"]["labelled_regions_02"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_labelled_post_removal.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_labelled_post_removal.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig
@@ -154,7 +154,7 @@ def test_region_properties(minicircle_grain_region_properties_post_removal: np.a
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_colour_regions(minicircle_grain_coloured: Grains, plotting_config: dict, plot_dict: dict, tmp_path) -> None:
     """Test removal of small objects."""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     assert isinstance(minicircle_grain_coloured.directions["upper"]["coloured_regions"], np.ndarray)
     assert minicircle_grain_coloured.directions["upper"]["coloured_regions"].shape == (1024, 1024, 3)
     assert minicircle_grain_coloured.directions["upper"]["coloured_regions"].sum() == 61714.27500000001
@@ -162,7 +162,7 @@ def test_colour_regions(minicircle_grain_coloured: Grains, plotting_config: dict
     fig, _ = Images(
         data=minicircle_grain_coloured.directions["upper"]["coloured_regions"],
         output_dir=tmp_path,
-        pixel_to_nm_scaling_factor=minicircle_grain_coloured.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_coloured.pixel_to_nm_scaling,
         **plotting_config,
     ).plot_and_save()
     return fig

--- a/tests/test_grainstats_minicircle.py
+++ b/tests/test_grainstats_minicircle.py
@@ -69,8 +69,8 @@ def test_cropped_image(minicircle_grainstats: GrainStats, tmp_path: Path):
         data=cropped_grain_image,
         output_dir=tmp_path,
         filename="cropped_grain_7.png",
-        pixel_to_nm_scaling_factor=minicircle_grainstats.pixel_to_nanometre_scaling,
-        type="non-binary",
+        pixel_to_nm_scaling=minicircle_grainstats.pixel_to_nanometre_scaling,
+        image_type="non-binary",
         image_set="all",
         core_set=True,
     ).plot_and_save()

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -56,7 +56,7 @@ def test_plot_and_save_no_colorbar(load_scan_data: LoadScan, tmp_path: Path) -> 
         data=load_scan_data.image,
         output_dir=tmp_path,
         filename="01-raw_heightmap",
-        pixel_to_nm_scaling_factor=load_scan_data.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=load_scan_data.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=False,
         axes=True,
@@ -72,7 +72,7 @@ def test_plot_and_save_colorbar(load_scan_data: LoadScan, tmp_path: Path) -> Non
         data=load_scan_data.image,
         output_dir=tmp_path,
         filename="01-raw_heightmap",
-        pixel_to_nm_scaling_factor=load_scan_data.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=load_scan_data.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=True,
         axes=True,
@@ -119,7 +119,7 @@ def test_plot_and_save_colorbar_afmhot(load_scan_data: LoadScan, tmp_path: Path,
         data=load_scan_data.image,
         output_dir=tmp_path,
         filename="01-raw_heightmap",
-        pixel_to_nm_scaling_factor=load_scan_data.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=load_scan_data.pixel_to_nm_scaling,
         title="Raw Height",
         colorbar=True,
         axes=True,
@@ -137,12 +137,12 @@ def test_plot_and_save_bounding_box(
     tmp_path: Path,
 ) -> None:
     """Test plotting bounding boxes"""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     fig, _ = Images(
         data=minicircle_grain_coloured.directions["upper"]["coloured_regions"],
         output_dir=tmp_path,
         filename="15-coloured_regions",
-        pixel_to_nm_scaling_factor=minicircle_grain_coloured.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_coloured.pixel_to_nm_scaling,
         title="Coloured Regions",
         **plotting_config,
         region_properties=minicircle_grain_region_properties_post_removal,
@@ -159,7 +159,7 @@ def test_plot_and_save_zrange(minicircle_grain_gaussian_filter: Grains, plotting
         data=minicircle_grain_gaussian_filter.images["gaussian_filtered"],
         output_dir=tmp_path,
         filename="08_5-z_threshold",
-        pixel_to_nm_scaling_factor=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
         title="Raw Height",
         **plotting_config,
     ).plot_and_save()
@@ -174,12 +174,12 @@ def test_plot_and_save_non_square_bounding_box(
     tmp_path: Path,
 ) -> None:
     """Test plotting bounding boxes"""
-    plotting_config["type"] = "binary"
+    plotting_config["image_type"] = "binary"
     fig, _ = Images(
         data=minicircle_grain_coloured.image[:, 0:512],
         output_dir=tmp_path,
         filename="15-coloured_regions.png",
-        pixel_to_nm_scaling_factor=minicircle_grain_coloured.pixel_to_nm_scaling,
+        pixel_to_nm_scaling=minicircle_grain_coloured.pixel_to_nm_scaling,
         title="Coloured Regions",
         **plotting_config,
         region_properties=minicircle_grain_region_properties_post_removal,

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -8,7 +8,6 @@ loading:
   channel: Height
 filter:
   run: true # Options : true, false
-  channel: Height
   threshold_method: otsu # Options : otsu, std_dev, absolute
   otsu_threshold_multiplier: 1.0
   threshold_std_dev: 1.0

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -29,7 +29,6 @@ class Filters:
         threshold_std_dev: float = None,
         threshold_absolute_lower: float = None,
         threshold_absolute_upper: float = None,
-        channel: str = "Height",
         gaussian_size: float = None,
         gaussian_mode: str = "nearest",
         quiet: bool = False,
@@ -278,7 +277,6 @@ class Filters:
         filter = Filter(image=load_scan.image,
         ...             pixel_to_nm_scaling=load_scan.pixel_to_nm_scaling,
         ...             filename=load_scan.filename,
-        ...             channel='Height',
         ...             threshold_method='otsu')
         filter.filter_image()
 

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -42,7 +42,6 @@ class Grains:
         },
         direction: str = None,
         absolute_smallest_grain_size: float = None,
-        base_output_dir: Union[str, Path] = ".",
     ):
         """Initialise the class.
 
@@ -68,10 +67,6 @@ class Grains:
             Dictionary of upper and lower grain's area thresholds
         direction: str
             Direction for which grains are to be detected, valid values are upper, lower and both.
-        background : float
-            The value to average the background around.
-        output_dir : Union[str, Path]
-            Output directory.
         """
         self.image = image
         self.filename = filename
@@ -84,7 +79,6 @@ class Grains:
         self.absolute_area_threshold = absolute_area_threshold
         # Only detect grains for the desired direction
         self.direction = [direction] if direction != "both" else ["upper", "lower"]
-        self.base_output_dir = Path(base_output_dir)
         self.absolute_smallest_grain_size = absolute_smallest_grain_size
         self.thresholds = None
         self.images = {
@@ -100,7 +94,6 @@ class Grains:
         self.region_properties = defaultdict()
         self.bounding_boxes = defaultdict()
         self.grainstats = None
-        Path.mkdir(self.base_output_dir, parents=True, exist_ok=True)
 
     def tidy_border(self, image: np.array, **kwargs) -> np.array:
         """Remove grains touching the border.

--- a/topostats/plotting_dictionary.yaml
+++ b/topostats/plotting_dictionary.yaml
@@ -8,112 +8,112 @@
 # |--------------|---------|------------------------------------------------------------------------------|
 # | filename     | String  | Filename (minus extension) to which image is saved.                          |
 # | title        | String  | Title for the plot                                                           |
-# | type         | String  | Whether the plot includes the height (non-binary) or the outline (binary)    |
+# | image_type         | String  | Whether the plot includes the height (non-binary) or the outline (binary)    |
 # | core_set     | Boolean | Whether a plot is considered part of the core set of images that are plotted.|
 extracted_channel:
   filename: "00-raw_heightmap"
   title: "Raw Height"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 pixels:
   filename: "01-pixels"
   title: "Pixels"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 initial_align:
   filename: "02-initial_align_unmasked"
   title: "Initial Alignment (Unmasked)"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 initial_tilt_removal:
   filename: "03-initial_tilt_removal_unmasked"
   title: "Initial Tilt Removal (Unmasked)"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 mask:
   filename: "04-binary_mask.png"
   title: "Binary Mask"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 masked_align:
   filename: "05-secondary_align_masked"
   title: "Secondary Alignment (Masked)"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 masked_tilt_removal:
   filename: "06-secondary_tilt_removal_masked"
   title: "Secondary Tilt Removal (Masked)"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 zero_averaged_background:
   filename: "07-zero_average_background"
   title: "Zero Average Background"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 gaussian_filtered:
   filename: "08-gaussian_filtered"
   title: "Gaussian Filtered"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 z_threshed:
   title: "Height Thresholded"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: true
 mask_grains:
   filename: "09-mask_grains"
   title: "Mask for Grains"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 labelled_regions_01:
   filename: "10-labelled_regions"
   title: "Labelled Regions"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 tidied_border:
   filename: "11-tidy_borders"
   title: "Tidied Borders"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 removed_noise:
   filename: "12-noise_removed"
   title: "Noise removed"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 removed_small_objects:
   filename: "13-small_objects_removed"
   title: "Small Objects Removed"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 mask_overlay:
   title: "Height Thresholded with Mask"
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: true
 labelled_regions_02:
   filename: "14-labelled_regions"
   title: "Labelled Regions"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 coloured_regions:
   filename: "15-coloured_regions"
   title: "Coloured Regions"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 bounding_boxes:
   filename: "16-bounding_boxes"
   title: "Bounding Boxes"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 coloured_boxes:
   filename: "17-labelled_image_bboxes"
   title: "Labelled Image with Bounding Boxes"
-  type: "binary"
+  image_type: "binary"
   core_set: false
 grain_image:
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: true
 grain_mask:
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false
 grain_mask_image:
-  type: "non-binary"
+  image_type: "non-binary"
   core_set: false

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -22,10 +22,10 @@ class Images:
         data: np.array,
         output_dir: Union[str, Path],
         filename: str,
-        pixel_to_nm_scaling_factor: float = 1.0,
+        pixel_to_nm_scaling: float = 1.0,
         data2: np.array = None,
         title: str = None,
-        type: str = "non-binary",
+        image_type: str = "non-binary",
         image_set: str = "core",
         core_set: bool = False,
         interpolation: str = "nearest",
@@ -48,13 +48,13 @@ class Images:
             Output directory to save the file to.
         filename : Union[str, Path]
             Filename to save image as.
-        pixel_to_nm_scaling_factor : float
+        pixel_to_nm_scaling : float
             The scaling factor showing the real length of 1 pixel, in nm.
         data2 : np.ndarray
             Optional mask array to overlay onto an image.
         title : str
             Title for plot.
-        type : str
+        image_type : str
             The image data type - binary or non-binary.
         image_set : str
             The set of images to process - core or all.
@@ -81,10 +81,10 @@ class Images:
         self.data = data
         self.output_dir = Path(output_dir)
         self.filename = filename
-        self.pixel_to_nm_scaling_factor = pixel_to_nm_scaling_factor
+        self.pixel_to_nm_scaling = pixel_to_nm_scaling
         self.data2 = data2
         self.title = title
-        self.type = type
+        self.image_type = image_type
         self.image_set = image_set
         self.core_set = core_set
         self.interpolation = interpolation
@@ -139,7 +139,7 @@ class Images:
         if isinstance(self.data, np.ndarray):
             im = ax.imshow(
                 self.data,
-                extent=(0, shape[1] * self.pixel_to_nm_scaling_factor, 0, shape[0] * self.pixel_to_nm_scaling_factor),
+                extent=(0, shape[1] * self.pixel_to_nm_scaling, 0, shape[0] * self.pixel_to_nm_scaling),
                 interpolation=self.interpolation,
                 cmap=Colormap(self.cmap).get_cmap(),
                 vmin=self.zrange[0],
@@ -153,9 +153,9 @@ class Images:
                     "jet_r",
                     extent=(
                         0,
-                        shape[1] * self.pixel_to_nm_scaling_factor,
+                        shape[1] * self.pixel_to_nm_scaling,
                         0,
-                        shape[0] * self.pixel_to_nm_scaling_factor,
+                        shape[0] * self.pixel_to_nm_scaling,
                     ),
                     interpolation=self.interpolation,
                     alpha=0.7,
@@ -167,14 +167,12 @@ class Images:
             plt.xlabel("Nanometres")
             plt.ylabel("Nanometres")
             plt.axis(self.axes)
-            if self.colorbar and self.type == "non-binary":
+            if self.colorbar and self.image_type == "non-binary":
                 divider = make_axes_locatable(ax)
                 cax = divider.append_axes("right", size="5%", pad=0.05)
                 plt.colorbar(im, cax=cax, label="Height (Nanometres)")
             if self.region_properties:
-                fig, ax = add_bounding_boxes_to_plot(
-                    fig, ax, shape, self.region_properties, self.pixel_to_nm_scaling_factor
-                )
+                fig, ax = add_bounding_boxes_to_plot(fig, ax, shape, self.region_properties, self.pixel_to_nm_scaling)
             if not self.axes and not self.colorbar:
                 plt.title("")
                 fig.frameon = False
@@ -191,7 +189,7 @@ class Images:
             plt.ylabel("Nanometres")
             self.data.show(
                 ax=ax,
-                extent=(0, shape[1] * self.pixel_to_nm_scaling_factor, 0, shape[0] * self.pixel_to_nm_scaling_factor),
+                extent=(0, shape[1] * self.pixel_to_nm_scaling, 0, shape[0] * self.pixel_to_nm_scaling),
                 interpolation=self.interpolation,
                 cmap=Colormap(self.cmap).get_cmap(),
             )
@@ -211,7 +209,7 @@ class Images:
         plt.close()
 
 
-def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to_nm_scaling_factor: float) -> None:
+def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to_nm_scaling: float) -> None:
     """Add the bounding boxes to a plot.
 
     Parameters
@@ -224,7 +222,7 @@ def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to
         Tuple of the image-to-be-plot's shape.
     region_properties:
         Region properties to add bounding boxes from.
-    pixel_to_nm_scaling_factor: float
+    pixel_to_nm_scaling: float
         The scaling factor from px to nm.
 
     Returns
@@ -235,10 +233,10 @@ def add_bounding_boxes_to_plot(fig, ax, shape, region_properties: list, pixel_to
         Matplotlib.pyplot axes object.
     """
     for region in region_properties:
-        min_y, min_x, max_y, max_x = [x * pixel_to_nm_scaling_factor for x in region.bbox]
+        min_y, min_x, max_y, max_x = [x * pixel_to_nm_scaling for x in region.bbox]
         # Correct y-axis
-        min_y = (shape[0] * pixel_to_nm_scaling_factor) - min_y
-        max_y = (shape[0] * pixel_to_nm_scaling_factor) - max_y
+        min_y = (shape[0] * pixel_to_nm_scaling) - min_y
+        max_y = (shape[0] * pixel_to_nm_scaling) - max_y
         rectangle = Rectangle((min_x, min_y), max_x - min_x, max_y - min_y, fill=False, edgecolor="white", linewidth=2)
         ax.add_patch(rectangle)
     return fig, ax

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -229,7 +229,6 @@ def process_scan(
                 image=filtered_image.images["gaussian_filtered"],
                 filename=filename,
                 pixel_to_nm_scaling=pixel_to_nm_scaling,
-                # base_output_dir=grain_out_path,
                 **grains_config,
             )
             grains.find_grains()

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -197,7 +197,7 @@ def process_scan(
             LOGGER.info(f"[{filename}] : Plotting Filtering Images")
             # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
             plot_opts = {
-                "pixel_to_nm_scaling_factor": pixel_to_nm_scaling,
+                "pixel_to_nm_scaling": pixel_to_nm_scaling,
             }
             for image, options in plotting_config["plot_dict"].items():
                 plotting_config["plot_dict"][image] = {**options, **plot_opts}
@@ -229,7 +229,7 @@ def process_scan(
                 image=filtered_image.images["gaussian_filtered"],
                 filename=filename,
                 pixel_to_nm_scaling=pixel_to_nm_scaling,
-                base_output_dir=grain_out_path,
+                # base_output_dir=grain_out_path,
                 **grains_config,
             )
             grains.find_grains()

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -34,7 +34,6 @@ def validate_config(config: dict):
                 "run": Or(
                     True, False, error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'"
                 ),
-                "channel": Or("Height"),
                 "threshold_method": Or(
                     "absolute",
                     "otsu",


### PR DESCRIPTION
* Rename `Image()` class option `type` to `image_type` as `type` is a core Python function.
* Rename `Image()` class option `pixel_to_nm_scaling_factor` to `pixel_to_nm_scaling` to be consistent across classes.
* Remove `channel` as an option to `Filter()` class.
* Remove `background` from `validate_config()`
* Remove `output_dir` from `Grains()` as it was only being used to make a directory and that is now done in `run_topostats.main()` / `process_scan()`.
* Tidied up docstring for `Grains()` class removing no longer used option `background`.

This also involved modifications to the validation schema and various tests.

(Noticed these as I was spending a little time updating the Notebook to work with the current codebase and started making the changes without creating an issue first).