### PR TITLE
Introduce pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0  # Use the ref you want to point at
+    hooks:
+      - id: trailing-whitespace
+        types: [file, text]
+      - id: check-docstring-first
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+        types: [python]
+      - id: requirements-txt-fixer
+      - id: check-byte-order-marker
+      - id: check-yaml
+
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+        types: [python]
+        additional_dependencies: ['click==8.0.4']
+
+  - repo: https://gitlab.com/pycqa/flake8.git
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-print]
+        types: [python]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -82,6 +82,28 @@ and reduces some of the [code smells](https://en.wikipedia.org/wiki/Code_smell) 
 making. A `.pylintrc` is included in the repository. Currently this isn't strictly applied but it is planned for part of
 the CI/CD pipeline and so we would be grateful if you could lint your code before making Pull Requests.
 
+### Pre-commit
+
+[pre-commit](https://pre-commit.com) is a powerful and useful tool that runs hooks on your code prior to making
+commits. For a more detailed exposition see [pre-commit : Protecting your future
+self](https://rse.shef.ac.uk/blog/pre-commit/).
+
+The repository includes `pre-commit` as a development dependency as well as a `.pre-commit-config.yaml`. To use these
+locally install `pre-commit` in your virtual environment and then install the configuration and all the configured hooks
+(**NB** this will download specific virtual environments that `pre-commit` uses when running hooks so the first time
+this is run may take a little while).
+
+
+``` bash
+pip install .[dev]
+pre-commit install --install-hooks
+```
+
+Currently there are hooks to remove trailing whitespace, check YAML configuration files and a few other common checks as
+well as hooks for `black` and `flake8`. If these fail then you will not be able to make a commit until they are
+fixed. The `black` hook will automatically format failed files so you can simply `git add` those and try committing
+straight away. `flake8` does not correct files automatically so the errors will need manually correcting.
+
 ### Typing
 
 Whilst Python is a dynamically typed language (that is the type of an object is determined dynamically) the use of Type

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ docs =
 
 dev =
   black
+  pre-commit
   pylint
   flake8
 


### PR DESCRIPTION
This introduces [pre-commit](https://rse.shef.ac.uk/blog/pre-commit/) with `black` and `flake8` linting to check the code as well as some checks on trailing whitespaces which will be corrected automatically.

Longer term I would like to incorporate the [pre-commit GitHub Action](https://github.com/marketplace/actions/pre-commit) so that PRs will not be accepted if the code does not pass the checks.

Further incorporating `pylint` into the `pre-commit` checks would be very sensible. I've applied `pylint` to much of the code I've worked on but there is the refactoring of `DNATracing` and `Plotting` as well as bits of `Grains`/`GrainStats` which would help those to be undertaken first.