### PR TITLE
Validating plotting configuration

### DIFF
--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -30,7 +30,7 @@ from topostats.utils import (
     create_empty_dataframe,
     folder_grainstats,
 )
-from topostats.validation import validate_config
+from topostats.validation import validate_config, validate_plotting
 
 LOGGER = setup_logger(LOGGER_NAME)
 
@@ -55,6 +55,13 @@ def create_parser() -> arg.ArgumentParser:
         dest="config_file",
         required=False,
         help="Path to a YAML configuration file.",
+    )
+    parser.add_argument(
+        "-p",
+        "--plotting_file",
+        dest="plotting_file",
+        required=False,
+        help="Path to a YAML plotting file.",
     )
     parser.add_argument(
         "-b",
@@ -170,6 +177,7 @@ def process_scan(
         filter_out_path = Path(_output_dir) / image_path.stem / "filters"
         grain_out_path = Path(_output_dir) / image_path.stem / "grains"
         filter_out_path.mkdir(exist_ok=True, parents=True)
+        grain_out_path.mkdir(exist_ok=True, parents=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "upper", parents=True, exist_ok=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "lower", parents=True, exist_ok=True)
 
@@ -341,7 +349,7 @@ def process_scan(
             except Exception:
                 # If no results we need a dummy dataframe to return.
                 LOGGER.info(
-                    f"[{filename}] : Errors occurred attempting to calculate grain statistics and DNA tracing statistics."
+                    f"[{filename}] : Errors occurred whilst calculating grain statistics and DNA tracing statistics."
                 )
                 results = create_empty_dataframe()
 
@@ -367,9 +375,13 @@ def main():
 
     config["output_dir"].mkdir(parents=True, exist_ok=True)
 
-    # Load plotting_dictionary
-    plotting_dictionary = pkg_resources.open_text(__package__, "plotting_dictionary.yaml")
-    config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary.read())
+    # Load plotting_dictionary and validate
+    if args.plotting_file is not None:
+        config["plotting"]["plot_dict"] = read_yaml(args.plotting_file)
+    else:
+        plotting_dictionary = pkg_resources.open_text(__package__, "plotting_dictionary.yaml")
+        config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary.read())
+    validate_plotting(config["plotting"]["plot_dict"])
 
     # FIXME : Make this a function and from topostats.utils import update_plot_dict and write tests
     # Update the config["plotting"]["plot_dict"] with plotting options
@@ -428,7 +440,10 @@ def main():
     results.reset_index()
     results.to_csv(config["output_dir"] / "all_statistics.csv", index=False)
     LOGGER.info(
-        f"All statistics combined for {len(img_files)} images(s) are saved to : {str(config['output_dir'] / 'all_statistics.csv')}"
+        (
+            f"All statistics combined for {len(img_files)} images(s) are "
+            "saved to : {str(config['output_dir'] / 'all_statistics.csv')}"
+        )
     )
     folder_grainstats(config["output_dir"], config["base_dir"], results)
 

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -8,6 +8,8 @@ from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
+# pylint: disable=line-too-long
+
 
 def validate_config(config: dict):
     """Validate configuration.
@@ -25,20 +27,28 @@ def validate_config(config: dict):
             "cores": lambda n: 1 <= n <= os.cpu_count(),
             "quiet": Or(True, False, error="Invalid value in config for 'quiet', valid values are 'True' or 'False'"),
             "file_ext": Or(
-                ".spm", ".jpk", error="Invalid value in config for 'file_ext', valid values are '.spm' or '.jpk'"
+                ".spm",
+                ".jpk",
+                ".ibw",
+                error="Invalid value in config for 'file_ext', valid values are '.spm', '.jpk' or '.ibw'",
             ),
             "loading": {
-                "channel": Or("Height"),
+                "channel": str,
             },
             "filter": {
                 "run": Or(
-                    True, False, error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'"
+                    True,
+                    False,
+                    error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'",
                 ),
                 "threshold_method": Or(
                     "absolute",
                     "otsu",
                     "std_dev",
-                    error="Invalid value in config for 'filter.threshold_method', valid values are 'absolute', 'otsu' or 'std_dev'",  # pylint: disable=line-too-long
+                    error=(
+                        "Invalid value in config for 'filter.threshold_method', valid values "
+                        "are 'absolute', 'otsu' or 'std_dev'"
+                    ),
                 ),
                 "otsu_threshold_multiplier": float,
                 "threshold_std_dev": lambda n: 0 < n <= 6,
@@ -46,7 +56,8 @@ def validate_config(config: dict):
                 "threshold_absolute_upper": float,
                 "gaussian_size": float,
                 "gaussian_mode": Or(
-                    "nearest", error="Invalid value in config for 'filter.gaussian_mode', valid values are 'nearest'"
+                    "nearest",
+                    error="Invalid value in config for 'filter.gaussian_mode', valid values are 'nearest'",
                 ),
             },
             "grains": {
@@ -58,7 +69,10 @@ def validate_config(config: dict):
                     "absolute",
                     "otsu",
                     "std_dev",
-                    error="Invalid value in config for 'grains.threshold_method', valid values are 'absolute', 'otsu' or 'std_dev'",  # pylint: disable=line-too-long
+                    error=(
+                        "Invalid value in config for 'grains.threshold_method', valid values "
+                        "are 'absolute', 'otsu' or 'std_dev'"
+                    ),
                 ),
                 "otsu_threshold_multiplier": float,
                 "threshold_std_dev": lambda n: 0 < n <= 6,
@@ -69,14 +83,20 @@ def validate_config(config: dict):
                         Or(
                             int,
                             None,
-                            error="Invalid value in config for 'grains.absolute_area_threshold.upper', valid values are int or null",  # pylint: disable=line-too-long
+                            error=(
+                                "Invalid value in config for 'grains.absolute_area_threshold.upper', valid values "
+                                "are int or null"
+                            ),
                         )
                     ],
                     "lower": [
                         Or(
                             int,
                             None,
-                            error="Invalid value in config for 'grains.absolute_area_threshold.lower', valid values are int or null",  # pylint: disable=line-too-long
+                            error=(
+                                "Invalid value in config for 'grains.absolute_area_threshold.lower', valid values "
+                                "are int or null"
+                            ),
                         )
                     ],
                 },
@@ -97,23 +117,30 @@ def validate_config(config: dict):
                 "save_cropped_grains": Or(
                     True,
                     False,
-                    error="Invalid value in config for 'grainstats.save_cropped_grains, valid values are 'True' or 'False'",  # pylint: disable=line-too-long
+                    error=(
+                        "Invalid value in config for 'grainstats.save_cropped_grains, valid values "
+                        "are 'True' or 'False'"
+                    ),
                 ),
             },
             "dnatracing": {
                 "run": Or(
-                    True, False, error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'"
+                    True,
+                    False,
+                    error="Invalid value in config for 'filter.run', valid values are 'True' or 'False'",
                 )
             },
             "plotting": {
                 "run": Or(
-                    True, False, error="Invalid value in config for 'plotting.run', valid values are 'True' or 'False'"
+                    True,
+                    False,
+                    error="Invalid value in config for 'plotting.run', valid values are 'True' or 'False'",
                 ),
                 "save_format": str,
                 "image_set": Or(
                     "all",
                     "core",
-                    error="Invalid value in config for 'plotting.image_set', valid values are 'all' or 'core'",
+                    error="Invalid value in config for 'plotting.image_set', valid values " "are 'all' or 'core'",
                 ),
                 "zrange": list,
                 "colorbar": Or(
@@ -122,7 +149,9 @@ def validate_config(config: dict):
                     error="Invalid value in config for 'plotting.colorbar', valid values are 'True' or 'False'",
                 ),
                 "axes": Or(
-                    True, False, error="Invalid value in config plotting.for 'axes', valid values are 'True' or 'False'"
+                    True,
+                    False,
+                    error="Invalid value in config plotting.for 'axes', valid values are 'True' or 'False'",
                 ),
                 "cmap": Or(
                     "afmhot",
@@ -136,7 +165,309 @@ def validate_config(config: dict):
     try:
         config_schema.validate(config)
         LOGGER.info("Configuration is valid.")
-    except SchemaError as se:
+    except SchemaError as schema_error:
         raise SchemaError(
             "There is an error in your configuration. Please refer to the first error message above for details"
-        ) from se
+        ) from schema_error
+
+
+def validate_plotting(config: dict) -> None:
+    """Validate configuration.
+
+    Parameters
+    ----------
+    config: dict
+        Config dictionary imported by read_yaml() and parsed through clean_config().
+    """
+    config_schema = Schema(
+        {
+            "extracted_channel": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'extracted_channel.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "pixels": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error="Invalid value in config 'pixels.image_type', valid values are 'binary' or 'non-binary'",
+                ),
+                "core_set": bool,
+            },
+            "initial_align": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'initial_align.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "initial_tilt_removal": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'initial_tilt_removal.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "mask": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error="Invalid value in config 'mask.image_type', valid values are 'binary' or 'non-binary'",
+                ),
+                "core_set": bool,
+            },
+            "masked_align": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'masked_align.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "masked_tilt_removal": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'masked_tilt_removal.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "zero_averaged_background": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'zero_averaged_bacground.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "gaussian_filtered": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'gaussian_filtered.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "z_threshed": {
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'z_threshold.image_type', valid values " "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": True,
+            },
+            "mask_grains": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'mask_grains.image_type', valid values " "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "labelled_regions_01": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'labelled_regions_01.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "tidied_border": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'tidied_border.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "removed_noise": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'removed_noise.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "removed_small_objects": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'removed_small_objects.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "mask_overlay": {
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'mask_overlay.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": True,
+            },
+            "labelled_regions_02": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'labelled_regions_02.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "coloured_regions": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'coloured_regions.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "bounding_boxes": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'bounding_boxes.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "coloured_boxes": {
+                "filename": str,
+                "title": str,
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'coloured_boxes.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "grain_image": {
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'grain_image.image_type', valid values " "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": True,
+            },
+            "grain_mask": {
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'grain_mask.image_type', valid values " "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+            "grain_mask_image": {
+                "image_type": Or(
+                    "binary",
+                    "non-binary",
+                    error=(
+                        "Invalid value in config 'grain_mask_image.image_type', valid values "
+                        "are 'binary' or 'non-binary'"
+                    ),
+                ),
+                "core_set": bool,
+            },
+        }
+    )
+    try:
+        config_schema.validate(config)
+        LOGGER.info("Plotting configuration is valid.")
+    except SchemaError as schema_error:
+        raise SchemaError(
+            "There is an error in your configuration. Please refer to the first error message above for details"
+        ) from schema_error


### PR DESCRIPTION
Closes #323 

Adds `io.validate_plotting()` function and incorporates it into `run_topostats.py` so that the plotting dictionary/YAML configuration is validated. I also took the opportunity to add a command line argument for users to provide their own plotting configuration YAML file.

Also noticed that whilst I had removed `output_dir` from `Grains()` in #325 as it was no longer used and should have been in `run_topostats.py` that on running through `flake8` courtesy of `pre-commit` it threw up the following error...

```
topostats/run_topostats.py:178:9: F841 local variable 'grain_out_path' is assigned to but never used
```

And so I've added a line to ensure that the `grain_out_path` is actually created (I should have had these checks in place much earlier, hope others are using them and finding them useful).

For some reason the `topostats/default_config.yaml` also had `channel` under `filters` which I thought I'd removed previously in #325 but despite `git checkout dev && git pull && git checkout -b ns-rse/323-validating-plotting` it reappeared. This meant it failed the validation. Hopefully it won't creep back in again!