### PR TITLE
Use pathlib methods to resolve directory paths in get_out_path()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,7 +37,7 @@ def test_get_out_path() -> None:
     output_dir = Path("output/here")
     out_path = get_out_path(image_path, base_dir, output_dir)
     assert isinstance(out_path, Path)
-    assert out_path == Path("output/here/path/test.spm")
+    assert out_path == Path("output/here/path/")
 
 
 def test_update_config(caplog) -> None:

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -168,7 +168,7 @@ def process_scan(
         grain_out_path = _output_dir
     else:
         filter_out_path = Path(_output_dir) / image_path.stem / "filters"
-        grain_out_path = Path(_output_dir).parent / image_path.stem / "grains"
+        grain_out_path = Path(_output_dir) / image_path.stem / "grains"
         filter_out_path.mkdir(exist_ok=True, parents=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "upper", parents=True, exist_ok=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "lower", parents=True, exist_ok=True)

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -160,7 +160,7 @@ def process_scan(
     Results are written to CSV and images produced in configuration options request them.
     """
     LOGGER.info(f"Processing : {image_path}")
-    _output_dir = get_out_path(image_path, base_dir, output_dir).parent / "Processed"
+    _output_dir = get_out_path(image_path, base_dir, output_dir) / "Processed"
     _output_dir.mkdir(parents=True, exist_ok=True)
 
     if plotting_config["image_set"] == "core":
@@ -168,7 +168,7 @@ def process_scan(
         grain_out_path = _output_dir
     else:
         filter_out_path = Path(_output_dir) / image_path.stem / "filters"
-        grain_out_path = Path(_output_dir) / image_path.stem / "grains"
+        grain_out_path = Path(_output_dir).parent / image_path.stem / "grains"
         filter_out_path.mkdir(exist_ok=True, parents=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "upper", parents=True, exist_ok=True)
         Path.mkdir(_output_dir / image_path.stem / "grains" / "lower", parents=True, exist_ok=True)
@@ -239,7 +239,6 @@ def process_scan(
             results = create_empty_dataframe()
         if grains.region_properties is None:
             results = create_empty_dataframe()
-
         # Optionally plot grain finding stage
         if plotting_config["run"] and grains.region_properties is not None:
             plotting_config.pop("run")
@@ -423,7 +422,6 @@ def main():
             for img, result in pool.imap_unordered(processing_function, img_files):
                 results[str(img)] = result
                 pbar.update()
-
     results = pd.concat(results.values())
     results.reset_index()
     results.to_csv(config["output_dir"] / "all_statistics.csv", index=False)

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -79,7 +79,7 @@ def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> Li
 def get_out_path(
     image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None
 ) -> Path:
-    """Replaces the base directory part of the image path with the output directory.
+    """Adds the image path relative to the base directory to the output directory.
 
     Parameters
     ----------
@@ -95,9 +95,19 @@ def get_out_path(
     Path
         The output path that mirrors the input path structure.
     """
-    pathparts = list(image_path.parts)
-    inparts = list(base_dir.parts)
-    return Path(output_dir / Path(*pathparts[len(inparts) :]))
+    try:
+        # Remove the filename if there is a suffix (not always the case as get_out_path is called from folder_grainstats())
+        if image_path.suffix:
+            return output_dir / image_path.parent.relative_to(base_dir)
+        else:
+            return output_dir / image_path.relative_to(base_dir)
+    # it output_dir is NOT within base_dir the relative_to() method raises a ValueError in which case we just want to
+    # append the image_path to the output_dir
+    except ValueError:
+        return output_dir / image_path.parent
+    except TypeError:
+        LOGGER.error("A string form of a Path has been passed to 'get_out_path()'")
+        raise
 
 
 def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
@@ -280,7 +290,7 @@ def folder_grainstats(output_dir: Union[str, Path], base_dir: Union[str, Path], 
     try:
         for _dir in dirs:
             out_path = get_out_path(Path(_dir), base_dir, output_dir)
-            all_stats_df[all_stats_df["Basename"]==_dir].to_csv(out_path / "Processed" / "folder_grainstats.csv")
+            all_stats_df[all_stats_df["Basename"] == _dir].to_csv(out_path / "Processed" / "folder_grainstats.csv")
             LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/Processed/folder_grainstats.csv")
     except TypeError:
-        LOGGER.info(f"Unable to generate folderwise statistics as 'all_statistics.csv' is empty")
+        LOGGER.info(f"Unable to generate folderwise statistics as 'all_stats_df' is empty")

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -96,12 +96,12 @@ def get_out_path(
         The output path that mirrors the input path structure.
     """
     try:
-        # Remove the filename if there is a suffix (not always the case as get_out_path is called from folder_grainstats())
+        # Remove the filename if there is a suffix, not always the case as get_out_path is called from folder_grainstats()
         if image_path.suffix:
             return output_dir / image_path.parent.relative_to(base_dir)
         else:
             return output_dir / image_path.relative_to(base_dir)
-    # it output_dir is NOT within base_dir the relative_to() method raises a ValueError in which case we just want to
+    # If output_dir is NOT within base_dir the relative_to() method raises a ValueError in which case we just want to
     # append the image_path to the output_dir
     except ValueError:
         return output_dir / image_path.parent


### PR DESCRIPTION
Closes #337 

Handles taking the relative path of each image found within `base_dir` and creates the directory (minus any filename) under the `output_dir`.

The key is using the `.relative_to` method, but careful attention is required in case the `output_dir` is _not_ within the `base_dir` and is somewhere completely different.