### PR TITLE
Added contingency for spm px_2_nm

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -139,6 +139,9 @@ class LoadScan:
             px_to_real[0][0] * unit_dict[px_to_real[0][1]],
             px_to_real[1][0] * unit_dict[px_to_real[1][1]],
         )[0]
+        if px_to_real[0][0] == 0 and px_to_real[1][0] == 0:
+            pixel_to_nm_scaling = 1
+            LOGGER.warning(f"[{self.filename}] : Pixel size not found in metadata, defaulting to 1nm")
         LOGGER.info(f"[{self.filename}] : Pixel to nm scaling : {pixel_to_nm_scaling}")
         return pixel_to_nm_scaling
 


### PR DESCRIPTION
I realised that when working with some files/data, the `pySPM.Bruker().pxs` gave a value of [[0.0, "um"],[0.0, "um"]].

This was because the metadata was lost/not included and thus the value for the px_2_nm scaling was 0, causing issues throughout TopoStats.

Where gwyddion defaults to a pixel size of 1m, I have implemented a quick fix which similarly defaults the pixel size to 1nm if this field is 0.