### PR TITLE
354 | Update flake8 repo for pre-commit; pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,20 +13,19 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         types: [python]
         additional_dependencies: ['click==8.0.4']
         args: ["--extend-exclude", "topostats/plotting.py", "topostats", "tests"]
 
-  - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8.git
+    rev: 5.0.4
     hooks:
       - id: flake8
-        args: ["--exclude=topostats/_version.py"]
+        args: ["--exclude=topostats/_version.py", "topostats", "tests"]
         additional_dependencies: [flake8-print]
-        args: ["topostats", "tests"]
         types: [python]
   # - repo: local
   #   hooks:


### PR DESCRIPTION
Closes #354

Updating the `repo:` target for `flake8` in the `.pre-commit-config.yaml`. At the same time I've updated all other `rev:` of the enabled repositories/hooks.