### PR TITLE
363 | Updating workflows: work with main; update actions

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -4,7 +4,7 @@ name: Sphinx docs to gh-pages
 on:
   push:
     branches:
-      - dev
+      - main
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: 3.9
       - name: Installing the Documentation requirements
@@ -26,9 +26,9 @@ jobs:
       - name: Running Sphinx to gh-pages Action
         uses: ns-rse/action-sphinx-docs-to-gh-pages@main
         with:
-          # When testing set this branch to your branch, when working switch to master or dev. It WILL fail if not
+          # When testing set this branch to your branch, when working switch to main. It WILL fail if not
           # defined as it defaults to 'main'.
-          branch: dev
+          branch: main
           dir_docs: docs
           sphinxapiexclude: '../*setup* ../*tests* ../*.ipynb ../demo.py ../make_baseline.py ../jupyter_notebook_config.py ../demo_ftrs.py'
           sphinxapiopts: '--separate -o . ../'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Tests (pytest)
 on:
   pull_request:
     branches:
-      - dev
+      - main
 
 jobs:
   build:
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.5.0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -30,4 +30,4 @@ jobs:
         run: |
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2.5.0
       - name: Set up Python


### PR DESCRIPTION
Closes #363 
Closes #345 

Updating workflows to run against `main` branch rather than `dev` now the branches have been renamed and the default branch switched to `main`.

Also updating the revisions for actions that are used, they were quite dated and resulted in a number of warnings.

Unfortunately we can't yet add Python 3.11.* to the `python-version` matrix for tests (this caused errors during package installation, see [previous PR](https://github.com/AFM-SPM/TopoStats/pull/346#issuecomment-1292192571). These have been fixed  (see [merged PR](https://github.com/h5py/h5py/pull/2165)) but reading the thread a new version release is still pending.