### PR TITLE
385 | Excluding *.ipynb files from pre-commit linting.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
       - id: black
         types: [python]
         additional_dependencies: ['click==8.0.4']
-        args: ["--extend-exclude", "topostats/plotting.py", "topostats", "tests"]
+        args: ["--extend-exclude", "topostats/plotting.py", "topostats", "tests", "*.ipynb"]
 
   - repo: https://github.com/pycqa/flake8.git
     rev: 5.0.4
     hooks:
       - id: flake8
-        args: ["--extend-exclude=topostats/_version.py", "topostats", "tests"]
+        args: ["--extend-exclude=topostats/_version.py", "topostats", "tests", "*.ipynb"]
         additional_dependencies: [flake8-print]
         types: [python]
   # - repo: local


### PR DESCRIPTION
Closes #385