### PR TITLE
Enabling pylint in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
         args: ["--extend-exclude=topostats/_version.py", "topostats", "tests", "*.ipynb"]
         additional_dependencies: [flake8-print]
         types: [python]
-  # - repo: local
-  #   hooks:
-  #     - id: pylint
-  #       name: Pylint
-  #       entry: python -m pylint.__main__
-  #       language: system
-  #       files: \.py$
+  - repo: local
+    hooks:
+      - id: pylint
+        name: Pylint
+        entry: python -m pylint.__main__
+        language: system
+        files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
   - repo: local
     hooks:
       - id: pylint
+        args: ["--rcfile=.pylintrc", "--ignore-patterns=*_version.py", "topostats", "tests"]
         name: Pylint
         entry: python -m pylint.__main__
         language: system


### PR DESCRIPTION
Closes #291

Enables a local hook (so that the local virtual environment is used) to run [pylint](https://pylint.pycqa.org/en/latest/) in pre-commit actions. 

* Existing `.pylintrc` in the repository is used.
* `topostats/_version.py` is ignored as this is an external file included by [versioneer](https://github.com/python-versioneer/python-versioneer) and is used for correctly determining package version based on tags when publishing to PyPI.
* Linting is restricted to the `topostats/` and `tests/` directories.

If you are able to test this that would be great (it should only run the linting against files that have changed).