### PR TITLE
Maxgamill sheffield/396 clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ An AFM image analysis program to batch process data and obtain statistics from i
 There is more complete documentation on the projects documentation website. This is hosted in two locations.
 
 * [GitHub Pages : TopoStats](https://afm-spm.github.io/TopoStats/)
-* [Readthedocs : TopoStats](https://topostats.readthedocs.io/en/dev/)
 
 ## Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ run_topostats --config my_config.yaml
 
 On completion a copy of the configuration that was used is written to the output directory.
 
-*Note: When writing file paths, paths that start with `/` are full paths, and mean that they contain the whole folder path to the destination, i.e. `/the/full/path/to/my/data`. The `.` at the start of the path represents a relative file path from where you invoke the command (your current postioion in the folder tree can be found by the command `pwd` i.e. `/the/full/path/to/my/`). From here, the relative path to your data would be: `./data`.
+*Note: When writing file paths, paths that start with `/` are full paths, and mean that they contain the whole folder path to the destination, i.e. `/the/full/path/to/my/data`. The `.` at the start of the path represents a relative file path from where you invoke the command (your current postioion in the folder tree can be found by the command `pwd` (present working directory) i.e. if you were in `/the/full/path/to/`). From here, the relative path to your data would be: `./my/data`.
 
 ## Fields
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ run_topostats --config my_config.yaml
 
 On completion a copy of the configuration that was used is written to the output directory.
 
+*Note: When writing file paths, paths that start with `/` are full paths, and mean that they contain the whole folder path to the destination, i.e. `/the/full/path/to/my/data`. The `.` at the start of the path represents a relative file path from where you invoke the command (your current postioion in the folder tree can be found by the command `pwd` i.e. `/the/full/path/to/my/`). From here, the relative path to your data would be: `./data`.
 
 ## Fields
 
@@ -23,7 +24,7 @@ Aside from the comments in YAML file itself the fields are described below.
 
 | Section      | Sub-Section                    | Data Type  | Default        | Description                                                                                                                                                                                                                                                  |
 |:-------------|:-------------------------------|:-----------|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `base_dir`   |                                | string     | `./`           | Directory to recursively search for files within.                                                                                                                                                                                                            |
+| `base_dir`   |                                | string     | `./`           | Directory to recursively search for files within.                                                                                                                                                                                                           |
 | `output_dir` |                                | string     | `./output`     | Directory that output should be saved to.                                                                                                                                                                                                                    |
 | `warnings`   |                                | string     | `ignore`       | Turns off warnings being shown.                                                                                                                                                                                                                              |
 | `cores`      |                                | integer    | `4`            | Number of cores to run parallel processes on.                                                                                                                                                                                                                |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,9 +47,10 @@ pip install topostats
 ```
 
 This will install TopoStats under your virtual environment and the command `run_topostats` will be available at the
-command line. You will probably want to download a copy of the
-[`default_config.yaml`](https://raw.githubusercontent.com/AFM-SPM/TopoStats/main/topostats/default_config.yaml) to edit
-and use for running your analysis. Please see the [usage](usage) section for more information on running TopoStats.
+command line. Following this, you may want to create a folder containing your data and a TopoStats configuration file to edit and use for running your analysis (download a copy here:
+[`default_config.yaml`](https://github.com/AFM-SPM/TopoStats/blob/a180198b369e68dd892038dca1893aa396b04d33/topostats/default_config.yaml). Download or copy and paste the contents into a text file ending with `.yaml`.
+
+Please see the [usage](usage) section for more information on running TopoStats.
 
 ### Cloning from GitHub
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ TopoStats will scan for all images within this directory but currently it will o
 (i.e. `.spm` _or_ `.jpk` _or_ `.asd`). This may change in the future.
 
 
-## Running TopoStats
+## Running TopoStats - Test Run
 
 The default location that TopoStats looks for scans is the directory from which it is invoked. Once you start your
 shell/terminal you will therefore need to do two things.
@@ -42,7 +42,7 @@ run_topostats
 ...
 ```
 
-## Configuring TopoStats
+## Configuring TopoStats - For Your Data
 
 Configuration of TopoStats is done through a [YAML](https://yuaml.org/) file and a full description of the fields used
 can be found under the [configuration](configuration) section.
@@ -53,12 +53,13 @@ them.
 ### Copying `default_config.yaml`
 
 If you have used Git to clone the TopoStats repository from GitHub the default configuration can be found in the
-sub-directory `topostats/default_config.yaml`. If you have installed TopoStats from PyPI then a sample configuration
-file can be downloaded from
-[here](https://raw.githubusercontent.com/AFM-SPM/TopoStats/main/topostats/default_config.yaml) (right-click on the link
-and select `Save As` to save the file to your computer).
+sub-directory `topostats/default_config.yaml`. 
 
-Save or copy this file to the same directory all of your scan files are located and call it `my_config.yaml`.
+If you have installed TopoStats from PyPI then a sample configuration
+file can be downloaded from
+[here](https://github.com/AFM-SPM/TopoStats/blob/a180198b369e68dd892038dca1893aa396b04d33/topostats/default_config.yaml), or copy and paste the contents into a text file ending with `.yaml`.
+
+Save or copy this file to the folder containing all of your scan files and call it `my_config.yaml`. The command for this is below but you can also use the drag-and-drop feature on your desktop.
 
 ``` bash
 cp /<path>/<to>/<where>/<topostats>/<is>/<cloned>/TopoStats/topostats/default_config.yaml /<where>/<scans>/<are>/my_config.yaml
@@ -75,10 +76,10 @@ You can now start customising the configuration you are going to run TopoStats w
 ones you may want to change are....
 
 * `base_dir` (default: `./`) the directory in which to search for scans. By default this is `./` which represents the
-  directory from which `run_topostats` is called and it is good practice to have one configuration file per batch of
+  folder from which `run_topostats` is called and it is good practice to have one configuration file per batch of
   scans that are being processed.
-* `output_dir` (default: `output`) the location where the output is saved, by default this is the directory `output`
-  which will be   created if it doesn't exist. If you wish for the output to be somewhere else specify it here. If you
+* `output_dir` (default: `output`) the location where the output is saved, by default this is the folder `output`
+  which will be created if it doesn't exist. If you wish for the output to be somewhere else specify it here. If you
   want `Processed` directories to sit within the directories that images are found then simply set the `output_dir` to
   the same value as `base_dir`.
 * `cores` (default: `4`) the number of parallel processes to run processing of all found images. Set this to a maximum


### PR DESCRIPTION
This PR:
- Adds relative path clarity in usage and configuration files
- Corrects the `default_config.yaml` link to the older file that works with the PyPI version.
- Removes the read the docs link (which connected to the wrong topostats version)

@ns-rse I'm aware you're working on generating the config file so let me know which sections you'll be adjusting