### PR TITLE
Molecule # in all_statistics.csv; correcting plotting validation

### DIFF
--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -387,7 +387,7 @@ def main():
     # Load plotting_dictionary and validate
     plotting_dictionary = pkg_resources.open_text(__package__, "plotting_dictionary.yaml")
     config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary.read())
-    validate_plotting(config["plotting"]["plot_dict"])
+    validate_config(config["plotting"]["plot_dict"], schema=PLOTTING_SCHEMA, config_type="YAML configuration file")
 
     # FIXME : Make this a function and from topostats.utils import update_plot_dict and write tests
     # Update the config["plotting"]["plot_dict"] with plotting options
@@ -450,7 +450,7 @@ def main():
                 pbar.update()
     results = pd.concat(results.values())
     results.reset_index()
-    results.to_csv(config["output_dir"] / "all_statistics.csv", index=False)
+    results.to_csv(config["output_dir"] / "all_statistics.csv", index=True)
     LOGGER.info(
         (
             f"All statistics combined for {len(img_files)} images(s) are "


### PR DESCRIPTION
Closes #403

`all_statistics.csv` now includes the molecule number as the first column.

Also in testing it highlighted that the recent merge of #400 hadn't correctly validated the plotting configuration so corrects that too.