### PR TITLE
GH Action to add issues to TopoStats project automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -1,0 +1,20 @@
+name: Add Issues to Project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/AFM-SPM/projects/2
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: admin, blocked, bug, CI/CD, DNATracing, documentation, enhancement, Filters, Grains, GrainStats, Images, linting, Plotting, testing, user experience
+          label-operator: OR


### PR DESCRIPTION
This uses the [add-to-project](https://github.com/actions/add-to-project) GitHub action to automate adding newly created issues to the [Project Backlob](https://github.com/orgs/AFM-SPM/projects/2/views/1).

The two issue templates have been updated to automatically have the labels `bug` and `enhancement` applied (depending on which template). If creating a blank issue you will _have_ to apply a label for this action to work and then add it to the project.

Of the labels we currently have the ones that trigger this action are listed below and have been selected because they are descriptive as to the aspect of the software the Issue relates to...

* admin
* blocked
* bug
* CI/CD
* DNATracing
* documentation
* enhancement
* Filters
* Grains
* GrainStats
* Images
* linting
* Plotting
* testing
* user experience

There are other labels which do _not_ trigger this action but they are more organisational labels, these are...

* blocked
* duplicate
* good first issue
* help wanted
* invalid
* Low priority
* Medium priority
* question
* wontfix

The action will need testing once merged.