### PR TITLE
Relaxes validation of absolute_threshold

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,6 +11,7 @@ TEST_SCHEMA = Schema(
         "a": Path,
         "b": Or("aa", "bb", error="Invalid value in config, valid values are 'aa' or 'bb"),
         "positive_integer": lambda n: 0 < n,
+        "absolute_threshold": Or(int, float, error=("Invalid value in config should be type int or float")),
     }
 )
 
@@ -19,13 +20,15 @@ TEST_SCHEMA = Schema(
     "config, expectation",
     [
         # A valid configuration
-        ({"a": Path(), "b": "aa", "positive_integer": 4}, does_not_raise()),
+        ({"a": Path(), "b": "aa", "positive_integer": 4, "absolute_threshold": 10.0}, does_not_raise()),
         # Invalid value for a (string instead of Path)
-        ({"a": "path", "b": "aa", "positive_integer": 4}, pytest.raises(SchemaError)),
-        # Invalid value for b (int instead of string)
-        ({"a": Path(), "b": 3, "positive_integer": 4}, pytest.raises(SchemaError)),
-        # Invalid value for positive_integer (int instead of string)
-        ({"a": Path(), "b": 3, "positive_integer": -4}, pytest.raises(SchemaError)),
+        ({"a": "path", "b": "aa", "positive_integer": 4, "absolute_threshold": 10.0}, pytest.raises(SchemaError)),
+        # Invalid value for b (int instead of str)
+        ({"a": Path(), "b": 3, "positive_integer": 4, "absolute_threshold": 10.0}, pytest.raises(SchemaError)),
+        # Invalid value for positive_integer (-ve instead +ve)
+        ({"a": Path(), "b": 3, "positive_integer": -4, "absolute_threshold": 10.0}, pytest.raises(SchemaError)),
+        # Invalid value for absolute_threshold (str instead of int/float)
+        ({"a": Path(), "b": 3, "positive_integer": -4, "absolute_threshold": "five"}, pytest.raises(SchemaError)),
     ],
 )
 def test_validate(config, expectation) -> None:

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -102,8 +102,20 @@ DEFAULT_CONFIG_SCHEMA = Schema(
                 "upper": lambda n: n > 0,
             },
             "threshold_absolute": {
-                "lower": lambda n: n < 0,
-                "upper": lambda n: n > 0,
+                "lower": Or(
+                    int,
+                    float,
+                    error=(
+                        "Invalid value in config for filter.threshold.absolute.lower " "should be type int or float"
+                    ),
+                ),
+                "upper": Or(
+                    int,
+                    float,
+                    error=(
+                        "Invalid value in config for filter.threshold.absolute.lower " "should be type int or float"
+                    ),
+                ),
             },
             "gaussian_size": float,
             "gaussian_mode": Or(
@@ -129,8 +141,20 @@ DEFAULT_CONFIG_SCHEMA = Schema(
                 "upper": lambda n: n > 0,
             },
             "threshold_absolute": {
-                "lower": lambda n: n < 0,
-                "upper": lambda n: n > 0,
+                "lower": Or(
+                    int,
+                    float,
+                    error=(
+                        "Invalid value in config for grains.threshold.absolute.lower " "should be type int or float"
+                    ),
+                ),
+                "upper": Or(
+                    int,
+                    float,
+                    error=(
+                        "Invalid value in config for grains.threshold.absolute.lower " "should be type int or float"
+                    ),
+                ),
             },
             "absolute_area_threshold": {
                 "upper": [


### PR DESCRIPTION
Closes #423

I understand the problem but do not feel this is an optimal solution given the situation that these absolute thresholds are image specific and the aim to use TopoStats to batch process images.

There are two threads here...

1) The need to have sensible values against which validation is performed as noted for discussion in #302.

2) The challenge of trying to write software and have defaults that cover all scenarios (or say ~80%).

Given the threshold can change on a per-image basis I do not think having user specified `absolute_threshold` for batch processing is sensible. Its highly likely some in a given batch will fail, users then split their batch of images into smaller batches with custom configs and process these. This seems convoluted and against the aim of batch processing.

Users can always load data into Notebooks and use TopoStats interactively to process on a per image basis (prototype notebooks are covered by issue #242, see also `ns-rse/242a-notebooks` branch for example). For batch processing the thresholds should be derived from the data itself using the `otsu` or `std_dev` method.