### PR TITLE
Corrects image paths, lints code, adds command line options and more

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -478,7 +478,7 @@ def minicircle_grain_mask(minicircle_grain_threshold_otsu: Grains) -> Grains:
     minicircle_grain_threshold_otsu.directions["upper"] = {}
     minicircle_grain_threshold_otsu.directions["upper"]["mask_grains"] = _get_mask(
         image=minicircle_grain_threshold_otsu.image,
-        threshold=minicircle_grain_threshold_otsu.thresholds["upper"],
+        thresh=minicircle_grain_threshold_otsu.thresholds["upper"],
         threshold_direction="upper",
         img_name=minicircle_grain_threshold_otsu.filename,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def dnatracing_config(default_config: Dict) -> Dict:
 def plotting_config(default_config: Dict) -> Dict:
     """Configurations for filtering"""
     config = default_config["plotting"]
+    config["image_set"] = "all"
     config.pop("run")
     config.pop("plot_dict")
     return config

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -144,9 +144,6 @@ def test_load_scan_jpk(load_scan_jpk: LoadScans) -> None:
     load_scan_jpk.img_path = load_scan_jpk.img_paths[0]
     load_scan_jpk.filename = load_scan_jpk.img_paths[0].stem
     image, px_to_nm_scaling = load_scan_jpk.load_jpk()
-    print(image.shape)
-    print(image.sum())
-    print(px_to_nm_scaling)
     assert isinstance(image, np.ndarray)
     assert image.shape == (256, 256)
     assert image.sum() == 286598232.9308627

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import numpy as np
 import pytest
 
-from topostats.io import read_yaml, LoadScans
+from topostats.io import read_yaml, find_images, get_out_path, LoadScans
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -27,6 +27,92 @@ def test_read_yaml() -> None:
     sample_config = read_yaml(RESOURCES / "test.yaml")
 
     TestCase().assertDictEqual(sample_config, CONFIG)
+
+
+def test_find_images() -> None:
+    """Test finding images"""
+    found_images = find_images(base_dir="tests/", file_ext=".spm")
+
+    assert isinstance(found_images, list)
+    assert len(found_images) == 1
+    assert isinstance(found_images[0], Path)
+    assert "minicircle.spm" in str(found_images[0])
+
+
+@pytest.mark.parametrize(
+    "base_dir, image_path, output_dir, expected",
+    [
+        # Absolute path, nested under base_dir, with file suffix
+        (
+            Path("/some/random/path"),
+            Path("/some/random/path/images/test.spm"),
+            Path("output/here"),
+            Path("output/here/images/test/"),
+        ),
+        # Absolute path, nested under base_dir, with file suffix and multiple periods
+        (
+            Path("/some/random/path"),
+            Path("/some/random/path/images/te.st.spm"),
+            Path("output/here"),
+            Path("output/here/images/te.st/"),
+        ),
+        # Absolute path, nested under base_dir, with file suffix
+        (
+            Path("/some/random/path"),
+            Path("/some/random/path/images/today/test.spm"),
+            Path("output/here"),
+            Path("output/here/images/today/test/"),
+        ),
+        # Relative path, nested under base_dir, with file_suffix
+        (
+            Path("/some/random/path"),
+            Path("images/test.spm"),
+            Path("output/here"),
+            Path("output/here/images/test"),
+        ),
+        # Relative path, nested (two deep) under base_dir, with file_suffix
+        (
+            Path("/some/random/path"),
+            Path("images/today/test.spm"),
+            Path("output/here"),
+            Path("output/here/images/today/test"),
+        ),
+        # Relative path, nested under base_dir, no file suffix
+        (Path("/some/random/path"), Path("images/"), Path("output/here"), Path("output/here/images/")),
+        # Absolute path, nested under base_dir, output not nested under base_dir, with file_suffix
+        (
+            Path("/some/random/path"),
+            Path("/some/random/path/images/test.spm"),
+            Path("/different/absolute/path"),
+            Path("/different/absolute/path/images/test"),
+        ),
+        # Absolute path, nested under base_dir, output not nested under base_dir, no file file_suffix
+        (
+            Path("/some/random/path"),
+            Path("/some/random/path/images/"),
+            Path("/different/absolute/path"),
+            Path("/different/absolute/path/images/"),
+        ),
+        # Relative path, nested under base_dir, output not nested under base_dir, with file_suffix
+        (
+            Path("/some/random/path"),
+            Path("images/test.spm"),
+            Path("/an/absolute/path"),
+            Path("/an/absolute/path/images/test"),
+        ),
+    ],
+)
+def test_get_out_path(image_path: Path, base_dir: Path, output_dir: Path, expected: Path) -> None:
+    """Test output directories"""
+    out_path = get_out_path(image_path, base_dir, output_dir)
+    assert isinstance(out_path, Path)
+    assert out_path == expected
+
+
+def test_get_out_path_attributeerror() -> None:
+    """Test get_out_path() raises AttribteError when passed a string instead of a Path() for image_path."""
+    with pytest.raises(AttributeError):
+        get_out_path(image_path="images/test.spm", base_dir=Path("/some/random/path"), output_dir=Path("output/here"))
 
 
 def test_load_scan_spm(load_scan: LoadScans) -> None:

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 
 import pytest
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 import numpy as np
 from skimage import io
 
@@ -11,11 +13,11 @@ from topostats.plottingfuncs import Images
 
 
 @pytest.mark.parametrize(
-    "data2, axes_colorbar, region_properties",
+    "masked_array, axes_colorbar, region_properties",
     [(np.random.rand(10, 10), True, None), (None, True, None), (None, False, True)],
 )
 def test_save_figure(
-    data2: np.ndarray,
+    masked_array: np.ndarray,
     axes_colorbar: bool,
     region_properties: bool,
     image_random: np.ndarray,
@@ -29,14 +31,14 @@ def test_save_figure(
         data=image_random,
         output_dir=tmp_path,
         filename="result",
-        data2=data2,
+        masked_array=masked_array,
         colorbar=axes_colorbar,
         axes=axes_colorbar,
         region_properties=region_properties,
     ).save_figure()
     assert Path(tmp_path / "result.png").exists()
-    assert fig is not None
-    assert ax is not None
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
 
 
 def test_save_array_figure(tmp_path: Path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,7 +76,10 @@ def test_folder_grainstats(tmp_path: Path, minicircle_tracestats: pd.DataFrame) 
     """Test a folder-wide grainstats file is made"""
     input_path = tmp_path / "minicircle"
     minicircle_tracestats["Basename"] = input_path / "subfolder"
-    true_out_path = tmp_path / "subfolder" / "Processed"
-    Path.mkdir(true_out_path, parents=True)
+    out_path = tmp_path / "subfolder" / "processed"
+    Path.mkdir(out_path, parents=True)
+    print(f"###### out_path   : {out_path}")
+    print(f"###### input_path : {input_path}")
+    print(f"###### minicircle_tracestats :\n{minicircle_tracestats['Basename']}")
     folder_grainstats(tmp_path, input_path, minicircle_tracestats)
-    assert Path(true_out_path / "folder_grainstats.csv").exists()
+    assert Path(out_path / "folder_grainstats.csv").exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import pandas as pd
 
-from topostats.utils import convert_path, find_images, get_out_path, update_config, get_thresholds, folder_grainstats
+from topostats.utils import convert_path, update_config, get_thresholds, folder_grainstats
 
 
 THRESHOLD_OPTIONS = {
@@ -22,69 +22,6 @@ def test_convert_path(tmp_path: Path) -> None:
 
     assert isinstance(converted_path, Path)
     assert tmp_path == converted_path
-
-
-def test_find_images() -> None:
-    """Test finding images"""
-    found_images = find_images(base_dir="tests/", file_ext=".spm")
-
-    assert isinstance(found_images, list)
-    assert len(found_images) == 1
-    assert isinstance(found_images[0], Path)
-    assert "minicircle.spm" in str(found_images[0])
-
-
-@pytest.mark.parametrize(
-    "image_path, base_dir, output_dir, expected",
-    [
-        # Full absolute path for test.spm
-        (
-            Path("/heres/some/random/path/images/test.spm"),
-            Path("/heres/some/random/path"),
-            Path("output/here"),
-            Path("output/here/test/"),
-        ),
-        # Relative path for test.spm, this raises a ValueError
-        (
-            Path("images/test.spm"),
-            Path("/heres/some/random/path"),
-            Path("output/here"),
-            Path("output/here/images/"),
-        ),
-        # No file with suffix
-        (Path("images/"), Path("/heres/some/random/path"), Path("output/here"), Path("output/here/images/")),
-        # Absolute path for output
-        (
-            Path("/heres/some/random/path/images/test.spm"),
-            Path("/heres/some/random/path"),
-            Path("/an/absolute/path"),
-            Path("/an/absolute/path/test"),
-        ),
-        # Absolute path for output and relative path for image
-        (
-            Path("images/test.spm"),
-            Path("/heres/some/random/path"),
-            Path("/an/absolute/path"),
-            Path("/an/absolute/path/images"),
-        ),
-    ],
-)
-def test_get_out_path(image_path: Path, base_dir: Path, output_dir: Path, expected: Path) -> None:
-    """Test output directories"""
-    image_path = Path(image_path)
-    base_dir = Path(base_dir)
-    output_dir = Path(output_dir)
-    out_path = get_out_path(image_path, base_dir, output_dir)
-    assert isinstance(out_path, Path)
-    assert out_path == expected
-
-
-def test_get_out_path_attributeerror() -> None:
-    """Test get_out_path() raises AttribteError when passed a string instead of a Path() for image_path."""
-    with pytest.raises(AttributeError):
-        get_out_path(
-            image_path="images/test.spm", base_dir=Path("/heres/some/random/path"), output_dir=Path("output/here")
-        )
 
 
 def test_update_config(caplog) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,7 +42,7 @@ def test_find_images() -> None:
             Path("/heres/some/random/path/images/test.spm"),
             Path("/heres/some/random/path"),
             Path("output/here"),
-            Path("output/here/images/"),
+            Path("output/here/test/"),
         ),
         # Relative path for test.spm, this raises a ValueError
         (
@@ -58,7 +58,7 @@ def test_find_images() -> None:
             Path("/heres/some/random/path/images/test.spm"),
             Path("/heres/some/random/path"),
             Path("/an/absolute/path"),
-            Path("/an/absolute/path/images"),
+            Path("/an/absolute/path/test"),
         ),
         # Absolute path for output and relative path for image
         (
@@ -113,7 +113,7 @@ def test_get_thresholds_stddev(image_random: np.ndarray) -> None:
     assert thresholds == {"lower": -2.3866804917165663, "upper": 0.7886033762450778}
 
     with pytest.raises(TypeError):
-        thresholds = get_thresholds(image=image_random, threshold_method="std_dev", deviation_from_mean=None)
+        thresholds = get_thresholds(image=image_random, threshold_method="std_dev")
 
 
 def test_get_thresholds_absolute(image_random: np.ndarray) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,8 +78,5 @@ def test_folder_grainstats(tmp_path: Path, minicircle_tracestats: pd.DataFrame) 
     minicircle_tracestats["Basename"] = input_path / "subfolder"
     out_path = tmp_path / "subfolder" / "processed"
     Path.mkdir(out_path, parents=True)
-    print(f"###### out_path   : {out_path}")
-    print(f"###### input_path : {input_path}")
-    print(f"###### minicircle_tracestats :\n{minicircle_tracestats['Basename']}")
     folder_grainstats(tmp_path, input_path, minicircle_tracestats)
     assert Path(out_path / "folder_grainstats.csv").exists()

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -44,7 +44,7 @@ dnatracing:
 plotting:
   run: true # Options : true, false
   save_format: png # Options : see https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
-  image_set: all  # Options : all, core
+  image_set: core  # Options : all, core
   zrange: [null, null]  # low and high height range for core images (can take [null, null])
   colorbar: true  # Options : true, false
   axes: true # Options : true, false (due to off being a bool when parsed)

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -19,7 +19,9 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 # pylint: disable=fixme
 # pylint: disable=line-too-long
 # pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-arguments
 # pylint: disable=bare-except
+# pylint: disable=dangerous-default-value
 
 
 class Grains:
@@ -277,7 +279,7 @@ class Grains:
                 self.directions[direction] = defaultdict()
                 self.directions[direction]["mask_grains"] = _get_mask(
                     self.image,
-                    threshold=self.thresholds[direction],
+                    thresh=self.thresholds[direction],
                     threshold_direction=direction,
                     img_name=self.filename,
                 )

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -15,6 +15,10 @@ import pandas as pd
 from topostats.plottingfuncs import Images
 from topostats.logs.logs import LOGGER_NAME
 
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-branches
 # pylint: disable=line-too-long
 # pylint: disable=fixme
 # FIXME : The calculate_stats() and calculate_aspect_ratio() raise this error when linting, could consider putting
@@ -883,9 +887,8 @@ class GrainStats:
         shift = np.hstack((shift, -coords[np.where(coords < 0)]))
         if len(shift) == 0:
             return 0
-        else:
-            max_index = np.argmax(abs(shift))
-            return shift[max_index]
+        max_index = np.argmax(abs(shift))
+        return shift[max_index]
 
     def get_cropped_region(self, image: np.ndarray, length: int, centre: np.ndarray) -> np.ndarray:
         """Crops the image with respect to a given pixel length around the centre coordinates.

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -113,7 +113,7 @@ def get_out_path(
 
 
 def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> List:
-    """Scan the specified directory for images with the given file extension.
+    """Recursively scan the specified directory for images with the given file extension.
 
     Parameters
     ----------

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -11,6 +11,11 @@ import numpy as np
 from topostats.logs.logs import LOGGER_NAME
 from topostats.theme import Colormap
 
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-arguments
+# pylint: disable=dangerous-default-value
+
 LOGGER = logging.getLogger(LOGGER_NAME)
 
 
@@ -23,7 +28,7 @@ class Images:
         output_dir: Union[str, Path],
         filename: str,
         pixel_to_nm_scaling: float = 1.0,
-        data2: np.array = None,
+        masked_array: np.array = None,
         title: str = None,
         image_type: str = "non-binary",
         image_set: str = "core",
@@ -51,7 +56,7 @@ class Images:
             Filename to save image as.
         pixel_to_nm_scaling : float
             The scaling factor showing the real length of 1 pixel, in nm.
-        data2 : np.ndarray
+        masked_array : np.ndarray
             Optional mask array to overlay onto an image.
         title : str
             Title for plot.
@@ -85,7 +90,7 @@ class Images:
         self.output_dir = Path(output_dir)
         self.filename = filename
         self.pixel_to_nm_scaling = pixel_to_nm_scaling
-        self.data2 = data2
+        self.masked_array = masked_array
         self.title = title
         self.image_type = image_type
         self.image_set = image_set
@@ -130,8 +135,7 @@ class Images:
             plt.close()
 
             return fig, ax
-        else:
-            return None
+        return None
 
     def plot_and_save(self):
         """
@@ -150,7 +154,7 @@ class Images:
                 if self.axes or self.colorbar:
                     fig, ax = self.save_figure()
                 else:
-                    if isinstance(self.data2, np.ndarray) or self.region_properties:
+                    if isinstance(self.masked_array, np.ndarray) or self.region_properties:
                         fig, ax = self.save_figure()
                     else:
                         self.save_array_figure()
@@ -182,9 +186,9 @@ class Images:
                 vmin=self.zrange[0],
                 vmax=self.zrange[1],
             )
-            if isinstance(self.data2, np.ndarray):
-                self.data2[self.data2 != 0] = 1
-                mask = np.ma.masked_where(self.data2 == 0, self.data2)
+            if isinstance(self.masked_array, np.ndarray):
+                self.masked_array[self.masked_array != 0] = 1
+                mask = np.ma.masked_where(self.masked_array == 0, self.masked_array)
                 ax.imshow(
                     mask,
                     "jet_r",

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -158,10 +158,7 @@ class Images:
                         fig, ax = self.save_figure()
                     else:
                         self.save_array_figure()
-        if "_processed" in self.filename:
-            LOGGER.info(
-                f"[{self.filename.split('_processed')[0]}] : Image saved to : {str(self.output_dir / self.filename)}"
-            )
+        LOGGER.info(f"[{self.filename}] : Image saved to : {str(self.output_dir / self.filename)}")
         return fig, ax
 
     def save_figure(self):

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -240,7 +240,7 @@ def folder_grainstats(output_dir: Union[str, Path], base_dir: Union[str, Path], 
     try:
         for _dir in dirs:
             out_path = get_out_path(Path(_dir), base_dir, output_dir)
-            all_stats_df[all_stats_df["Basename"] == _dir].to_csv(out_path / "folder_grainstats.csv")
+            all_stats_df[all_stats_df["Basename"] == _dir].to_csv(out_path / "processed" / "folder_grainstats.csv")
             LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/folder_grainstats.csv")
     except TypeError:
         LOGGER.info("Unable to generate folderwise statistics as 'all_stats_df' is empty")

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -2,12 +2,13 @@
 from argparse import Namespace
 import logging
 from pathlib import Path
-from typing import Union, List, Dict
+from typing import Union, Dict
 from collections import defaultdict
 
 import numpy as np
 import pandas as pd
 
+from topostats.io import get_out_path
 from topostats.thresholds import threshold
 from topostats.logs.logs import LOGGER_NAME
 
@@ -55,62 +56,6 @@ def convert_path(path: Union[str, Path]) -> Path:
         pathlib Path
     """
     return Path().cwd() if path == "./" else Path(path).expanduser()
-
-
-def find_images(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> List:
-    """Scan the specified directory for images with the given file extension.
-
-    Parameters
-    ----------
-    base_dir: Union[str, Path]
-        Directory to recursively search for files, if not specified the current directory is scanned.
-    file_ext: str
-        File extension to search for.
-
-    Returns
-    -------
-    List
-        List of files found with the extension in the given directory.
-    """
-    base_dir = Path("./") if base_dir is None else Path(base_dir)
-    return list(base_dir.glob("**/*" + file_ext))
-
-
-def get_out_path(
-    image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None
-) -> Path:
-    """Adds the image path relative to the base directory to the output directory.
-
-    Parameters
-    ----------
-    image_path: Path
-        The path of the current image.
-    base_dir: Path
-        Directory to recursively search for files.
-    output_dir: Path
-        The output directory specified in the configuration file.
-
-    Returns
-    -------
-    Path
-        The output path that mirrors the input path structure.
-    """
-    # If image_path is relative and doesn't include base_dir then a ValueError is raisedin which
-    # case we just want to append the image_path to the output_dir
-    try:
-        # Remove the filename if there is a suffix, not always the case as
-        # get_out_path is called from folder_grainstats()
-        if image_path.suffix:
-            return output_dir / image_path.relative_to(base_dir).stem
-        return output_dir / image_path.relative_to(base_dir)
-    except ValueError:
-        if image_path.suffix:
-            return output_dir / image_path.parent
-        return output_dir / image_path
-    # AttributeError is raised if image_path is a string (since it isn't a Path() object with a .suffix)
-    except AttributeError:
-        LOGGER.error("A string form of a Path has been passed to 'get_out_path()' for image_path")
-        raise
 
 
 def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
@@ -275,7 +220,7 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS) -> pd.DataFram
 
 
 def folder_grainstats(output_dir: Union[str, Path], base_dir: Union[str, Path], all_stats_df: pd.DataFrame) -> None:
-    """Creates saves a data frame of grain and tracing statictics at the folder level.
+    """Saves a data frame of grain and tracing statictics at the folder level.
 
     Parameters
     ----------
@@ -295,7 +240,7 @@ def folder_grainstats(output_dir: Union[str, Path], base_dir: Union[str, Path], 
     try:
         for _dir in dirs:
             out_path = get_out_path(Path(_dir), base_dir, output_dir)
-            all_stats_df[all_stats_df["Basename"] == _dir].to_csv(out_path / "Processed" / "folder_grainstats.csv")
-            LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/Processed/folder_grainstats.csv")
+            all_stats_df[all_stats_df["Basename"] == _dir].to_csv(out_path / "folder_grainstats.csv")
+            LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/folder_grainstats.csv")
     except TypeError:
-        LOGGER.info("Unable to generate folderwise statistics as 'all_statis_df' is empty")
+        LOGGER.info("Unable to generate folderwise statistics as 'all_stats_df' is empty")


### PR DESCRIPTION
Closes #362 
Closes #391 
Closes #428 
Closes #430 
Closes #433 

Pull request and code changes grew after initially making #429 (see for useful comments/feedback) but in summary...

## Double periods

`LoadScans()` class gets the filename using `Path.stem` method. However `processed_scan()` in `run_topostats.py` also took `Path.stem` so if filenames had two (or more) periods in them the filename ended up truncated and the last two sections after periods were excised (e.g. `mini.circle.spm` > `mini`). This is resolved by using `Path.name` in `processed_scan()` now instead.

There were also some problems with the `utils.get_out_path()` function which have been corrected but aren't easily visible because of having moved the function from `utils.py` to `io.py`.

## Processed Directory

* Retain a `processed` directory for _each_ level of nesting of files.
* Changed the default `image_set: core` (was `all`) so that minimal output is generated, decreasing run-time, two images are now output for each image under `processed`, one from the `z_threshed` array (aka "Height Thresholded") and one from `mask_overlay` (aka "Height Thresholded with Mask"). Images of individual grains are written to `processed/grains/<direction>/`. A file for all statistics in a given folder is written to `processed/folder_grainstats.csv` (and actually includes DNA Tracing statistics too!).

## Command line argument to run with cores

Added a simple command line argument (`-j` / `--cores`) to over-ride the number of cores used in processing (reduced default number in `default_config.yaml` because of issue with GitHub runners, this means its easy when running/testing locally to over-ride this).

`-j` because `-c` is already taken for `--config_file` and `-j` is the option the `gcc` compiler takes for the number of cores to use.

## Restructured Code

Having lots of things in a `utils` module is poor practice, it means we've not thought about code and what its doing well enough (I'm guilty of this as I created the module!). To which end I have moved some functions and their tests around.


## Linting

Resolved some linting errors, disabled some others across files that I touched. Also renamed `data2` option to the `Images()` class to `masked_array` which is more informative.


## Completion message

Added a completion message that summarises the images found, how many successfully processed (which means that some statistics were calculated for them). It includes the input directory, output directory along with key URLs, how to report bugs and a request to cite the software if used.