### PR TITLE
Adding pre-commit.ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![pre-commit.ci
+status](https://results.pre-commit.ci/badge/github/AFM-SPM/TopoStats/main.svg)](https://results.pre-commit.ci/latest/github/AFM-SPM/TopoStats/main)
 
 | [Installation](#installation) | [Tutorials and Examples](#tutorials-and-examples) | [Contributing](contributing.md) | [Licence](#licence) | [Citation](#citation) |
 </div>


### PR DESCRIPTION
Closes #357 

Added [pre-commit.ci](https://pre-commit.ci) and badge to show if its passing.

This should run `pre-commit` on pull requests here on GitHub.