### PR TITLE
Enabling pre-commit.ci on the repo; applying black to plotting files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0  # Use the ref you want to point at
+    rev: v4.4.0  # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
-        types: [python, yaml]
+        types: [python, yaml, markdown]
       - id: check-docstring-first
       - id: check-case-conflict
       - id: end-of-file-fixer
@@ -13,7 +13,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         types: [python]
@@ -21,7 +21,7 @@ repos:
         args: ["--extend-exclude", "topostats/plotting.py"]
 
   - repo: https://github.com/pycqa/flake8.git
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: ["--extend-exclude=topostats/_version.py"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v4.3.0  # Use the ref you want to point at
     hooks:
       - id: trailing-whitespace
-        types: [file, text]
+        types: [python, yaml]
       - id: check-docstring-first
       - id: check-case-conflict
       - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
         args: ["--extend-exclude=topostats/_version.py"]
         additional_dependencies: [flake8-print]
         types: [python]
+  # - repo: https://github.com/pycqa/pylint.git
+  #   rev: 2.15.9
+  #   hooks:
+  #     - id: pylint
+  #       types: [python]
+  #       args: ["--rcfile=.pylintrc"]
+  #       files: \.py$
   - repo: local
     hooks:
       - id: pylint
@@ -35,3 +42,10 @@ repos:
         entry: python -m pylint
         language: system
         files: \.py$
+
+ci:
+  autofix_prs: true
+  autofix_commit_msg: '[pre-commit.ci] Fixing issues with pre-commit'
+  autoupdate_schedule: weekly
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit-autoupdate'
+  skip: [pylint] # Optionally list ids of hooks to skip on CI

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore-paths=
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.
-ignore-patterns=minicircle.spm
+ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,7 +29,7 @@ ignore-paths=
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=minicircle.spm
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/downloads/release/python-390/)
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-360/)
+[![pre-commit.ci
+status](https://results.pre-commit.ci/badge/github/AFM-SPM/TopoStats/main.svg)](https://results.pre-commit.ci/latest/github/AFM-SPM/TopoStats/main)
 
 | [Installation](#installation) | [Tutorials and Examples](#tutorials-and-examples) | [Contributing](contributing.md) | [Licence](#licence) | [Citation](#citation) |
 </div>

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -202,15 +202,16 @@ RNG = np.random.default_rng(seed=1000)
 array = RNG.random((10, 10))
 mask = RNG.uniform(low=0, high=1, size=array.shape) > 0.5
 
+
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_mask_cmap(plotting_config: dict, tmp_path: Path) -> None:
     """Test the plotting of a mask with a different colourmap (blu)."""
-    plotting_config['mask_cmap'] = 'blu'
+    plotting_config["mask_cmap"] = "blu"
     fig, _ = Images(
         data=array,
         output_dir=tmp_path,
         filename="colour.png",
         masked_array=mask,
         **plotting_config,
-        ).plot_and_save()
+    ).plot_and_save()
     return fig

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -22,6 +22,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 # pylint: disable=too-many-branches
 # pylint: disable=dangerous-default-value
 
+
 class Filters:
     """Class for filtering scans."""
 

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -237,9 +237,7 @@ class Images:
                     dpi=self.dpi,
                 )
             else:
-                plt.savefig(
-                    (self.output_dir / f"{self.filename}.{self.save_format}"), dpi=self.dpi
-                )
+                plt.savefig((self.output_dir / f"{self.filename}.{self.save_format}"), dpi=self.dpi)
         else:
             plt.xlabel("Nanometres")
             plt.ylabel("Nanometres")

--- a/topostats/theme.py
+++ b/topostats/theme.py
@@ -50,7 +50,7 @@ class Colormap:
         The colormap is implemented in Gwyddion's GwyGradient via 'Nanoscope.txt'
         """
         cdict = {
-            'red': (
+            "red": (
                 (0.0, 0.0, 0.0),
                 (0.124464, 0.0, 0.0),
                 (0.236052, 0.0670103, 0.0670103),
@@ -66,7 +66,7 @@ class Colormap:
                 (0.971401, 0.996006, 0.996006),
                 (1, 1, 1),
             ),
-            'green': (
+            "green": (
                 (0.0, 0.0, 0.0),
                 (0.124464, 0.0, 0.0),
                 (0.236052, 0.0, 0.0),
@@ -82,7 +82,7 @@ class Colormap:
                 (0.971401, 0.993565, 0.993565),
                 (1, 1, 1),
             ),
-            'blue': (
+            "blue": (
                 (0.0, 0.0, 0.0),
                 (0.124464, 0.0, 0.0),
                 (0.236052, 0.0, 0.0),
@@ -97,8 +97,8 @@ class Colormap:
                 (0.965682, 0.974293, 0.974293),
                 (0.971401, 0.990347, 0.990347),
                 (1, 1, 1),
-            )
-            }
+            ),
+        }
 
         colormap = LinearSegmentedColormap("nanoscope", cdict)
         return colormap
@@ -109,8 +109,8 @@ class Colormap:
         N = 4  # Number of values
         vals = np.ones((N, 4))  # Initialise the array to be full of 1.0
         vals[0] = [0.0, 0.0, 0.0, 1]
-        vals[1] = [168/256, 40/256, 15/256, 1.0]
-        vals[2] = [243/256, 194/256, 93/256, 1.0]
+        vals[1] = [168 / 256, 40 / 256, 15 / 256, 1.0]
+        vals[2] = [243 / 256, 194 / 256, 93 / 256, 1.0]
         vals[3] = [1.0, 1.0, 1.0, 1.0]
 
         colormap = LinearSegmentedColormap.from_list("gwyddion", vals, N=256)
@@ -119,4 +119,4 @@ class Colormap:
     @staticmethod
     def blu():
         "RGBA colour map of just the colour blue."
-        return ListedColormap([[32/256, 226/256, 205/256]], "blu", N=256)
+        return ListedColormap([[32 / 256, 226 / 256, 205 / 256]], "blu", N=256)


### PR DESCRIPTION
Closes #357

Introduces [pre-commit.ci](https://pre-commit.ci) to the GitHub Actions.

Also applies `black` to the files modified in PR #409