### PR TITLE
Add Height Sensor channel to validation.py

### DIFF
--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -56,6 +56,7 @@ DEFAULT_CONFIG_SCHEMA = Schema(
                 "Adhesion",
                 "Deformation",
                 "Dissipation",
+                "Height Sensor",
                 "Height",  # end of spm channels
                 "HeightTracee",
                 "HeightRetrace",


### PR DESCRIPTION
Closes #459 

This PR adds the commonly used "Height Sensor" channel to `validation.py`.