### PR TITLE
Update Bug template to request commit hash; TopoStats arg to show version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,9 +20,10 @@ A clear and concise description of what you expected to happen.
 
 **Output**
 
-If applicable please include the output error, this can be a copy and paste of the output (preferable** or a screenshot.
-If applicable, add screenshots to help explain your problem.
-Output files can be attached to this bug report.
+If applicable please include the output error, this can be a copy and paste of the output (preferable) or a screenshot.
+
+Any images or output files that have been produced can be attached to this bug report (by default they will be under the
+`output` directory unless you have customised the configuration).
 
 ** TopoStats version
 
@@ -34,12 +35,12 @@ have installed TopoStats from source/GitHub and are working on features.
 - `run_topostats --version`
 
 
+** Your computer configuration (please complete the following information):**
 
-**(Not required if using Docker) Your computer configuration (please complete the following information):**
- - OS: e.g. windows, MacOS, linux; please include OS version
- - topostats version: best way to get this at the moment is to paste the results of running `git show --oneline -s` in your topostats folder.
- - Python version: best way to get this is to paste the results of typing `python --version`.
- - Optionally, your installed packages: best way to get this is to paste the results of typing `pip freeze`.
+- OS: e.g. windows, MacOS, linux; please include OS version
+- Python version: paste the results of typing `python --version`.
+- Optionally, your installed packages: the best way to get this is to copy and paste the results of typing `pip freeze`.
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,9 +20,20 @@ A clear and concise description of what you expected to happen.
 
 **Output**
 
-If applicable please include the output error, this can be a copy and paste of the output (preferable) or a screenshot.
+If applicable please include the output error, this can be a copy and paste of the output (preferable** or a screenshot.
 If applicable, add screenshots to help explain your problem.
 Output files can be attached to this bug report.
+
+** TopoStats version
+
+Please report the version of TopoStats you are using. There are several ways of doing this, either with `pip` or
+`run_topostats`. Please copy and paste all output from either of the following, although the later is preferable if you
+have installed TopoStats from source/GitHub and are working on features.
+
+- `pip show topostats`
+- `run_topostats --version`
+
+
 
 **(Not required if using Docker) Your computer configuration (please complete the following information):**
  - OS: e.g. windows, MacOS, linux; please include OS version

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -255,9 +255,11 @@ def main(args=None):
     write_yaml(config, output_dir=config["output_dir"])
     results.reset_index(inplace=True)  # So we can access unique image names
     images_processed = len(results["image"].unique())
+    topostats_version = get_versions()
     LOGGER.info(
         (
             f"\n\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
+            f"  TopoStats Version           : {topostats_version['version']}\n"
             f"  Base Directory              : {config['base_dir']}\n"
             f"  File Extension              : {config['file_ext']}\n"
             f"  Files Found                 : {len(img_files)}\n"

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -13,6 +13,7 @@ import yaml
 import pandas as pd
 from tqdm import tqdm
 
+from topostats._version import get_versions
 from topostats.io import find_files, read_yaml, write_yaml, save_folder_grainstats, LoadScans
 from topostats.logs.logs import setup_logger, LOGGER_NAME
 from topostats.plotting import toposum
@@ -104,6 +105,13 @@ def create_parser() -> arg.ArgumentParser:
     )
     parser.add_argument("-m", "--mask", dest="mask", type=bool, required=False, help="Mask the image.")
     parser.add_argument("-q", "--quiet", dest="quiet", type=bool, required=False, help="Toggle verbosity.")
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"Installed version of TopoStats : {get_versions()}",
+        help="Report the current version of TopoStats that is installed.",
+    )
     parser.add_argument(
         "-w",
         "--warnings",


### PR DESCRIPTION
As discussed in todays meeting (but not noted in a specific issue) it would be useful to report the full version, including a commit hash if we are working on development.

This PR updates the `bug_repor.md` template to request that, including instructions on how to obtain it.

To assist a command line argument `-v/--version` has been added to `run_topostats` which reports the version.