### PR TITLE
Empty commit to trigger workflows with 3.11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ packages = find:
 
 [options.extras_require]
 tests =
+  py
   pytest
   pytest-cov
   pytest-mpl


### PR DESCRIPTION
Closes #345

The `h5py-3.7.0` package had some [issues](https://github.com/h5py/h5py/pull/2165) which were addressed and merged into `h5py-3.8.0` which was released 2023-01-23. This should mean that TopoStats tests run against Python 3.11 and so making an empty commit so I can create a Pull Request and test.
