### PR TITLE
Fixing plotting in light of feedback

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,10 +285,10 @@ and generate the plots you want there. A sample notebook is included to show how
 
 Configuration of summary plots is also via a YAML configuration file a description of the fields can be found under
 [configuration](configuration#summary-configuration) page. You can generate a sample configuration by invoking the
-`--create_config_file` option to `toposum`
+`--create-config-file` option to `toposum`
 
 ``` bash
-toposum --create_config_file custom_summary_config.yaml
+toposum --create-config-file custom_summary_config.yaml
 ```
 
 The file `custom_summary_config.yaml` can then be edited to change what plots are generated, where they are saved to and

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -6,7 +6,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from topostats.io import read_yaml, find_files, get_out_path, save_folder_grainstats, LoadScans, save_pkl, load_pkl
+from topostats.io import (
+    read_yaml,
+    find_files,
+    get_out_path,
+    path_to_str,
+    save_folder_grainstats,
+    LoadScans,
+    save_pkl,
+    load_pkl,
+)
 
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests" / "resources"
@@ -28,6 +37,18 @@ def test_read_yaml() -> None:
     sample_config = read_yaml(RESOURCES / "test.yaml")
 
     TestCase().assertDictEqual(sample_config, CONFIG)
+
+
+def test_path_to_str(tmp_path) -> None:
+    """Test that Path objects are converted to strings."""
+    CONFIG_PATH = {"this": "is", "a": "test", "with": tmp_path, "and": {"nested": tmp_path / "nested"}}
+    CONFIG_STR = path_to_str(CONFIG_PATH)
+
+    assert isinstance(CONFIG_STR, dict)
+    assert isinstance(CONFIG_STR["with"], str)
+    assert CONFIG_STR["with"] == str(tmp_path)
+    assert isinstance(CONFIG_STR["and"]["nested"], str)
+    assert CONFIG_STR["and"]["nested"] == str(tmp_path / "nested")
 
 
 def test_find_files() -> None:

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -62,9 +62,7 @@ def write_yaml(
     # Save the configuration to output directory
     output_config = Path(output_dir) / config_file
     # Revert PosixPath items to string
-    # FIXME : Now need to recursively process the whole dictionary to convert PosixPath to string
-    config["base_dir"] = str(config["base_dir"])
-    config["output_dir"] = str(config["output_dir"])
+    config = path_to_str(config)
     config_yaml = yaml_load(yaml_dump(config))
     if header_message:
         config_yaml.yaml_set_start_comment(f"{header_message} : {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
@@ -77,6 +75,28 @@ def write_yaml(
             f.write(yaml_dump(config_yaml))
         except YAMLError as exception:
             LOGGER.error(exception)
+
+
+def path_to_str(config: dict) -> Dict:
+    """Recursively traverse a dictionary and convert any Path() objects to strings for writing to YAML.
+
+    Parameters
+    ----------
+    config: dict
+        Dictionary to be converted.
+
+    Returns
+    -------
+    Dict:
+        The same dictionary with any Path() objects converted to string.
+    """
+    for key, value in config.items():
+        if isinstance(value, dict):
+            path_to_str(value)
+        elif isinstance(value, Path):
+            config[key] = str(value)
+
+    return config
 
 
 def get_out_path(

--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -281,10 +281,13 @@ def toposum(config: dict) -> Dict:
        'violin' is itself a dictionary with two elements 'figures' and 'axes' which correspond to MatplotLib 'fig' and
        'ax' for that plot.
     """
+    if "df" not in config.keys():
+        config["df"] = pd.read_csv(config["csv_file"])
     violin = config.pop("violin")
     all_stats_to_sum = config.pop("stats_to_sum")
     pickle_plots = config.pop("pickle_plots")
     figures = defaultdict()
+
     # Plot each variable on its own graph
     for var in all_stats_to_sum:
         if var in config["df"].columns:


### PR DESCRIPTION
@derollins was testing the `plotting` refactor and found some errors. This PR corrects those.

The `write_yaml()` function had a hard coding to convert `Path()` objects in a configuration dictionary to `str` for writing to file. That is now done by the `path_to_str()` function (tests included) and in doing so removes the need for the presence of `base_dir: ./` in the `summary_config.yaml`.

Also if a `df` is not passed to the `TopoSum` class when it was being instantiated nothing could be plotted. If no `df` is provided in the `config` (which `run_topostats` adds before plotting) then `TopoSum` now loads the provided `csv` file and the plotting can proceed.