### PR TITLE
Additional pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,16 +2,18 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0  # Use the ref you want to point at
     hooks:
-      - id: trailing-whitespace
-        types: [python, yaml, markdown]
-      - id: check-docstring-first
       - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
       - id: end-of-file-fixer
         types: [python]
-      - id: requirements-txt-fixer
       - id: fix-byte-order-marker
-      - id: check-yaml
-      - id: check-toml
+      - id: name-tests-test
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+        types: [python, yaml, markdown]
 
   - repo: https://github.com/psf/black
     rev: 23.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: end-of-file-fixer
         types: [python]
       - id: fix-byte-order-marker
-      - id: name-tests-test
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         types: [python, yaml, markdown]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
       - id: end-of-file-fixer
         types: [python]
       - id: fix-byte-order-marker
+      - id: name-tests-test
+        args: ["--pytest-test-first"]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
         types: [python, yaml, markdown]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# TopoStats
+
 <div align="center">
 
 [![PyPI version](https://badge.fury.io/py/topostats.svg)](https://badge.fury.io/py/topostats)
@@ -16,8 +18,6 @@ status](https://results.pre-commit.ci/badge/github/AFM-SPM/TopoStats/main.svg)](
 </div>
 
 --------------------------------------------------------------------------------
-
-# TopoStats
 
 An AFM image analysis program to batch process data and obtain statistics from images.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ run_topostats --config my_config.yaml
 On completion a copy of the configuration that was used is written to the output directory so you have a record of the
 parameters used to generate the results you have. This file can be used in subsequent runs of TopoStats.
 
-
 ## YAML Structure
 
 YAML files have key and value pairs, the first word, e.g. `base_dir` is the key this is followed by a colon to separate
@@ -49,14 +48,9 @@ upper:
   - 400
 ```
 
-
 ## Fields
 
-
-
 Aside from the comments in YAML file itself the fields are described below.
-
-
 
 | Section         | Sub-Section                  | Data Type  | Default        | Description                                                                                                                                                                                                                                                  |
 |:----------------|:-----------------------------|:-----------|:---------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -70,7 +64,7 @@ Aside from the comments in YAML file itself the fields are described below.
 | `filter`        | `run`                        | boolean    | `true`         | Whether to run the filtering stage, without this other stages won't run so leave as `true`.                                                                                                                                                                  |
 |                 | `threshold_method`           | str        | `std_dev`      | Threshold method for filtering, options are `ostu`, `std_dev` or `absolute`.                                                                                                                                                                                 |
 |                 | `otsu_threshold_multiplier`  | float      | `1.0`          |                                                                                                                                                                                                                                                              |
-|                 | `threshold_std_dev`          | float      | ` 1.0`         |                                                                                                                                                                                                                                                              |
+|                 | `threshold_std_dev`          | float      | `1.0`         |                                                                                                                                                                                                                                                              |
 |                 | `threshold_absolute_lower`   | float      | `-1.0`         |                                                                                                                                                                                                                                                              |
 |                 | `threshold_absolute_upper`   | float      | `1.0`          |                                                                                                                                                                                                                                                              |
 |                 | `gaussian_size`              | float      | `0.5`          | The number of standard deviations to build the Gaussian kernel and thus affects the degree of blurring. See [skimage.filters.gaussian](https://scikit-image.org/docs/dev/api/skimage.filters.html#skimage.filters.gaussian) and `sigma` for more information |
@@ -82,8 +76,8 @@ Aside from the comments in YAML file itself the fields are described below.
 |                 | `threshold_method`           | float      | `std_dev`      | Threshold method for grain finding.  Options : `otsu`, `std_dev`, `absolute`                                                                                                                                                                                 |
 |                 | `otsu_threshold_multiplier`  |            | `1.0`          | Factor by which the derived Otsu Threshold should be scaled.                                                                                                                                                                                                 |
 |                 | `threshold_std_dev`          |            | `1.0`          |                                                                                                                                                                                                                                                              |
-|                 | `  threshold_absolute_lower` |            | `1.0`          |                                                                                                                                                                                                                                                              |
-|                 | `  threshold_absolute_upper` |            | `1.0`          |                                                                                                                                                                                                                                                              |
+|                 | `threshold_absolute_lower` |            | `1.0`          |                                                                                                                                                                                                                                                              |
+|                 | `threshold_absolute_upper` |            | `1.0`          |                                                                                                                                                                                                                                                              |
 |                 | `absolute_area_threshold`    | dictionary |                |                                                                                                                                                                                                                                                              |
 |                 | `...upper`                   | list       | `[30,3000]`    | Height above surface [Low, High] in nm^2 (also takes null)                                                                                                                                                                                                   |
 |                 | `...lower`                   |            | `[null, null]` | Height below surface [Low, High] in nm^2 (also takes null)                                                                                                                                                                                                   |
@@ -111,7 +105,6 @@ Aside from the comments in YAML file itself the fields are described below.
 Plots summarising the distribution of metrics are generated by default. The behaviour is controlled by a configuration
 file. The default example can be found in [`topostats/summary_config.yaml`](). The fields of this file are described below.
 
-
 | Section        | Sub-Section | Data Type                  | Default           | Description                                                                                                             |
 |:---------------|:------------|:---------------------------|:------------------|:------------------------------------------------------------------------------------------------------------------------|
 | `output_dir`   |             | `str`                      | `./output/`       | Where output plots should be saved to.                                                                                  |
@@ -131,7 +124,6 @@ file. The default example can be found in [`topostats/summary_config.yaml`](). T
 | `palette`      |             | `str`                      | `bright`          | Seaborn color palette. Options `colorblind`, `deep`, `muted`, `pastel`, `bright`, `dark`, `Spectral`, `Set2`            |
 | `stats_to_sum` |             | `list`                     | `str`             | A list of strings of variables to plot, comment (placing a `#` at the start of the line) and uncomment as required. Possible values are `area`, `area_cartesian_bbox`, `aspect_ratio`, `banding_angle`, `contour_lengths`, `end_to_end_distance`, `height_max`, `height_mean`, `height_median`, `height_min`, `radius_max`, `radius_mean`, `radius_median`, `radius_min`, `smallest_bounding_area`, `smallest_bounding_length`, `smallest_bounding_width`, `volume` |
 
-
 ## Validation
 
 Configuration files are validated against a schema to check that the values in the configuration file are within the
@@ -144,7 +136,6 @@ which denotes the current directory or one or more `../` which means the higher 
 directory. You can always find the current directory you are in using the `pwd` (`p`rint `w`orking `d`irectory). If
 your work is in `/home/user/path/to/my/data` and `pwd` prints `/home/user` then the relative path to your data is
 `./path/to/my/data`. The `cd` command is used to `c`hange `d`irectory.
-
 
 ``` bash
 pwd

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,6 @@
 
 This document describes how to contribute to the development of this software.
 
-
 ## Contribution Workflow
 
 ### Create an Issue
@@ -11,7 +10,6 @@ Before starting please search for and review the existing [issues](https://githu
 `open` and `closed`) and [pull requests](https://github.com/AFM-SPM/TopoStats/pulls) to see if anyone has reported the
 bug or requested the feature already or work is in progress. If nothing exists then you should create a [new
 issue](https://github.com/AFM-SPM/TopoStats/issues/new/choose) using one of the templates provided.
-
 
 ### Cloning the repository
 
@@ -46,7 +44,6 @@ work on the issue you wish to address. It is not compulsory but we try to use a 
 that shows who has worked on the branch, the issue it pertains to and a short description of the work. To which end you
 will see branches with the form `<GITHUB_USERNAME>/<GITHUB_ISSUE>-<DESCRIPTION>`. Some examples are shown below...
 
-
 | Branch                                | User                                                | Issue                                                  | Description                                                                              |
 |:--------------------------------------|:----------------------------------------------------|:-------------------------------------------------------|:-----------------------------------------------------------------------------------------|
 | `ns-rse/259-contributing`             | [`ns-rse`](https://github.com/ns-rse)               | [259](https://github.com/AFM-SPM/TopoStats/issues/259) | `contributing` short for the issue subject _Add contributing section to documentation_.  |
@@ -71,7 +68,6 @@ git checkout ns-rse/000-fix-an-issue
 
 You can now start working on your issue and making regular commits, but please bear in mind the following section on
 Coding Standards.
-
 
 ## Coding Standards
 
@@ -103,7 +99,6 @@ locally install `pre-commit` in your virtual environment and then install the co
 (**NB** this will download specific virtual environments that `pre-commit` uses when running hooks so the first time
 this is run may take a little while).
 
-
 ``` bash
 pip install .[dev]
 pre-commit install --install-hooks
@@ -129,14 +124,12 @@ by way of the `missing-function-docstring` condition.
 Further, when new methods are incorporated into the package that introduce changes to the configuration they should be
 documented under [Parameter Configuration](configuration)
 
-
 ### Testing
 
 New features should have unit-tests written and included under the `tests/` directory to ensure the functions work as
 expected. The [pytest](https://docs.pytest.org/en/latest/) framework is used for running tests along with a number of
 plugins ([pytest-regtest](https://gitlab.com/uweschmitt/pytest-regtest) for regression testing;
 [pytest-mpl](https://github.com/matplotlib/pytest-mpl) for testing generated Matplotlib images).
-
 
 ## Configuration
 
@@ -147,7 +140,6 @@ have to ensure that the default configuration file (`topostats/default.yaml`) is
 Further the `topostats.validation.validate.config()` function, which checks a valid configuration file with all necessary
 fields has been passed when invoking `run_topostats`, will also need updating to include new options in the Schema against
 which validation of configuration files is made.
-
 
 ### IDE Configuration
 

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -2,7 +2,6 @@
 
 The resulting statistics file has the following fields.
 
-
 | Column / field / feature | Description | Units |
 | --- | --- | --- |
 | `centre_x` | x co-ordinate of object centre. | m |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -38,7 +38,7 @@ The process of removing [tilt](#tilt) from an image.
 ### GitHub
 
 [GitHub](https://www.github.com) is a website for sharing and collaboratively working on software that is version
-controlled using [Git](#Git).
+controlled using [Git](#git).
 
 ### grains
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,6 @@
 [discussion](https://github.com/AFM-SPM/TopoStats/discussions) for possible solutions. If your problem isn't covered
 then please do not hesitate to ask a question.
 
-
 TopoStats is a [Python](https://www.python.org) package designed to run at the command line. If you are using Microsoft
 Windows you should use
 [Powershell](https://learn.microsoft.com/en-us/powershell/scripting/learn/ps101/01-getting-started?view=powershell-7.3). You
@@ -81,7 +80,6 @@ git clone https://github.com/AFM-SPM/TopoStats.git
 git clone git@github.com:AFM-SPM/TopoStats.git
 ```
 
-
 #### Cloning Using GitKraken
 
 If you are using GitKraken you can clone the repository by selecting "Clone" and then "GitHub.com" and typing
@@ -90,7 +88,6 @@ If you are using GitKraken you can clone the repository by selecting "Clone" and
 
 Alternatively you can "Clone with URL" and enter `https://github.com/AFM-SPM/TopoStats.git` as the URL to clone from,
 selecting a destination to clone to.
-
 
 #### Installing TopoStats from the Cloned Repository
 
@@ -108,7 +105,6 @@ i.e. `pip install -e .`.
 If you wish to develop features or address an existing [issue](https://github.com/AFM-SPM/TopoStats/issues) please refer
 to the [contributing](contributing) section.
 
-
 ## Tests
 
 One of the major changes in the refactoring is the introduction of unit tests. These require certain packages to be
@@ -117,14 +113,12 @@ installed which are not installed to your virtual environment by
 contribute to the development of TopoStats and making changes to the code base you will likely want to be able to run
 the tests. Install the necessary dependencies to do so with...
 
-
 ``` bash
 cd TopoStats
 git checkout dev
 pip install ".[tests]"
 pytest
 ```
-
 
 ## Git
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -21,7 +21,6 @@ The resulting statistics are written to a [CSV file](data_dictionary) and option
 various stages of the processing as well as cropped images of each grain. The amount of images produced is also
 configurable.
 
-
 An schematic overview of the classes and methods that are run in processing files can be found in the
 [workflows](workflows) page along with more detailed information on [installation](installation), [usage](usage),
 [configuration](configuration) and [contributing](contributing).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,7 +133,6 @@ can be found under the [configuration](configuration) section.
 Here we will go through generating a configuration file to edit and some of the common changes that you are likely to
 want to make to the default configuration and how to make them.
 
-
 ### Generating Configuration File
 
 TopoStats will use some reasonable default parameters by default, but typically you will want to customise the
@@ -155,12 +154,10 @@ sample_image_scan_2022-12-08-1204.spm
 You can now edit and/or rename the `my_config.yaml`. It can be called anything you want,
 e.g. `todays_first_run_configuration.yaml` is a valid name.
 
-
 ### Editing `config.yaml`
 
 **IMPORTANT** This file is an ASCII text file and  you should use NotePad (Windows), TextEdit (OSX) or Nano/Emacs/Vim
 (GNU/Linux) or any other text editor. Do _not_ use Microsoft Word or any other Word Processor to edit this file.
-
 
 You can now start customising the configuration you are going to run TopoStats with. All fields have defaults but the
 ones you may want to change are....
@@ -183,7 +180,6 @@ ones you may want to change are....
   `.spm` but other file format support is in the pipeline.
 * `plotting` : `image_set` (default `core`) specifies which steps of the processing to plot images of. The value `all`
   gets images for all stages, `core` saves only a subset of images.
-
 
 Most of the other configuration options can be left on their default values for now. Once you have made any changes save
 the file and return to your terminal.
@@ -283,7 +279,6 @@ configured. It uses the plotting library [Seaborn](https://seaborn.pydata.org/) 
 [Matplotlib](https://matplotlib.org/)) to produce basic plots, which are not intended for publication. If you want to
 tweak or customise plots it is recommended to load `all_statistics.csv` into a [Jupyter Notebook](https://jupyter.org)
 and generate the plots you want there. A sample notebook is included to show how to do this.
-
 
 ### Configuring Summary Plots
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,8 +2,7 @@
 
 This section gives a broad overview of the steps taken in processing images.
 
-
-## Topotracing : Processing a single `.spm` file.
+## Topotracing : Processing a single `.spm` file
 
 Topotracing loads images from `.spm` files and extracts the specified channel, performing various filtering stages
 (`Filters()` class) before finding grains (`Grains()` class) and then calculating statistics for each grain


### PR DESCRIPTION
Closes #490

One off linting of Markdown files.

Tested `name-tests-test` but opted to remove it as the hook only supports `.*_test.py` whilst [`pytest`](https://docs.pytest.org/en/7.1.x/how-to/usage.html#usage) and the convention we've used supports `test_*.py`.