### PR TITLE
Sylvia whittle/514 grainstats assignment

### DIFF
--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -295,6 +295,9 @@ def toposum(config: dict) -> Dict:
     """
     if "df" not in config.keys():
         config["df"] = pd.read_csv(config["csv_file"])
+    if config["df"].empty:
+        LOGGER.info("[plotting] No stats in DataFrame. Exiting...")
+        sys.exit()
     violin = config.pop("violin")
     all_stats_to_sum = config.pop("stats_to_sum")
     pickle_plots = config.pop("pickle_plots")

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -244,4 +244,5 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple =
         Empty Pandas DataFrame.
     """
     empty_df = pd.DataFrame([np.repeat(np.nan, len(columns))], columns=columns)
-    return empty_df.set_index(index, inplace=True)
+    empty_df.set_index(index, inplace=True)
+    return empty_df

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -230,7 +230,7 @@ def get_thresholds(
     return thresholds
 
 
-def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple = ("molecule_number")) -> pd.DataFrame:
+def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple = "molecule_number") -> pd.DataFrame:
     """Create an empty data frame for returning when no results are found.
 
     Parameters


### PR DESCRIPTION
Closes #514 

Small patch to fix #514 where a grainstats DataFrame was not being returned from `create_empty_dataframe()` due to the `inplace=True` flag of `set_index` meant that the returned value was None, rather than the dataframe which was being acted on.

As a result of fixing that issue, `plotting.py` had an issue where it could not handle a dataframe of only `nan`s, and so I have added a hasty solution to fix that, detecting empty dataframes and simply declaring it and exiting. Please do suggest better alternatives or behaviours if you can think of any.

I also removed some parentheses around a tuple which feels wrong, but Pylint knows best.


Please verify that this fixes #514 on your system too if you have time. Thanks! 😄 