### PR TITLE
Consistent bin-width in histograms summarising multiple images

### DIFF
--- a/notebooks/02-Summary-statistics-and-plots.ipynb
+++ b/notebooks/02-Summary-statistics-and-plots.ipynb
@@ -272,7 +272,7 @@
    "metadata": {},
    "source": [
     "The bin width in above figure varies for each \"image\" (`smaller`, `larger` and `minicircle`). This is because each\n",
-    "images data is plotted separately (but overlaid on the same graph) and determined dynamically from the range of the data\n",
+    "image's data is plotted separately (but overlaid on the same graph) and determined dynamically from the range of the data\n",
     "and is a known shortcoming of Pandas (see [ENH: groupby.hist bins don't match\n",
     "#22222](https://github.com/pandas-dev/pandas/issues/22222). To get around this you can specify the number of `bins`\n",
     "explicitly based on the range of _all_ observed data (i.e. `min` to `max`) using `np.linspace()` (from the NumPy\n",
@@ -293,9 +293,7 @@
     "bins = 20\n",
     "df_three_images[\"contour_lengths\"].groupby(\"image\").plot.hist(\n",
     "    figsize=(16, 9),\n",
-    "    # bins=20,\n",
-    "    # bins=np.linspace(start, stop, num=x), # Use this if there are different number of grains per image\n",
-    "    bins=np.linspace(min, max, num=bins),  # Use this if there are different number of grains per image\n",
+    "    bins=np.linspace(min, max, num=bins),  # Sets the bin width based on total range\n",
     "    title=\"Contour Lengths\",\n",
     "    alpha=0.5,\n",
     ")"

--- a/notebooks/02-Summary-statistics-and-plots.ipynb
+++ b/notebooks/02-Summary-statistics-and-plots.ipynb
@@ -238,8 +238,8 @@
     "    return _df\n",
     "\n",
     "\n",
-    "smaller = scale_df(df, scale=0.9, image=\"smaller\")\n",
-    "larger = scale_df(df, scale=1.25, image=\"larger\")\n",
+    "smaller = scale_df(df, scale=0.4, image=\"smaller\")\n",
+    "larger = scale_df(df, scale=1.5, image=\"larger\")\n",
     "df_three_images = pd.concat([smaller, df, larger])"
    ]
   },
@@ -254,14 +254,48 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9820d259-680e-49fd-a1eb-e14d200a0b7a",
+   "id": "afd797d8-9775-4f62-8da9-d135eaa34b49",
    "metadata": {},
    "outputs": [],
    "source": [
     "df_three_images[\"contour_lengths\"].groupby(\"image\").plot.hist(\n",
     "    figsize=(16, 9),\n",
     "    bins=20,\n",
+    "    title=\"Contour Lengths\",\n",
+    "    alpha=0.5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b362e9af-8577-4c44-8afb-199ef2535607",
+   "metadata": {},
+   "source": [
+    "The bin width in above figure varies for each \"image\" (`smaller`, `larger` and `minicircle`). This is because each\n",
+    "images data is plotted separately (but overlaid on the same graph) and determined dynamically from the range of the data\n",
+    "and is a known shortcoming of Pandas (see [ENH: groupby.hist bins don't match\n",
+    "#22222](https://github.com/pandas-dev/pandas/issues/22222). To get around this you can specify the number of `bins`\n",
+    "explicitly based on the range of _all_ observed data (i.e. `min` to `max`) using `np.linspace()` (from the NumPy\n",
+    "package) along with the number of bins across the _total_ space (bins)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9820d259-680e-49fd-a1eb-e14d200a0b7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "min = df_three_images[\"contour_lengths\"].min()\n",
+    "max = df_three_images[\"contour_lengths\"].max()\n",
+    "bins = 20\n",
+    "df_three_images[\"contour_lengths\"].groupby(\"image\").plot.hist(\n",
+    "    figsize=(16, 9),\n",
+    "    # bins=20,\n",
     "    # bins=np.linspace(start, stop, num=x), # Use this if there are different number of grains per image\n",
+    "    bins=np.linspace(min, max, num=bins),  # Use this if there are different number of grains per image\n",
     "    title=\"Contour Lengths\",\n",
     "    alpha=0.5,\n",
     ")"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -107,7 +107,7 @@ def test_toposum(summary_config: dict) -> None:
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_kde(summary_config: dict) -> None:
-    """Regression test for plotkde()."""
+    """Regression test for sns_plot() with a single KDE."""
     summary_config["hist"] = False
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     fig, _ = _toposum.sns_plot()
@@ -116,7 +116,7 @@ def test_plot_kde(summary_config: dict) -> None:
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_kde_multiple_images(summary_config: dict, toposum_multiple_images: pd.DataFrame) -> None:
-    """Regression test for plotkde()."""
+    """Regression test for sns_plot() with multiple KDE."""
     summary_config["hist"] = False
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     _toposum.melted_data = toposum_multiple_images
@@ -126,7 +126,7 @@ def test_plot_kde_multiple_images(summary_config: dict, toposum_multiple_images:
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_hist(summary_config: dict) -> None:
-    """Regression test for plotkde()."""
+    """Regression test for sns_plot() with a single histogram."""
     summary_config["kde"] = False
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     fig, _ = _toposum.sns_plot()
@@ -135,7 +135,7 @@ def test_plot_hist(summary_config: dict) -> None:
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_hist_multiple_images(summary_config: dict, toposum_multiple_images: pd.DataFrame) -> None:
-    """Regression test for plotkde()."""
+    """Regression test for sns_plot() with multiple overlaid histograms."""
     summary_config["kde"] = False
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     _toposum.melted_data = toposum_multiple_images
@@ -162,7 +162,7 @@ def test_plot_hist_kde_multiple_images(summary_config: dict, toposum_multiple_im
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_violin(summary_config: dict) -> None:
-    """Test plotting Kernel Density Estimate and Histogram for area."""
+    """Test plotting Kernel Density Estimate and Histogram for area for a single image."""
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     fig, _ = _toposum.sns_violinplot()
     return fig
@@ -170,7 +170,7 @@ def test_plot_violin(summary_config: dict) -> None:
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/distributions/")
 def test_plot_violin_multiple_images(summary_config: dict, toposum_multiple_images: pd.DataFrame) -> None:
-    """Test plotting Kernel Density Estimate and Histogram for area."""
+    """Test plotting Kernel Density Estimate and Histogram for area with multiple images."""
     _toposum = TopoSum(csv_file=RESOURCES / "minicircle_default_all_statistics.csv", **summary_config)
     _toposum.melted_data = toposum_multiple_images
     fig, _ = _toposum.sns_violinplot()


### PR DESCRIPTION
Closes #479

Contrary to the title `plotting.py`, which uses Seaborn, produces consistent bin-width when the range of values differs between images. The Jupyter Notebook (`notebooks/02-Summary-statistics-and-plots.ipynb`) uses Pandas for loading data and plotting it (a deliberate choice to reduce the number of packages users would encounter) and it is Pandas which produces the different bin-widths (see [#22222 ENH: groupby.hist bins don't match](https://github.com/pandas-dev/pandas/issues/22222)).

The Notebook has been updated to show how to use `np.linspace()` across the total range of data.

Docstrings of `tests/test_plotting.py` have also been improved.