### PR TITLE
Enabling multiple versions of documentation

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -6,7 +6,7 @@ on:
     tags:
       - v*
 
-# workflow_dispatch:        # Un comment line if you also want to trigger action manually
+workflow_dispatch:        # Un comment line if you also want to trigger action manually
 
 jobs:
   sphinx_docs_to_gh-pages:
@@ -34,3 +34,5 @@ jobs:
           sphinxapiexclude: '../*setup* ../*tests* ../*.ipynb ../demo.py ../make_baseline.py ../jupyter_notebook_config.py ../demo_ftrs.py'
           sphinxapiopts: '--separate -o . ../'
           sphinxopts: ''
+          multiversion: true
+          multiversionopts: ''

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ autodoc_mock_imports = ["pygtk", "gwy", "numpy", "pandas", "matplotlib", "seabor
 # -- Project information -----------------------------------------------------
 
 project = "TopoStats"
-copyright = "2021, TopoStats authors"
+copyright = "2023, TopoStats authors"
 author = "TopoStats authors"
 
 # The short X.Y version
@@ -53,11 +53,19 @@ extensions = [
     "myst_parser",
     "numpydoc",
     "sphinx_markdown_tables",
+    "sphinx_multiversion",
     "sphinxcontrib.mermaid",
 ]
 
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
+
+html_sidebars = {
+    "**": [
+        "versioning.html",
+    ],
+}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -190,3 +198,17 @@ epub_exclude_files = ["search.html"]
 
 # -- Extension configuration -------------------------------------------------
 numpydoc_class_members_toctree = False
+
+# sphinx-multiversion (https://holzhaus.github.io/sphinx-multiversion/master/configuration.html)
+smv_tag_whitelist = r"^v\d+.*$"  # Tags begining with v#
+smv_branch_whitelist = r"^main$"  # main branch
+# If testing changes locally comment out the above and the smv_branch_whitelist below instead. Replace the branch name
+# you are working on ("ns-rse/466-doc-versions" in the example below) with the branch you are working on and run...
+#
+# cd docs
+# sphinx-multiversion . _build/html
+#
+# smv_branch_whitelist = r"^(main|ns-rse/466-doc-versions)$"  # main branch
+smv_released_pattern = r"^tags/.*$"  # Tags only
+# smv_released_pattern = r"^(/.*)|(main).*$"  # Tags and HEAD of main
+smv_outputdir_format = "{ref.name}"

--- a/docs/data_dictionary.md
+++ b/docs/data_dictionary.md
@@ -2,30 +2,31 @@
 
 The resulting statistics file has the following fields.
 
-| Column / field / feature | Description | Units |
-| --- | --- | --- |
-| `centre_x` | x co-ordinate of object centre. | m |
-| `centre_y` | y co-ordinate of object centre. | m |
-| `radius_min` | | |
-| `radius_max` | | |
-| `radius_mean` | | |
-| `radius_median` | | |
-| `height_min` | | |
-| `height_max` | | |
-| `height_median` | | |
-| `height_mean` | | |
-| `volume` | | |
-| `area` | | |
-| `area_cartesian_bbox` | | |
-| `smallest_bounding_width` | | |
-| `smallest_bounding_length` | | |
-| `smallest_bounding_area` | | |
-| `aspect_ratio` | | |
-| `threshold` | | |
-| `max_feret` | | |
-| `min_feret` | | |
-| `Contour Lengths` | | |
-| `Circular` | | |
-| `End to End Distance` | | |
-| `Image Name` | | |
-| `Basename` | | |
+| Column / field / feature   | Description                                                                                          | Type    | Units            |
+|----------------------------|------------------------------------------------------------------------------------------------------|---------|------------------|
+| `image`                    | Filename (minus extension) of scan.                                                                  | `str`   | N/A              |
+| `threshold`                | Whether grain is `above` or `below` a threshold.                                                     | `str`   | N/A              |
+| `molecule_number`          | Number of found grain (starts at `0`)                                                                | `int`   | N/A              |
+| `centre_x`                 | x co-ordinate of grain centre.                                                                       | `float` | m                |
+| `centre_y`                 | y co-ordinate of grain centre.                                                                       | `float` | m                |
+| `radius_min`               | minimum distance from the centroid to edge of the grain.                                             | `float` | m                |
+| `radius_max`               | maximum distance from the centroid to edge of the grain.                                             | `float` | m                |
+| `radius_mean`              | mean distance from the centroid to the edge of the grain.                                            | `float` | m                |
+| `radius_median`            | median distance from the centroid to the edge of the grain.                                          | `float` | m                |
+| `height_min`               | Minimum height of grain.                                                                             | `float` | m                |
+| `height_max`               | Maximum height of grain.                                                                             | `float` | m                |
+| `height_median`            | Median height of grain.                                                                              | `float` | m                |
+| `height_mean`              | Mean height of grain.                                                                                | `float` | m                |
+| `volume`                   | Volume of the grain calculated as the number of pixels multiplied by each height and scaled to metres.         | `float` | m^3              |
+| `area`                     | Area of the grain itself calculated as the number of pixels scaled to metres.      | `float` | m^2              |
+| `area_cartesian_bbox`      | Area of the bounding box for the grain along the cartesian axes. (Not the smallest bounding box).    | `float` | m^2              |
+| `smallest_bounding_width`  | Width of the smallest bounding box for the grain (not along cartesian axes).                         | `float` | m                |
+| `smallest_bounding_length` | Length of the smallest bounding box for the grain (not along cartesian axes).                        | `float` | m                |
+| `smallest_bounding_area`   | Area of the smallest bounding box for the grain (not along cartesian axes).                          | `float` | m^2              |
+| `aspect_ratio`             | Aspect ratio of the grain (length / width), always >= 1.                                             | `float` | N/A              |
+| `max_feret`                | Longest length of the grain (see [Feret diameter](https://en.wikipedia.org/wiki/Feret_diameter)).    | `float` | m                |
+| `min_feret`                | Shortest width of the grain (see [Feret diameter](https://en.wikipedia.org/wiki/Feret_diameter)).    | `float` | m                |
+| `contour_lengths`          | UNKNOWN                                                                                              | `float` | m                |
+| `circular`                 | Whether the grain is a circular loop or not.                                                         | `float` | `True` / `False` |
+| `end_to_end_distance`      | UNKNOWN                                                                                              | `float` | m                |
+| `basename`                 | Directory in which images was found.                                                                 | `str`   | N/A              |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,9 +8,9 @@ are not answered here please consider starting a [new
 discussion](https://github.com/AFM-SPM/TopoStats/discussions/new?category=q-a) in the TopoStats Discussion section of
 the GitHub repository. Developers will endeavour to help you resolve your problem and it may get added to this page.
 
-# General Questions
+## General Questions
 
-## My files image files are on a mounted Google Drive, can I process them there?
+### My files image files are on a mounted Google Drive, can I process them there?
 
 Maybe! We have had mixed success with processing images that are located on Google Drive and mounted on your local
 computer.
@@ -18,6 +18,6 @@ If you find you are encountering errors such as `FileExistsError` (see
 [#201](https://github.com/AFM-SPM/TopoStats/issues/201)) then please copy your files to a local drive on your computer
 for processing and then copy the results back to the network drive.
 
-# Common Errors
+## Common Errors
 
 Common errors that are encountered along with explanations are listed below.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -17,7 +17,7 @@ where columns of data are separated by commas.
 
 ### DNA
 
-[Deoxribonucleic acid (DNA)](https://en.wikipedia.org/wiki/DNA) is a double-helix polymer of four molecules Cytosine,
+[Deoxyribonucleic acid (DNA)](https://en.wikipedia.org/wiki/DNA) is a double-helix polymer of four molecules Cytosine,
 Guanine, Adenine and Thymine. It is the genetic material of the vast majority of organisms (some viruses use
 [Ribonucleic Acid (RNA)](https://en.wikipedia.org/wiki/RNA) as their genetic material).
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,8 +18,8 @@ listed below to find out more.
     workflow
     data_dictionary
     related_software
-    faq
     glossary
+    faq
 
 .. toctree::
    :maxdepth: 1

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -11,6 +11,7 @@ be found in the `notebook/` directory after cloning the GitHub repository.
 | `00-Walkthrough-minicircle.ipynb`       | Step-by-step walkthrough of processing `minicircle.spm` from the `tests/resources/` directory.                          |
 | `01-Walthrhgouh-interactive.ipynb`      | **Work in Progress** As above but uploading a single scan. Will be deployed in Google Colab/Binder for interactive use. |
 | `02-Summary-statistics-and-plots.ipynb` | Plotting statistics interactively.                                                                                      |
+| `03-Plotting-scans.ipynb`               | Plotting NumPy arrays of scans from different stages of processing.                                                     |
 
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ docs = [
   "sphinxcontrib-mermaid",
   "sphinxcontrib-napoleon",
   "sphinx-autodoc-typehints",
+  "sphinx-multiversion",
 ]
 dev = [
   "black",


### PR DESCRIPTION
Closes #466

* Limits to tagged release versions and `main` branch
* Includes changes to GitHub actions to build documentation
* Requires inclusion of an `index.html` to the `gh-pages` to [redirect](https://holzhaus.github.io/sphinx-multiversion/master/github_pages.html#redirecting-from-the-document-root).