### PR TITLE
Add sphinx-autoapi; removing pre-generated API .rst files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ version = ".".join(release.split(".")[:2])
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "autoapi.extension",
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
@@ -199,7 +200,10 @@ epub_exclude_files = ["search.html"]
 # -- Extension configuration -------------------------------------------------
 numpydoc_class_members_toctree = False
 
-# sphinx-multiversion (https://holzhaus.github.io/sphinx-multiversion/master/configuration.html)
+# sphinx-autoapi https://sphinx-autoapi.readthedocs.io/en/latest/
+autoapi_dirs = ["../topostats"]
+
+# sphinx-multiversion https://holzhaus.github.io/sphinx-multiversion/master/configuration.html
 smv_tag_whitelist = r"^v\d+.*$"  # Tags begining with v#
 smv_branch_whitelist = r"^main$"  # main branch
 # If testing changes locally comment out the above and the smv_branch_whitelist below instead. Replace the branch name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,23 +64,24 @@ tests = [
 ]
 docs = [
   "Sphinx",
-  "sphinx_rtd_theme",
-  "numpydoc",
   "myst_parser",
+  "numpydoc",
   "pydata_sphinx_theme",
-  "sphinx_markdown_tables",
-  "sphinxcontrib-mermaid",
-  "sphinxcontrib-napoleon",
+  "sphinx-autoapi",
   "sphinx-autodoc-typehints",
   "sphinx-multiversion",
+  "sphinx_markdown_tables",
+  "sphinx_rtd_theme",
+  "sphinxcontrib-mermaid",
+  "sphinxcontrib-napoleon",
 ]
 dev = [
+  "Flake8-pyproject",
   "black",
-  "pre-commit",
-  "pylint",
   "flake8",
   "flake8-print",
-  "Flake8-pyproject",
+  "pre-commit",
+  "pylint",
   "pyupgrade",
 ]
 pypi = [


### PR DESCRIPTION
Closes #532

The problem was that [sphinx-multiversion](https://holzhaus.github.io/sphinx-multiversion/master/configuration.html) checks out each branch/tag that it is building for prior to build documentation. If there are no `.rst` files in that branch/commit for API documentation then the API docs can not be generated.

The solution is to use [sphinx-autoapi](https://sphinx-autoapi.readthedocs.io/en/latest/) to automatically generate the `.rst` files for the API on each run that `sphinx-multiversion` makes on each branch/tag it is building documentation for.

Also sorts package dependencies in `pyproject.toml`.