### PR TITLE
Fix summary_config undefined in completion message

### DIFF
--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -350,6 +350,11 @@ def completion_message(config: Dict, img_files: List, summary_config: Dict, imag
     -------
     None
     """
+
+    if summary_config is not None:
+        distribution_plots_message = str(summary_config["output_dir"])
+    else:
+        distribution_plots_message = "Disabled. Enable in config 'summary_stats/run' if needed."
     LOGGER.info(
         f"\n\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
         f"  TopoStats Version           : {__version__}\n"
@@ -359,7 +364,7 @@ def completion_message(config: Dict, img_files: List, summary_config: Dict, imag
         f"  Successfully Processed^1    : {images_processed} ({(images_processed * 100) / len(img_files)}%)\n"
         f"  Configuration               : {config['output_dir']}/config.yaml\n"
         f"  All statistics              : {str(config['output_dir'])}/all_statistics.csv\n"
-        f"  Distribution Plots          : {str(summary_config['output_dir'])}\n\n"
+        f"  Distribution Plots          : {distribution_plots_message}\n\n"
         f"  Email                       : topostats@sheffield.ac.uk\n"
         f"  Documentation               : https://afm-spm.github.io/topostats/\n"
         f"  Source Code                 : https://github.com/AFM-SPM/TopoStats/\n"

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -245,7 +245,6 @@ def main(args=None):
         LOGGER.error(error)
 
     # Summary Statistics and Plots
-    summary_config = None
     if config["summary_stats"]["run"]:
         # Load summary plots/statistics configuration and validate, location depends on command line args or value in
         # any config file given, if neither are provided the default topostats/summary_config.yaml is loaded
@@ -282,6 +281,8 @@ def main(args=None):
                 "There are no results to plot, either you have disabled grains/grainstats/dnatracing or there "
                 "have been errors, please check the log for further information."
             )
+    else:
+        summary_config = None
 
     # Write statistics to CSV
     if isinstance(results, pd.DataFrame):

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -245,6 +245,7 @@ def main(args=None):
         LOGGER.error(error)
 
     # Summary Statistics and Plots
+    summary_config = None
     if config["summary_stats"]["run"]:
         # Load summary plots/statistics configuration and validate, location depends on command line args or value in
         # any config file given, if neither are provided the default topostats/summary_config.yaml is loaded


### PR DESCRIPTION
Closes #537 

This error was caused by the `summary_stats`/`run` option being `false`, and so the variable `summary_config` was never assigned before being accessed by `completion_message`.

- This PR fixes the issue of the call to `completion_message` crashing due to an unassigned variable `summary_config`, by setting `summary_config` to `None` by default.
- It also adds a message that replaces the directory for the summary stats in the completion message (if the summary stats are not generated).