### PR TITLE
Sylvia whittle/507 svd nonconverging

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -371,6 +371,7 @@ class LoadScans:
         self.image = None
         self.pixel_to_nm_scaling = None
         self.img_dict = {}
+        self.MINIMUM_IMAGE_SIZE = 10
 
     def load_spm(self) -> tuple:
         """Extract image and pixel to nm scaling from the Bruker .spm file.
@@ -731,32 +732,32 @@ class LoadScans:
         """Method to extract image, filepath and pixel to nm scaling value, and append these to the
         img_dic object.
         """
+
+        suffix_to_loader = {
+            ".spm": self.load_spm,
+            ".jpk": self.load_jpk,
+            ".ibw": self.load_ibw,
+            ".gwy": self.load_gwy,
+        }
+
         for img_path in self.img_paths:
             self.img_path = img_path
             self.filename = img_path.stem
             suffix = img_path.suffix
             LOGGER.info(f"Extracting image from {self.img_path}")
             LOGGER.debug(f"File extension : {suffix}")
-            if suffix == ".spm":
-                self.image, self.pixel_to_nm_scaling = self.load_spm()
-                self.add_to_dic(
-                    self.filename, self.image, self.img_path.with_name(self.filename), self.pixel_to_nm_scaling
-                )
-            elif suffix == ".jpk":
-                self.image, self.pixel_to_nm_scaling = self.load_jpk()
-                self.add_to_dic(
-                    self.filename, self.image, self.img_path.with_name(self.filename), self.pixel_to_nm_scaling
-                )
-            elif suffix == ".ibw":
-                self.image, self.pixel_to_nm_scaling = self.load_ibw()
-                self.add_to_dic(
-                    self.filename, self.image, self.img_path.with_name(self.filename), self.pixel_to_nm_scaling
-                )
-            elif suffix == ".gwy":
-                self.image, self.pixel_to_nm_scaling = self.load_gwy()
-                self.add_to_dic(
-                    self.filename, self.image, self.img_path.with_name(self.filename), self.pixel_to_nm_scaling
-                )
+
+            # Check that the file extension is supported
+            if suffix in suffix_to_loader:
+                self.image, self.pixel_to_nm_scaling = suffix_to_loader[suffix]()
+                # Ensure the image is large enough in both dimensions to be processed, if not, do not add to image
+                # dictionary
+                if self.image.shape[0] < self.MINIMUM_IMAGE_SIZE or self.image.shape[1] < self.MINIMUM_IMAGE_SIZE:
+                    LOGGER.warning(f"Image {self.filename} too small: {self.image.shape} this image will be skipped.")
+                else:
+                    self.add_to_dic(
+                        self.filename, self.image, self.img_path.with_name(self.filename), self.pixel_to_nm_scaling
+                    )
             else:
                 raise ValueError(
                     f"File type {suffix} not yet supported. Please make an issue at \

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -85,6 +85,7 @@ def process_scan(
     # Filter Image
     if filter_config["run"]:
         filter_config.pop("run")
+        LOGGER.info(f"image dimensions: {image.shape}")
         LOGGER.info(f"[{filename}] : *** Filtering ***")
         filtered_image = Filters(
             image,


### PR DESCRIPTION
Closes #507 

Issue #507 stemmed from a file being too small in one of its dimensions to be able to have `np.polyfit` applied to it, hence the `numpy.linalg.LinAlgError: SVD did not converge in Linear Least Squares` error in the output log.

- Added a `LOGGER.info()` statement to list the shape of the input image: `[Fri, 28 Apr 2023 20:53:09] [INFO    ] [topostats] image dimensions: (1, 512)`

- Refactored the `get_data()` function in the `LoadScans` class in `io.py`, to reduce code duplication.

- Added a check for image size in `get_data()`, if the image is too small (less than 10 pixels in either dimension), it will not be added to the image dictionary of the `LoadScans` object, and thus will not be processed. This also triggers a `LOGGER.warning` message in the log, and the completion message reflects the image not processing: `  Successfully Processed^1    : 2 (66.66666666666667%)`.