### PR TITLE
Sylvia whittle/pandas reset index error

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,6 +1,7 @@
 """Test end-to-end running of topostats."""
 from pathlib import Path
 
+# pylint: disable=deprecated-module
 import imghdr
 import pytest
 
@@ -308,3 +309,23 @@ def test_process_stages(
 
     assert log_msg1 in caplog.text
     assert log_msg2 in caplog.text
+
+
+def test_process_scan_region_properties_is_none(
+    process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, caplog
+) -> None:
+    """Test capturing disabling GrainStats where no grains have been found."""
+    img_dic = load_scan_data.img_dict
+    process_scan_config["grains"]["absolute_area_threshold"] = [4000, 9000]
+    _, _ = process_scan(
+        img_path_px2nm=img_dic["minicircle"],
+        base_dir=BASE_DIR,
+        filter_config=process_scan_config["filter"],
+        grains_config=process_scan_config["grains"],
+        grainstats_config=process_scan_config["grainstats"],
+        dnatracing_config=process_scan_config["dnatracing"],
+        plotting_config=process_scan_config["plotting"],
+        output_dir=tmp_path,
+    )
+    assert "No grains to plot" in caplog.text
+    assert "No grains detected skipping calculation of grain statistics and DNA tracing." in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from topostats.utils import convert_path, update_config, get_thresholds, update_plotting_config
+from topostats.utils import (
+    convert_path,
+    update_config,
+    get_thresholds,
+    update_plotting_config,
+    create_empty_dataframe,
+    ALL_STATISTICS_COLUMNS,
+)
 
 
 THRESHOLD_OPTIONS = {
@@ -88,3 +95,12 @@ def test_get_thresholds_value_error(image_random: np.ndarray) -> None:
     """Test a ValueError is raised if an invalid value is passed to get_thresholds()"""
     with pytest.raises(ValueError):
         get_thresholds(image=image_random, threshold_method="mean", **THRESHOLD_OPTIONS)
+
+
+def test_create_empty_dataframe() -> None:
+    """Test the empty dataframe is created correctly."""
+    empty_df = create_empty_dataframe(ALL_STATISTICS_COLUMNS)
+
+    assert empty_df.index.name == "molecule_number"
+    assert empty_df.shape == (0, 26)
+    assert {"image", "basename", "area"}.intersection(empty_df.columns)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,5 +102,6 @@ def test_create_empty_dataframe() -> None:
     empty_df = create_empty_dataframe(ALL_STATISTICS_COLUMNS)
 
     assert empty_df.index.name == "molecule_number"
+    assert "molecule_number" not in empty_df.columns
     assert empty_df.shape == (0, 26)
     assert {"image", "basename", "area"}.intersection(empty_df.columns)

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -224,8 +224,8 @@ class Grains:
         uniq = np.delete(np.unique(image), 0)
         grain_count = 0
         LOGGER.info(
-            f"[{self.filename}] : Area thresholding grains | Thresholds: L:{below / self.pixel_to_nm_scaling**2:.2f},"
-            "U:{above / self.pixel_to_nm_scaling**2:.2f} px^2, L:{below:.2f}, U:{above:.2f} nm^2."
+            f"[{self.filename}] : Area thresholding grains | Thresholds: L: {(below / self.pixel_to_nm_scaling**2):.2f},"
+            f"U: {(above / self.pixel_to_nm_scaling**2):.2f} px^2, L: {below:.2f}, U: {above:.2f} nm^2."
         )
         for grain_no in uniq:  # Calculate grian area in nm^2
             grain_area = np.sum(image_cp == grain_no) * (self.pixel_to_nm_scaling**2)

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -154,7 +154,7 @@ def process_scan(
             LOGGER.warning(f"[{filename}] : No image, it is all masked.")
             results = create_empty_dataframe()
         if grains.region_properties is None:
-            LOGGER.warning(f"[{filename}] : No region properties found for grains.")
+            LOGGER.warning(f"[{filename}] : No grains have been detected, skipping calculation of grain statistics.")
             results = create_empty_dataframe()
         # Optionally plot grain finding stage if we have found grains and plotting is required
         if len(grains.region_properties) > 0:

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -267,15 +267,21 @@ def main(args=None):
 
         # If we don't have a dataframe or we do and it is all NaN there is nothing to plot
         if isinstance(results, pd.DataFrame) and not results.isna().values.all():
-            # If summary_config["output_dir"] does not match or is not a sub-dir of config["output_dir"] it
-            # needs creating
-            summary_config["output_dir"] = config["output_dir"] / "summary_distributions"
-            summary_config["output_dir"].mkdir(parents=True, exist_ok=True)
-            LOGGER.info(f"Summary plots and statistics will be saved to : {summary_config['output_dir']}")
+            if results.shape[0] > 1:
+                # If summary_config["output_dir"] does not match or is not a sub-dir of config["output_dir"] it
+                # needs creating
+                summary_config["output_dir"] = config["output_dir"] / "summary_distributions"
+                summary_config["output_dir"].mkdir(parents=True, exist_ok=True)
+                LOGGER.info(f"Summary plots and statistics will be saved to : {summary_config['output_dir']}")
 
-            # Plot summaries
-            summary_config["df"] = results.reset_index()
-            toposum(summary_config)
+                # Plot summaries
+                summary_config["df"] = results.reset_index()
+                toposum(summary_config)
+            else:
+                LOGGER.warning(
+                    "There are fewer than two grains that have been detected, so"
+                    " summary plots cannot be made for this image."
+                )
         else:
             LOGGER.warning(
                 "There are no results to plot, either...\n\n"

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -237,5 +237,5 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple =
         Empty Pandas DataFrame.
     """
     empty_df = pd.DataFrame(columns=columns)
-    empty_df.index.names = [index]
+    empty_df = empty_df.set_index(index)
     return empty_df


### PR DESCRIPTION
Fixes a bug where TopoStats would crash just before saving results to csv, on calling `results.reset_index()`. After a lot of digging, it appears that this is caused by a line in `create_empty_dataframe` that sets the index of the empty dataframe to `molecule_number` without then removing the column name `molecule_number`. This then causes a crash when `reset_index()` attempts to turn the index column `molecule_number` into a regular column, since there is already a regular column of the same name.

This issue only happens if grainstats returns an empty dataframe, and so was difficult and rare to find. The solution that I have proposed brings the dataframe that is returned by `create_empty_dataframe()` in line with the dataframes that are returned by grainstats when grains have been found, by using the `set_index()` method of dataframes, which removes the column after setting the index to that column name. Here is a visual example:

```python
import pandas as pd
import numpy as np

df = pd.DataFrame(data={'col1': [7, 8, 9], 'molecule_number': [0, 1, 2]})
print(df)
df.index.name = 'molecule_number'
print(df)
df_reset = df.reset_index()
print(df_reset)

```
```
col1  molecule_number
0     7                0
1     8                1
2     9                2
                 col1  molecule_number
molecule_number                       
0                   7                0
1                   8                1
2                   9                2
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[7], line 8
      6 df.index.name = 'molecule_number'
      7 print(df)
----> 8 df_reset = df.reset_index()
      9 print(df_reset)

File [/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/util/_decorators.py:331](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/util/_decorators.py:331), in deprecate_nonkeyword_arguments..decorate..wrapper(*args, **kwargs)
    325 if len(args) > num_allow_args:
    326     warnings.warn(
    327         msg.format(arguments=_format_argument_list(allow_args)),
    328         FutureWarning,
    329         stacklevel=find_stack_level(),
    330     )
--> 331 return func(*args, **kwargs)

File [/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/core/frame.py:6361](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/core/frame.py:6361), in DataFrame.reset_index(self, level, drop, inplace, col_level, col_fill, allow_duplicates, names)
   6355         if lab is not None:
   6356             # if we have the codes, extract the values with a mask
   6357             level_values = algorithms.take(
   6358                 level_values, lab, allow_fill=True, fill_value=lev._na_value
   6359             )
-> 6361         new_obj.insert(
   6362             0,
   6363             name,
   6364             level_values,
   6365             allow_duplicates=allow_duplicates,
   6366         )
   6368 new_obj.index = new_index
   6369 if not inplace:

File [/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/core/frame.py:4817](https://file+.vscode-resource.vscode-cdn.net/opt/homebrew/Caskroom/miniforge/base/envs/new/lib/python3.10/site-packages/pandas/core/frame.py:4817), in DataFrame.insert(self, loc, column, value, allow_duplicates)
   4811     raise ValueError(
   4812         "Cannot specify 'allow_duplicates=True' when "
   4813         "'self.flags.allows_duplicate_labels' is False."
   4814     )
   4815 if not allow_duplicates and column in self.columns:
   4816     # Should this be a different kind of error??
-> 4817     raise ValueError(f"cannot insert {column}, already exists")
   4818 if not isinstance(loc, int):
   4819     raise TypeError("loc must be int")

ValueError: cannot insert molecule_number, already exists
```


My fix:
```python
df = pd.DataFrame(data={'col1': [7, 8, 9], 'molecule_number': [0, 1, 2]})
print(df)
df = df.set_index('molecule_number')
print(df)
df_reset = df.reset_index()
print(df_reset)
```
```
   col1  molecule_number
0     7                0
1     8                1
2     9                2
                 col1
molecule_number      
0                   7
1                   8
2                   9
   molecule_number  col1
0                0     7
1                1     8
2                2     9
```