### PR TITLE
Fix no grains found crash

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -311,12 +311,11 @@ def test_process_stages(
     assert log_msg2 in caplog.text
 
 
-def test_process_scan_region_properties_is_none(
-    process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, caplog
-) -> None:
-    """Test capturing disabling GrainStats where no grains have been found."""
+def test_process_scan_no_grains(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, caplog) -> None:
+    """Test handling no grains found during grains.find_grains()."""
     img_dic = load_scan_data.img_dict
-    process_scan_config["grains"]["absolute_area_threshold"] = [4000, 9000]
+    process_scan_config["grains"]["threshold_std_dev"]["above"] = 1000
+    process_scan_config["filter"]["remove_scars"]["run"] = "false"
     _, _ = process_scan(
         img_path_px2nm=img_dic["minicircle"],
         base_dir=BASE_DIR,
@@ -327,5 +326,6 @@ def test_process_scan_region_properties_is_none(
         plotting_config=process_scan_config["plotting"],
         output_dir=tmp_path,
     )
-    assert "No grains to plot" in caplog.text
-    assert "No grains detected skipping calculation of grain statistics and DNA tracing." in caplog.text
+    assert "Grains found for direction above : 0" in caplog.text
+    assert "There are 0 circular and 0 linear DNA molecules found in the image" in caplog.text
+    assert "No grains exist for the above direction. Skipping grainstats and DNAtracing." in caplog.text

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -86,10 +86,10 @@ class Grains:
             # "labelled_regions": None,
             # "coloured_regions": None,
         }
-        self.directions = {}
+        self.directions = defaultdict()
         self.minimum_grain_size = None
-        self.region_properties = {}
-        self.bounding_boxes = {}
+        self.region_properties = defaultdict()
+        self.bounding_boxes = defaultdict()
         self.grainstats = None
         self.number_of_grains_found = {}
 
@@ -297,8 +297,6 @@ class Grains:
             threshold_std_dev=self.threshold_std_dev,
             absolute=self.threshold_absolute,
         )
-        # try:
-        # region_props_count = 0
         for direction in self.direction:
             LOGGER.info(f"[{self.filename}] : Finding {direction} grains, threshold: ({self.thresholds[direction]})")
             self.directions[direction] = {}
@@ -344,10 +342,3 @@ class Grains:
             )
             self.bounding_boxes[direction] = self.get_bounding_boxes(direction=direction)
             LOGGER.info(f"[{self.filename}] : Extracted bounding boxes ({direction})")
-
-            # region_props_count += len(self.region_properties[direction])
-        # if region_props_count == 0:
-        #     self.region_properties = None
-        # FIXME : Identify what exception is raised with images without grains and replace broad except
-        # except:  # noqa: E722
-        #     LOGGER.info(f"[{self.filename}] : No grains found.")

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -91,7 +91,6 @@ class Grains:
         self.region_properties = defaultdict()
         self.bounding_boxes = defaultdict()
         self.grainstats = None
-        self.number_of_grains_found = {}
 
     def tidy_border(self, image: np.array, **kwargs) -> np.array:
         """Remove grains touching the border.
@@ -332,7 +331,6 @@ class Grains:
             self.directions[direction]["labelled_regions_02"] = self.label_regions(
                 self.directions[direction]["removed_small_objects"]
             )
-            self.number_of_grains_found[direction] = np.max(self.directions[direction]["labelled_regions_02"])
             self.region_properties[direction] = self.get_region_properties(
                 self.directions[direction]["labelled_regions_02"]
             )

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -150,17 +150,17 @@ def process_scan(
             grains.find_grains()
             for direction, _ in grains.directions.items():
                 LOGGER.info(
-                    f"[{filename}] : Grains found for direction {direction} : {grains.number_of_grains_found[direction]}"
+                    f"[{filename}] : Grains found for direction {direction} : {len(grains.region_properties[direction])}"
                 )
-                if grains.number_of_grains_found[direction] == 0:
+                if len(grains.region_properties[direction]) == 0:
                     LOGGER.warning(f"[{filename}] : No grains found for direction {direction}")
         except Exception as e:
             LOGGER.error(f"[{filename}] : An error occured during grain finding, skipping grainstats and dnatracing.")
             LOGGER.error(f"[{filename}] : The error: {e}")
             results = create_empty_dataframe()
         else:
-            for direction, number_of_grains in grains.number_of_grains_found.items():
-                if number_of_grains == 0:
+            for direction, region_props in grains.region_properties.items():
+                if len(region_props) == 0:
                     LOGGER.warning(f"[{filename}] : No grains found for the {direction} direction.")
             # Optionally plot grain finding stage if we have found grains and plotting is required
             if plotting_config["run"]:
@@ -214,7 +214,7 @@ def process_scan(
                     grainstats = {}
                     # There are two layers to process those above the given threshold and those below
                     for direction, _ in grains.directions.items():
-                        if grains.number_of_grains_found[direction] == 0:
+                        if len(grains.region_properties[direction]) == 0:
                             LOGGER.warning(
                                 f"[{filename}] : No grains exist for the {direction} direction. Skipping grainstats and DNAtracing."
                             )

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -139,164 +139,178 @@ def process_scan(
     # Find Grains :
     if grains_config["run"]:
         grains_config.pop("run")
-        # try:
-        LOGGER.info(f"[{filename}] : *** Grain Finding ***")
-        grains = Grains(
-            image=filtered_image.images["gaussian_filtered"],
-            filename=filename,
-            pixel_to_nm_scaling=pixel_to_nm_scaling,
-            **grains_config,
-        )
-        grains.find_grains()
-        for direction in grains.directions.keys():
-            LOGGER.info(
-                f"[{filename}] : Grains found for direction {direction} : {grains.number_of_grains_found[direction]}"
+        try:
+            LOGGER.info(f"[{filename}] : *** Grain Finding ***")
+            grains = Grains(
+                image=filtered_image.images["gaussian_filtered"],
+                filename=filename,
+                pixel_to_nm_scaling=pixel_to_nm_scaling,
+                **grains_config,
             )
-            if grains.number_of_grains_found[direction] == 0:
-                LOGGER.warning(f"[{filename}] : No grains found for direction {direction}")
-        # except IndexError:
-        #     LOGGER.warning(f"[{filename}] : No grains were detected, skipping Grain Statistics and DNA Tracing.")
-        # except ValueError:
-        #     LOGGER.warning(f"[{filename}] : No image, it is all masked.")
-        #     results = create_empty_dataframe()
-        # if grains.region_properties is None:
-        #     LOGGER.warning(f"[{filename}] : No grains have been detected, skipping calculation of grain statistics.")
-        #     results = create_empty_dataframe()
-        # Optionally plot grain finding stage if we have found grains and plotting is required
-        if plotting_config["run"]:
-            plotting_config.pop("run")
-            LOGGER.info(f"[{filename}] : Plotting Grain Finding Images")
-            for direction, image_arrays in grains.directions.items():
-                LOGGER.info(f"[{filename}] : Plotting {direction} Grain Finding Images")
-                for plot_name, array in image_arrays.items():
-                    LOGGER.info(f"[{filename}] : Plotting {plot_name} image")
-                    plotting_config["plot_dict"][plot_name]["output_dir"] = grain_out_path / f"{direction}"
-                    Images(array, **plotting_config["plot_dict"][plot_name]).plot_and_save()
-                # Make a plot of coloured regions with bounding boxes
-                plotting_config["plot_dict"]["bounding_boxes"]["output_dir"] = grain_out_path / f"{direction}"
-                Images(
-                    grains.directions[direction]["coloured_regions"],
-                    **plotting_config["plot_dict"]["bounding_boxes"],
-                    region_properties=grains.region_properties[direction],
-                ).plot_and_save()
-                plotting_config["plot_dict"]["coloured_boxes"]["output_dir"] = grain_out_path / f"{direction}"
-                Images(
-                    grains.directions[direction]["labelled_regions_02"],
-                    **plotting_config["plot_dict"]["coloured_boxes"],
-                    region_properties=grains.region_properties[direction],
-                ).plot_and_save()
-                # Always want mask_overlay (aka "Height Thresholded with Mask") but in core_out_path
-                plot_name = "mask_overlay"
-                plotting_config["plot_dict"][plot_name]["output_dir"] = core_out_path
-                Images(
-                    filtered_image.images["gaussian_filtered"],
-                    filename=f"{filename}_{direction}_masked",
-                    masked_array=grains.directions[direction]["removed_small_objects"],
-                    **plotting_config["plot_dict"][plot_name],
-                ).plot_and_save()
-
-            plotting_config["run"] = True
-        else:
-            LOGGER.info(f"[{filename}] : Plotting disabled for Grain Finding Images")
-
-        # Grainstats :
-        #
-        # If grains have ben found we calculate statistics if required to
-        # if len(grains.region_properties) > 0:
-        if grainstats_config["run"]:
-            grainstats_config.pop("run")
-            # Grain Statistics :
-            # try:
-            LOGGER.info(f"[{filename}] : *** Grain Statistics ***")
-            grain_plot_dict = {
-                key: value
-                for key, value in plotting_config["plot_dict"].items()
-                if key in ["grain_image", "grain_mask", "grain_mask_image"]
-            }
-            grainstats = {}
-            # There are two layers to process those above the given threshold and those below
+            grains.find_grains()
             for direction, _ in grains.directions.items():
-                grainstats[direction], grains_plot_data = GrainStats(
-                    data=filtered_image.images["gaussian_filtered"],
-                    labelled_data=grains.directions[direction]["labelled_regions_02"],
-                    pixel_to_nanometre_scaling=pixel_to_nm_scaling,
-                    direction=direction,
-                    base_output_dir=grain_out_path,
-                    image_name=filename,
-                    plot_opts=grain_plot_dict,
-                    **grainstats_config,
-                ).calculate_stats()
-                grainstats[direction]["threshold"] = direction
-                # Plot grains
-                if plotting_config["image_set"] == "all":
-                    LOGGER.info(f"[{filename}] : Plotting grain images.")
-                    for plot_data in grains_plot_data:
-                        LOGGER.info(f"[{filename}] : Plotting grain image. {plot_data['filename']}")
-                        Images(
-                            data=plot_data["data"],
-                            output_dir=plot_data["output_dir"],
-                            filename=plot_data["filename"],
-                            **plotting_config["plot_dict"][plot_data["name"]],
-                        ).plot_and_save()
-            # Set tracing_stats_df in light of direction
-            if grains_config["direction"] == "both":
-                grainstats_df = pd.concat([grainstats["below"], grainstats["above"]])
-            elif grains_config["direction"] == "above":
-                grainstats_df = grainstats["above"]
-            elif grains_config["direction"] == "below":
-                grainstats_df = grainstats["below"]
-            # except Exception:
-            #     LOGGER.info(f"[{filename}] : Errors occurred whilst calculating grain statistics.")
-            #     results = create_empty_dataframe()
-            # Run dnatracing
-            try:
-                if dnatracing_config["run"]:
-                    dnatracing_config.pop("run")
-                    LOGGER.info(f"[{filename}] : *** DNA Tracing ***")
-                    dna_traces = defaultdict()
-                    tracing_stats = defaultdict()
-                    for direction, _ in grainstats.items():
-                        dna_traces[direction] = dnaTrace(
-                            full_image_data=filtered_image.images["gaussian_filtered"].T,
-                            grains=grains.directions[direction]["labelled_regions_02"],
-                            filename=filename,
-                            pixel_size=pixel_to_nm_scaling,
-                            **dnatracing_config,
-                        )
-                        dna_traces[direction].trace_dna()
-                        tracing_stats[direction] = traceStats(trace_object=dna_traces[direction], image_path=image_path)
-                        tracing_stats[direction].df["threshold"] = direction
+                LOGGER.info(
+                    f"[{filename}] : Grains found for direction {direction} : {grains.number_of_grains_found[direction]}"
+                )
+                if grains.number_of_grains_found[direction] == 0:
+                    LOGGER.warning(f"[{filename}] : No grains found for direction {direction}")
+        except Exception as e:
+            LOGGER.error(f"[{filename}] : An error occured during grain finding, skipping grainstats and dnatracing.")
+            LOGGER.error(f"[{filename}] : The error: {e}")
+            results = create_empty_dataframe()
+        else:
+            for direction, number_of_grains in grains.number_of_grains_found.items():
+                if number_of_grains == 0:
+                    LOGGER.warning(f"[{filename}] : No grains found for the {direction} direction.")
+            # Optionally plot grain finding stage if we have found grains and plotting is required
+            if plotting_config["run"]:
+                plotting_config.pop("run")
+                LOGGER.info(f"[{filename}] : Plotting Grain Finding Images")
+                for direction, image_arrays in grains.directions.items():
+                    LOGGER.info(f"[{filename}] : Plotting {direction} Grain Finding Images")
+                    for plot_name, array in image_arrays.items():
+                        LOGGER.info(f"[{filename}] : Plotting {plot_name} image")
+                        plotting_config["plot_dict"][plot_name]["output_dir"] = grain_out_path / f"{direction}"
+                        Images(array, **plotting_config["plot_dict"][plot_name]).plot_and_save()
+                    # Make a plot of coloured regions with bounding boxes
+                    plotting_config["plot_dict"]["bounding_boxes"]["output_dir"] = grain_out_path / f"{direction}"
+                    Images(
+                        grains.directions[direction]["coloured_regions"],
+                        **plotting_config["plot_dict"]["bounding_boxes"],
+                        region_properties=grains.region_properties[direction],
+                    ).plot_and_save()
+                    plotting_config["plot_dict"]["coloured_boxes"]["output_dir"] = grain_out_path / f"{direction}"
+                    Images(
+                        grains.directions[direction]["labelled_regions_02"],
+                        **plotting_config["plot_dict"]["coloured_boxes"],
+                        region_properties=grains.region_properties[direction],
+                    ).plot_and_save()
+                    # Always want mask_overlay (aka "Height Thresholded with Mask") but in core_out_path
+                    plot_name = "mask_overlay"
+                    plotting_config["plot_dict"][plot_name]["output_dir"] = core_out_path
+                    Images(
+                        filtered_image.images["gaussian_filtered"],
+                        filename=f"{filename}_{direction}_masked",
+                        masked_array=grains.directions[direction]["removed_small_objects"],
+                        **plotting_config["plot_dict"][plot_name],
+                    ).plot_and_save()
+
+                plotting_config["run"] = True
+            else:
+                LOGGER.info(f"[{filename}] : Plotting disabled for Grain Finding Images")
+
+            # Grainstats :
+            # Calculate statistics if required
+            if grainstats_config["run"]:
+                grainstats_config.pop("run")
+                # Grain Statistics :
+                try:
+                    LOGGER.info(f"[{filename}] : *** Grain Statistics ***")
+                    grain_plot_dict = {
+                        key: value
+                        for key, value in plotting_config["plot_dict"].items()
+                        if key in ["grain_image", "grain_mask", "grain_mask_image"]
+                    }
+                    grainstats = {}
+                    # There are two layers to process those above the given threshold and those below
+                    for direction, _ in grains.directions.items():
+                        if grains.number_of_grains_found[direction] == 0:
+                            LOGGER.warning(
+                                f"[{filename}] : No grains exist for the {direction} direction. Skipping grainstats and DNAtracing."
+                            )
+                            grainstats[direction] = create_empty_dataframe()
+                        else:
+                            grainstats[direction], grains_plot_data = GrainStats(
+                                data=filtered_image.images["gaussian_filtered"],
+                                labelled_data=grains.directions[direction]["labelled_regions_02"],
+                                pixel_to_nanometre_scaling=pixel_to_nm_scaling,
+                                direction=direction,
+                                base_output_dir=grain_out_path,
+                                image_name=filename,
+                                plot_opts=grain_plot_dict,
+                                **grainstats_config,
+                            ).calculate_stats()
+                            grainstats[direction]["threshold"] = direction
+                            # Plot grains
+                            if plotting_config["image_set"] == "all":
+                                LOGGER.info(f"[{filename}] : Plotting grain images for direction: {direction}.")
+                                for plot_data in grains_plot_data:
+                                    LOGGER.info(
+                                        f"[{filename}] : Plotting grain image {plot_data['filename']} for direction: {direction}."
+                                    )
+                                    Images(
+                                        data=plot_data["data"],
+                                        output_dir=plot_data["output_dir"],
+                                        filename=plot_data["filename"],
+                                        **plotting_config["plot_dict"][plot_data["name"]],
+                                    ).plot_and_save()
                     # Set tracing_stats_df in light of direction
                     if grains_config["direction"] == "both":
-                        tracing_stats_df = pd.concat([tracing_stats["below"].df, tracing_stats["above"].df])
+                        grainstats_df = pd.concat([grainstats["below"], grainstats["above"]])
                     elif grains_config["direction"] == "above":
-                        tracing_stats_df = tracing_stats["above"].df
+                        grainstats_df = grainstats["above"]
                     elif grains_config["direction"] == "below":
-                        tracing_stats_df = tracing_stats["below"].df
-                    LOGGER.info(f"[{filename}] : Combining {direction} grain statistics and dnatracing statistics")
-                    # NB - Merge on image, molecule and threshold because we may have above and below molecueles which
-                    #      gives duplicate molecule numbers as they are processed separately
-                    results = grainstats_df.merge(tracing_stats_df, on=["image", "threshold", "molecule_number"])
+                        grainstats_df = grainstats["below"]
+                except Exception:
+                    LOGGER.info(
+                        f"[{filename}] : Errors occurred whilst calculating grain statistics. Skipping DNAtracing."
+                    )
+                    results = create_empty_dataframe()
                 else:
-                    LOGGER.info(f"[{filename}] Calculation of DNA Tracing disabled, returning grainstats data frame.")
-                    results = grainstats_df
-                    results["basename"] = image_path.parent
-            except Exception:
-                # If no results we need a dummy dataframe to return.
-                LOGGER.warning(
-                    f"[{filename}] : Errors occurred whilst calculating DNA tracing statistics, "
-                    "returning grain statistics"
-                )
-                results = grainstats_df
-                results["basename"] = image_path.parent
-        else:
-            LOGGER.info(f"[{filename}] Calculation of grainstats disabled, returning empty data frame.")
-            results = create_empty_dataframe()
-        # else:
-        #     LOGGER.info(f"[{filename}] No grains detected skipping calculation of grain statistics and DNA tracing.")
-        #     results = create_empty_dataframe()
+                    # Run dnatracing
+                    try:
+                        if dnatracing_config["run"]:
+                            dnatracing_config.pop("run")
+                            LOGGER.info(f"[{filename}] : *** DNA Tracing ***")
+                            dna_traces = defaultdict()
+                            tracing_stats = defaultdict()
+                            for direction, _ in grainstats.items():
+                                dna_traces[direction] = dnaTrace(
+                                    full_image_data=filtered_image.images["gaussian_filtered"].T,
+                                    grains=grains.directions[direction]["labelled_regions_02"],
+                                    filename=filename,
+                                    pixel_size=pixel_to_nm_scaling,
+                                    **dnatracing_config,
+                                )
+                                dna_traces[direction].trace_dna()
+                                tracing_stats[direction] = traceStats(
+                                    trace_object=dna_traces[direction], image_path=image_path
+                                )
+                                tracing_stats[direction].df["threshold"] = direction
+                            # Set tracing_stats_df in light of direction
+                            if grains_config["direction"] == "both":
+                                tracing_stats_df = pd.concat([tracing_stats["below"].df, tracing_stats["above"].df])
+                            elif grains_config["direction"] == "above":
+                                tracing_stats_df = tracing_stats["above"].df
+                            elif grains_config["direction"] == "below":
+                                tracing_stats_df = tracing_stats["below"].df
+                            LOGGER.info(
+                                f"[{filename}] : Combining {direction} grain statistics and dnatracing statistics"
+                            )
+                            # NB - Merge on image, molecule and threshold because we may have above and below molecueles which
+                            #      gives duplicate molecule numbers as they are processed separately
+                            results = grainstats_df.merge(
+                                tracing_stats_df, on=["image", "threshold", "molecule_number"]
+                            )
+                        else:
+                            LOGGER.info(
+                                f"[{filename}] Calculation of DNA Tracing disabled, returning grainstats data frame."
+                            )
+                            results = grainstats_df
+                            results["basename"] = image_path.parent
+                    except Exception:
+                        # If no results we need a dummy dataframe to return.
+                        LOGGER.warning(
+                            f"[{filename}] : Errors occurred whilst calculating DNA tracing statistics, "
+                            "returning grain statistics"
+                        )
+                        results = grainstats_df
+                        results["basename"] = image_path.parent
+            else:
+                LOGGER.info(f"[{filename}] Calculation of grainstats disabled, returning empty data frame.")
+                results = create_empty_dataframe()
     else:
-        LOGGER.info(f"[{filename}] Detection of grains disabled, returning empty data frame.")
+        LOGGER.info(f"[{filename}] Detection of grains disabled, skipping and returning empty data frame.")
         results = create_empty_dataframe()
 
     return image_path, results

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -310,7 +310,7 @@ def process_scan(
                 LOGGER.info(f"[{filename}] Calculation of grainstats disabled, returning empty data frame.")
                 results = create_empty_dataframe()
     else:
-        LOGGER.info(f"[{filename}] Detection of grains disabled, skipping and returning empty data frame.")
+        LOGGER.info(f"[{filename}] Detection of grains disabled, returning empty data frame.")
         results = create_empty_dataframe()
 
     return image_path, results

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -139,159 +139,162 @@ def process_scan(
     # Find Grains :
     if grains_config["run"]:
         grains_config.pop("run")
-        try:
-            LOGGER.info(f"[{filename}] : *** Grain Finding ***")
-            grains = Grains(
-                image=filtered_image.images["gaussian_filtered"],
-                filename=filename,
-                pixel_to_nm_scaling=pixel_to_nm_scaling,
-                **grains_config,
+        # try:
+        LOGGER.info(f"[{filename}] : *** Grain Finding ***")
+        grains = Grains(
+            image=filtered_image.images["gaussian_filtered"],
+            filename=filename,
+            pixel_to_nm_scaling=pixel_to_nm_scaling,
+            **grains_config,
+        )
+        grains.find_grains()
+        for direction in grains.directions.keys():
+            LOGGER.info(
+                f"[{filename}] : Grains found for direction {direction} : {grains.number_of_grains_found[direction]}"
             )
-            grains.find_grains()
-        except IndexError:
-            LOGGER.warning(f"[{filename}] : No grains were detected, skipping Grain Statistics and DNA Tracing.")
-        except ValueError:
-            LOGGER.warning(f"[{filename}] : No image, it is all masked.")
-            results = create_empty_dataframe()
-        if grains.region_properties is None:
-            LOGGER.warning(f"[{filename}] : No grains have been detected, skipping calculation of grain statistics.")
-            results = create_empty_dataframe()
+            if grains.number_of_grains_found[direction] == 0:
+                LOGGER.warning(f"[{filename}] : No grains found for direction {direction}")
+        # except IndexError:
+        #     LOGGER.warning(f"[{filename}] : No grains were detected, skipping Grain Statistics and DNA Tracing.")
+        # except ValueError:
+        #     LOGGER.warning(f"[{filename}] : No image, it is all masked.")
+        #     results = create_empty_dataframe()
+        # if grains.region_properties is None:
+        #     LOGGER.warning(f"[{filename}] : No grains have been detected, skipping calculation of grain statistics.")
+        #     results = create_empty_dataframe()
         # Optionally plot grain finding stage if we have found grains and plotting is required
-        if len(grains.region_properties) > 0:
-            if plotting_config["run"]:
-                plotting_config.pop("run")
-                LOGGER.info(f"[{filename}] : Plotting Grain Finding Images")
-                for direction, image_arrays in grains.directions.items():
-                    for plot_name, array in image_arrays.items():
-                        plotting_config["plot_dict"][plot_name]["output_dir"] = grain_out_path / f"{direction}"
-                        Images(array, **plotting_config["plot_dict"][plot_name]).plot_and_save()
-                    # Make a plot of coloured regions with bounding boxes
-                    plotting_config["plot_dict"]["bounding_boxes"]["output_dir"] = grain_out_path / f"{direction}"
-                    Images(
-                        grains.directions[direction]["coloured_regions"],
-                        **plotting_config["plot_dict"]["bounding_boxes"],
-                        region_properties=grains.region_properties[direction],
-                    ).plot_and_save()
-                    plotting_config["plot_dict"]["coloured_boxes"]["output_dir"] = grain_out_path / f"{direction}"
-                    Images(
-                        grains.directions[direction]["labelled_regions_02"],
-                        **plotting_config["plot_dict"]["coloured_boxes"],
-                        region_properties=grains.region_properties[direction],
-                    ).plot_and_save()
-                    # Always want mask_overlay (aka "Height Thresholded with Mask") but in core_out_path
-                    plot_name = "mask_overlay"
-                    plotting_config["plot_dict"][plot_name]["output_dir"] = core_out_path
-                    Images(
-                        filtered_image.images["gaussian_filtered"],
-                        filename=f"{filename}_{direction}_masked",
-                        masked_array=grains.directions[direction]["removed_small_objects"],
-                        **plotting_config["plot_dict"][plot_name],
-                    ).plot_and_save()
+        if plotting_config["run"]:
+            plotting_config.pop("run")
+            LOGGER.info(f"[{filename}] : Plotting Grain Finding Images")
+            for direction, image_arrays in grains.directions.items():
+                LOGGER.info(f"[{filename}] : Plotting {direction} Grain Finding Images")
+                for plot_name, array in image_arrays.items():
+                    LOGGER.info(f"[{filename}] : Plotting {plot_name} image")
+                    plotting_config["plot_dict"][plot_name]["output_dir"] = grain_out_path / f"{direction}"
+                    Images(array, **plotting_config["plot_dict"][plot_name]).plot_and_save()
+                # Make a plot of coloured regions with bounding boxes
+                plotting_config["plot_dict"]["bounding_boxes"]["output_dir"] = grain_out_path / f"{direction}"
+                Images(
+                    grains.directions[direction]["coloured_regions"],
+                    **plotting_config["plot_dict"]["bounding_boxes"],
+                    region_properties=grains.region_properties[direction],
+                ).plot_and_save()
+                plotting_config["plot_dict"]["coloured_boxes"]["output_dir"] = grain_out_path / f"{direction}"
+                Images(
+                    grains.directions[direction]["labelled_regions_02"],
+                    **plotting_config["plot_dict"]["coloured_boxes"],
+                    region_properties=grains.region_properties[direction],
+                ).plot_and_save()
+                # Always want mask_overlay (aka "Height Thresholded with Mask") but in core_out_path
+                plot_name = "mask_overlay"
+                plotting_config["plot_dict"][plot_name]["output_dir"] = core_out_path
+                Images(
+                    filtered_image.images["gaussian_filtered"],
+                    filename=f"{filename}_{direction}_masked",
+                    masked_array=grains.directions[direction]["removed_small_objects"],
+                    **plotting_config["plot_dict"][plot_name],
+                ).plot_and_save()
 
-                plotting_config["run"] = True
+            plotting_config["run"] = True
         else:
-            LOGGER.info(f"[{filename}] : No grains to plot.")
+            LOGGER.info(f"[{filename}] : Plotting disabled for Grain Finding Images")
 
         # Grainstats :
         #
         # If grains have ben found we calculate statistics if required to
-        if len(grains.region_properties) > 0:
-            if grainstats_config["run"]:
-                grainstats_config.pop("run")
-                # Grain Statistics :
-                try:
-                    LOGGER.info(f"[{filename}] : *** Grain Statistics ***")
-                    grain_plot_dict = {
-                        key: value
-                        for key, value in plotting_config["plot_dict"].items()
-                        if key in ["grain_image", "grain_mask", "grain_mask_image"]
-                    }
-                    grainstats = {}
-                    # There are two layers to process those above the given threshold and those below
-                    for direction, _ in grains.directions.items():
-                        grainstats[direction], grains_plot_data = GrainStats(
-                            data=filtered_image.images["gaussian_filtered"],
-                            labelled_data=grains.directions[direction]["labelled_regions_02"],
-                            pixel_to_nanometre_scaling=pixel_to_nm_scaling,
-                            direction=direction,
-                            base_output_dir=grain_out_path,
-                            image_name=filename,
-                            plot_opts=grain_plot_dict,
-                            **grainstats_config,
-                        ).calculate_stats()
-                        grainstats[direction]["threshold"] = direction
-                        # Plot grains
-                        if plotting_config["image_set"] == "all":
-                            LOGGER.info(f"[{filename}] : Plotting grain images.")
-                            for plot_data in grains_plot_data:
-                                LOGGER.info(f"[{filename}] : Plotting grain image. {plot_data['filename']}")
-                                Images(
-                                    data=plot_data["data"],
-                                    output_dir=plot_data["output_dir"],
-                                    filename=plot_data["filename"],
-                                    **plotting_config["plot_dict"][plot_data["name"]],
-                                ).plot_and_save()
+        # if len(grains.region_properties) > 0:
+        if grainstats_config["run"]:
+            grainstats_config.pop("run")
+            # Grain Statistics :
+            # try:
+            LOGGER.info(f"[{filename}] : *** Grain Statistics ***")
+            grain_plot_dict = {
+                key: value
+                for key, value in plotting_config["plot_dict"].items()
+                if key in ["grain_image", "grain_mask", "grain_mask_image"]
+            }
+            grainstats = {}
+            # There are two layers to process those above the given threshold and those below
+            for direction, _ in grains.directions.items():
+                grainstats[direction], grains_plot_data = GrainStats(
+                    data=filtered_image.images["gaussian_filtered"],
+                    labelled_data=grains.directions[direction]["labelled_regions_02"],
+                    pixel_to_nanometre_scaling=pixel_to_nm_scaling,
+                    direction=direction,
+                    base_output_dir=grain_out_path,
+                    image_name=filename,
+                    plot_opts=grain_plot_dict,
+                    **grainstats_config,
+                ).calculate_stats()
+                grainstats[direction]["threshold"] = direction
+                # Plot grains
+                if plotting_config["image_set"] == "all":
+                    LOGGER.info(f"[{filename}] : Plotting grain images.")
+                    for plot_data in grains_plot_data:
+                        LOGGER.info(f"[{filename}] : Plotting grain image. {plot_data['filename']}")
+                        Images(
+                            data=plot_data["data"],
+                            output_dir=plot_data["output_dir"],
+                            filename=plot_data["filename"],
+                            **plotting_config["plot_dict"][plot_data["name"]],
+                        ).plot_and_save()
+            # Set tracing_stats_df in light of direction
+            if grains_config["direction"] == "both":
+                grainstats_df = pd.concat([grainstats["below"], grainstats["above"]])
+            elif grains_config["direction"] == "above":
+                grainstats_df = grainstats["above"]
+            elif grains_config["direction"] == "below":
+                grainstats_df = grainstats["below"]
+            # except Exception:
+            #     LOGGER.info(f"[{filename}] : Errors occurred whilst calculating grain statistics.")
+            #     results = create_empty_dataframe()
+            # Run dnatracing
+            try:
+                if dnatracing_config["run"]:
+                    dnatracing_config.pop("run")
+                    LOGGER.info(f"[{filename}] : *** DNA Tracing ***")
+                    dna_traces = defaultdict()
+                    tracing_stats = defaultdict()
+                    for direction, _ in grainstats.items():
+                        dna_traces[direction] = dnaTrace(
+                            full_image_data=filtered_image.images["gaussian_filtered"].T,
+                            grains=grains.directions[direction]["labelled_regions_02"],
+                            filename=filename,
+                            pixel_size=pixel_to_nm_scaling,
+                            **dnatracing_config,
+                        )
+                        dna_traces[direction].trace_dna()
+                        tracing_stats[direction] = traceStats(trace_object=dna_traces[direction], image_path=image_path)
+                        tracing_stats[direction].df["threshold"] = direction
                     # Set tracing_stats_df in light of direction
                     if grains_config["direction"] == "both":
-                        grainstats_df = pd.concat([grainstats["below"], grainstats["above"]])
+                        tracing_stats_df = pd.concat([tracing_stats["below"].df, tracing_stats["above"].df])
                     elif grains_config["direction"] == "above":
-                        grainstats_df = grainstats["above"]
+                        tracing_stats_df = tracing_stats["above"].df
                     elif grains_config["direction"] == "below":
-                        grainstats_df = grainstats["below"]
-                except Exception:
-                    LOGGER.info(f"[{filename}] : Errors occurred whilst calculating grain statistics.")
-                    results = create_empty_dataframe()
-                # Run dnatracing
-                try:
-                    if dnatracing_config["run"]:
-                        dnatracing_config.pop("run")
-                        LOGGER.info(f"[{filename}] : *** DNA Tracing ***")
-                        dna_traces = defaultdict()
-                        tracing_stats = defaultdict()
-                        for direction, _ in grainstats.items():
-                            dna_traces[direction] = dnaTrace(
-                                full_image_data=filtered_image.images["gaussian_filtered"].T,
-                                grains=grains.directions[direction]["labelled_regions_02"],
-                                filename=filename,
-                                pixel_size=pixel_to_nm_scaling,
-                                **dnatracing_config,
-                            )
-                            dna_traces[direction].trace_dna()
-                            tracing_stats[direction] = traceStats(
-                                trace_object=dna_traces[direction], image_path=image_path
-                            )
-                            tracing_stats[direction].df["threshold"] = direction
-                        # Set tracing_stats_df in light of direction
-                        if grains_config["direction"] == "both":
-                            tracing_stats_df = pd.concat([tracing_stats["below"].df, tracing_stats["above"].df])
-                        elif grains_config["direction"] == "above":
-                            tracing_stats_df = tracing_stats["above"].df
-                        elif grains_config["direction"] == "below":
-                            tracing_stats_df = tracing_stats["below"].df
-                        LOGGER.info(f"[{filename}] : Combining {direction} grain statistics and dnatracing statistics")
-                        # NB - Merge on image, molecule and threshold because we may have above and below molecueles which
-                        #      gives duplicate molecule numbers as they are processed separately
-                        results = grainstats_df.merge(tracing_stats_df, on=["image", "threshold", "molecule_number"])
-                    else:
-                        LOGGER.info(
-                            f"[{filename}] Calculation of DNA Tracing disabled, returning grainstats data frame."
-                        )
-                        results = grainstats_df
-                        results["basename"] = image_path.parent
-                except Exception:
-                    # If no results we need a dummy dataframe to return.
-                    LOGGER.warning(
-                        f"[{filename}] : Errors occurred whilst calculating DNA tracing statistics, "
-                        "returning grain statistics"
-                    )
+                        tracing_stats_df = tracing_stats["below"].df
+                    LOGGER.info(f"[{filename}] : Combining {direction} grain statistics and dnatracing statistics")
+                    # NB - Merge on image, molecule and threshold because we may have above and below molecueles which
+                    #      gives duplicate molecule numbers as they are processed separately
+                    results = grainstats_df.merge(tracing_stats_df, on=["image", "threshold", "molecule_number"])
+                else:
+                    LOGGER.info(f"[{filename}] Calculation of DNA Tracing disabled, returning grainstats data frame.")
                     results = grainstats_df
                     results["basename"] = image_path.parent
-            else:
-                LOGGER.info(f"[{filename}] Calculation of grainstats disabled, returning empty data frame.")
-                results = create_empty_dataframe()
+            except Exception:
+                # If no results we need a dummy dataframe to return.
+                LOGGER.warning(
+                    f"[{filename}] : Errors occurred whilst calculating DNA tracing statistics, "
+                    "returning grain statistics"
+                )
+                results = grainstats_df
+                results["basename"] = image_path.parent
         else:
-            LOGGER.info(f"[{filename}] No grains detected skipping calculation of grain statistics and DNA tracing.")
+            LOGGER.info(f"[{filename}] Calculation of grainstats disabled, returning empty data frame.")
             results = create_empty_dataframe()
+        # else:
+        #     LOGGER.info(f"[{filename}] No grains detected skipping calculation of grain statistics and DNA tracing.")
+        #     results = create_empty_dataframe()
     else:
         LOGGER.info(f"[{filename}] Detection of grains disabled, returning empty data frame.")
         results = create_empty_dataframe()


### PR DESCRIPTION
Fixes the error we found last week where images that had no grains would crash TopoStats. This was due to sometimes returning an empty `defaultdict` object, and sometimes returning `None` instead.

This solution fixes that issue, and another issue, that had not been noticed yet, where if you were to run an image and request grains to be found in both directions `above` and `below`, then it would detect grains in `below` fine, but if when detecting grains in `above`, it found no grains, then it would error out, and skip steps for both the `above` and `below` directions. 

I fix this by checking explicitly for each direction before calling grainstats. This also gives a more informative output message, so you know which direction found no grains:

```
[Tue, 09 May 2023 13:37:26] [INFO    ] [topostats] [minicircle] : Grains found for direction above : 0
```

and 

```
[Tue, 09 May 2023 13:37:26] [INFO    ] [topostats] [minicircle] : *** Grain Statistics ***
[Tue, 09 May 2023 13:37:26] [WARNING ] [topostats] [minicircle] : No grains exist for the above direction. Skipping grainstats and DNAtracing.
```

I have edited @ns-rse 's test to accomodate this.