### PR TITLE
Only create filters, grains dirs when image_set is "all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![pre-commit.ci
 status](https://results.pre-commit.ci/badge/github/AFM-SPM/TopoStats/main.svg)](https://results.pre-commit.ci/latest/github/AFM-SPM/TopoStats/main)
-[![](https://img.shields.io/badge/ORDA--DOI-10.15131%2Fshef.data.22633528.v.1-lightgrey)](https://figshare.shef.ac.uk/articles/software/TopoStats/22633528/1)
+[![ORDA](https://img.shields.io/badge/ORDA--DOI-10.15131%2Fshef.data.22633528.v.1-lightgrey)](https://figshare.shef.ac.uk/articles/software/TopoStats/22633528/1)
 
 | [Installation](#installation) | [Tutorials and Examples](#tutorials-and-examples) | [Contributing](contributing.md) |
 | [Licence](#licence) | [Citation](#citation) |

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -77,10 +77,12 @@ def process_scan(
     core_out_path = get_out_path(image_path, base_dir, output_dir).parent / "processed"
     core_out_path.mkdir(parents=True, exist_ok=True)
     filter_out_path = core_out_path / filename / "filters"
-    filter_out_path.mkdir(exist_ok=True, parents=True)
+    if plotting_config["image_set"] == "all":
+        filter_out_path.mkdir(exist_ok=True, parents=True)
     grain_out_path = core_out_path / filename / "grains"
-    Path.mkdir(grain_out_path / "above", parents=True, exist_ok=True)
-    Path.mkdir(grain_out_path / "below", parents=True, exist_ok=True)
+    if plotting_config["image_set"] == "all":
+        Path.mkdir(grain_out_path / "above", parents=True, exist_ok=True)
+        Path.mkdir(grain_out_path / "below", parents=True, exist_ok=True)
 
     # Filter Image
     if filter_config["run"]:

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -79,8 +79,7 @@ def process_scan(
     filter_out_path = core_out_path / filename / "filters"
     if plotting_config["image_set"] == "all":
         filter_out_path.mkdir(exist_ok=True, parents=True)
-    grain_out_path = core_out_path / filename / "grains"
-    if plotting_config["image_set"] == "all":
+        grain_out_path = core_out_path / filename / "grains"
         Path.mkdir(grain_out_path / "above", parents=True, exist_ok=True)
         Path.mkdir(grain_out_path / "below", parents=True, exist_ok=True)
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -77,9 +77,9 @@ def process_scan(
     core_out_path = get_out_path(image_path, base_dir, output_dir).parent / "processed"
     core_out_path.mkdir(parents=True, exist_ok=True)
     filter_out_path = core_out_path / filename / "filters"
+    grain_out_path = core_out_path / filename / "grains"
     if plotting_config["image_set"] == "all":
         filter_out_path.mkdir(exist_ok=True, parents=True)
-        grain_out_path = core_out_path / filename / "grains"
         Path.mkdir(grain_out_path / "above", parents=True, exist_ok=True)
         Path.mkdir(grain_out_path / "below", parents=True, exist_ok=True)
 


### PR DESCRIPTION
Closes #541 

Adds simple checks to ensure that the `filters` and `grains` directories are only created when `image_set` is `"all"`.

I can't imagine this having any conflicts, and I tried running TopoStats a few times with various configurations including `image_set: "core"` and `image_set: "all"`, but I could have missed something.