### PR TITLE
Updating package build to work with Debian System

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -24,6 +24,8 @@ jobs:
           pip3 install .[pypi]
       - name: Build package
         run: |
+          pip3 install --upgrade setuptools
+          export DEB_PYTHON_INSTALL_LAYOUT=deb_system
           python -m build --no-isolation
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
I realised I'd encountered the issue with the package name not being correctly picked up and built as `UNKNOWN` which results in `Error InvalidDistribution: Metadata is missing required fields: Name` when trying to upload and solved it for another package (see [here](https://github.com/claritychallenge/clarity/issues/266)).
