### PR TITLE
Sylvia whittle/486 area unit tests

### DIFF
--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -72,6 +72,45 @@ def test_known_array_threshold(area_thresh_nm, expected) -> None:
 #     assert True
 
 
+def test_remove_small_objects():
+    """Test the remove_small_objects method of the Grains class."""
+
+    grains_object = Grains(
+        image=None,
+        filename="",
+        pixel_to_nm_scaling=1.0,
+    )
+
+    test_img = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 3, 3, 0],
+            [0, 0, 1, 0, 3, 3, 0],
+            [0, 0, 0, 0, 0, 3, 0],
+            [0, 2, 0, 2, 0, 3, 0],
+            [0, 2, 2, 2, 0, 3, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+
+    expected = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 1, 1, 0],
+            [0, 0, 0, 0, 1, 1, 0],
+            [0, 0, 0, 0, 0, 1, 0],
+            [0, 1, 0, 1, 0, 1, 0],
+            [0, 1, 1, 1, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+
+    grains_object.minimum_grain_size = 5
+    result = grains_object.remove_small_objects(test_img)
+
+    np.testing.assert_array_equal(result, expected)
+
+
 def test_area_thresholding():
     """Test the area_thresholding() method of the Grains class."""
 

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -70,3 +70,40 @@ def test_known_array_threshold(area_thresh_nm, expected) -> None:
 #     # FIXME : I can see for myself that the error message is logged but the assert fails as caplog.text is empty?
 #     # assert "No gains found." in caplog.text
 #     assert True
+
+
+def test_area_thresholding():
+    """Test the area_thresholding() method of the Grains class."""
+
+    grains_object = Grains(
+        image=None,
+        filename="",
+        pixel_to_nm_scaling=1.0,
+    )
+
+    test_img = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 3, 3, 0],
+            [0, 0, 1, 0, 3, 3, 0],
+            [0, 0, 0, 0, 0, 3, 0],
+            [0, 2, 0, 2, 0, 3, 0],
+            [0, 2, 2, 2, 0, 3, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    area_thresholds = [4.0, 6.0]
+    expected = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 1, 0, 0, 0],
+            [0, 1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0],
+        ]
+    )
+    result = grains_object.area_thresholding(test_img, area_thresholds=area_thresholds)
+
+    np.testing.assert_array_equal(result, expected)

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -111,7 +111,62 @@ def test_remove_small_objects():
     np.testing.assert_array_equal(result, expected)
 
 
-def test_area_thresholding():
+@pytest.mark.parametrize(
+    "test_labelled_image, area_thresholds, expected",
+    [
+        (
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 0, 3, 3, 0],
+                    [0, 0, 1, 0, 3, 3, 0],
+                    [0, 0, 0, 0, 0, 3, 0],
+                    [0, 2, 0, 2, 0, 3, 0],
+                    [0, 2, 2, 2, 0, 3, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+            [4.0, 6.0],
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 0, 1, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        ),
+        (
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 0, 3, 3, 0],
+                    [0, 0, 1, 0, 3, 3, 0],
+                    [0, 0, 0, 0, 0, 3, 0],
+                    [0, 2, 0, 2, 0, 3, 0],
+                    [0, 2, 2, 2, 0, 3, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+            [None, None],
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 0, 3, 3, 0],
+                    [0, 0, 1, 0, 3, 3, 0],
+                    [0, 0, 0, 0, 0, 3, 0],
+                    [0, 2, 0, 2, 0, 3, 0],
+                    [0, 2, 2, 2, 0, 3, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+        ),
+    ],
+)
+def test_area_thresholding(test_labelled_image, area_thresholds, expected):
     """Test the area_thresholding() method of the Grains class."""
 
     grains_object = Grains(
@@ -120,29 +175,6 @@ def test_area_thresholding():
         pixel_to_nm_scaling=1.0,
     )
 
-    test_img = np.array(
-        [
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 1, 1, 0, 3, 3, 0],
-            [0, 0, 1, 0, 3, 3, 0],
-            [0, 0, 0, 0, 0, 3, 0],
-            [0, 2, 0, 2, 0, 3, 0],
-            [0, 2, 2, 2, 0, 3, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-        ]
-    )
-    area_thresholds = [4.0, 6.0]
-    expected = np.array(
-        [
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-            [0, 1, 0, 1, 0, 0, 0],
-            [0, 1, 1, 1, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0],
-        ]
-    )
-    result = grains_object.area_thresholding(test_img, area_thresholds=area_thresholds)
+    result = grains_object.area_thresholding(test_labelled_image, area_thresholds=area_thresholds)
 
     np.testing.assert_array_equal(result, expected)

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -205,7 +205,7 @@ class Grains:
             Image array where the background == 0 and grains are labelled as integers > 0.
         area_thresholds: list
             List of area thresholds (in nanometres squared, not pixels squared), first should be
-            the below (smaller) threshold, second above (larger) threshold.
+            the lower limit for size, and the second should be the upper limit for size.
 
         Returns
         -------
@@ -214,23 +214,23 @@ class Grains:
 
         """
         image_cp = image.copy()
-        below, above = area_thresholds
+        lower_size_limit, upper_size_limit = area_thresholds
         # if one value is None adjust for comparison
-        if above is None:
-            above = image.size * self.pixel_to_nm_scaling**2
-        if below is None:
-            below = 0
+        if upper_size_limit is None:
+            upper_size_limit = image.size * self.pixel_to_nm_scaling**2
+        if lower_size_limit is None:
+            lower_size_limit = 0
         # Get array of grain numbers (discounting zero)
         uniq = np.delete(np.unique(image), 0)
         grain_count = 0
         LOGGER.info(
-            f"[{self.filename}] : Area thresholding grains | Thresholds: L: {(below / self.pixel_to_nm_scaling**2):.2f},"
-            f"U: {(above / self.pixel_to_nm_scaling**2):.2f} px^2, L: {below:.2f}, U: {above:.2f} nm^2."
+            f"[{self.filename}] : Area thresholding grains | Thresholds: L: {(lower_size_limit / self.pixel_to_nm_scaling**2):.2f},"
+            f"U: {(upper_size_limit / self.pixel_to_nm_scaling**2):.2f} px^2, L: {lower_size_limit:.2f}, U: {upper_size_limit:.2f} nm^2."
         )
         for grain_no in uniq:  # Calculate grian area in nm^2
             grain_area = np.sum(image_cp == grain_no) * (self.pixel_to_nm_scaling**2)
             # Compare area in nm^2 to area thresholds
-            if grain_area > above or grain_area < below:
+            if grain_area > upper_size_limit or grain_area < lower_size_limit:
                 image_cp[image_cp == grain_no] = 0
             else:
                 grain_count += 1


### PR DESCRIPTION
Closes #486 

This PR adds unit tests for area thresholding functions, `area_thresholding` and `remove_small_objects` in `grains.py`. I think there is something to be said for potentially removing the `remove_small_objects` function since it runs when no area thresholds are set, and so feels a bit counter to what the user might want, but that decision should be left to discussion at a later point.