### PR TITLE
Sylvia whittle/550 replace imghdr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tests = [
   "pytest-cov",
   "pytest-mpl",
   "pytest-regtest",
+  "filetype",
 ]
 docs = [
   "Sphinx",

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,8 +1,7 @@
 """Test end-to-end running of topostats."""
 from pathlib import Path
 
-# pylint: disable=deprecated-module
-import imghdr
+import filetype
 import numpy as np
 import pytest
 
@@ -113,7 +112,7 @@ def test_save_cropped_grains(
     )
 
 
-@pytest.mark.parametrize("extension", [("png"), ("tiff")])
+@pytest.mark.parametrize("extension", [("png"), ("tif")])
 def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, extension: str):
     """Tests if save format applied to cropped images"""
     process_scan_config["plotting"]["image_set"] = "all"
@@ -132,12 +131,10 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
         output_dir=tmp_path,
     )
 
-    assert (
-        imghdr.what(
-            tmp_path / "tests/resources/processed/minicircle/grains/above" / f"minicircle_grain_image_0.{extension}"
-        )
-        == extension
+    guess = filetype.guess(
+        tmp_path / "tests/resources/processed/minicircle/grains/above" / f"minicircle_grain_image_0.{extension}"
     )
+    assert guess.extension == extension
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #550 

My attempt at a solution for the depreciation of `imghdr`. Uses `filetype` which while it is not part of the standard library, is listed as one of the go-to alternatives in the [PEP 594](https://peps.python.org/pep-0594/#imghdr) document. 

<img width="844" alt="image" src="https://github.com/AFM-SPM/TopoStats/assets/86117496/067db67b-40da-41ea-9f93-0927b1ec3829">
