### PR TITLE
Sylvia whittle/596 zscale grains

### DIFF
--- a/topostats/plotting_dictionary.yaml
+++ b/topostats/plotting_dictionary.yaml
@@ -137,7 +137,7 @@ grain_image:
   image_type: "non-binary"
   core_set: false
 grain_mask:
-  image_type: "non-binary"
+  image_type: "binary"
   core_set: false
 grain_mask_image:
   image_type: "non-binary"

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -102,8 +102,10 @@ def update_plotting_config(plotting_config: dict) -> dict:
         main_config.pop(opt)
     for image, options in plotting_config["plot_dict"].items():
         plotting_config["plot_dict"][image] = {**options, **main_config}
-        if image not in ["z_threshed", "mask_overlay"]:
-            plotting_config["plot_dict"][image].pop("zrange")
+        # Make it so that binary images do not have the user-defined z-scale
+        # applied, but non-binary images do.
+        if plotting_config["plot_dict"][image]["image_type"] == "binary":
+            plotting_config["plot_dict"][image]["zrange"] = [None, None]
 
     return plotting_config
 


### PR DESCRIPTION
Closes #596 

This PR makes it so that the `z-range` set in the config file is applied to all non-binary images, not just the `core` image set. This has been done by editing `update_plotting_config` to no longer remove the `zrange` item from the `plot_dict` dictionaries and instead, sets the item to `[None, None]` for binary images, and sets it to the user defined range for non-binary images.

I have updated the test `test_update_plotting_config` in `test_utils.py` accordingly to check that binary and non-binary images behave as expected.

The new outputs with a `z-range` of `[-3, 4]` applied:
![image](https://github.com/AFM-SPM/TopoStats/assets/86117496/f92638ff-e1b7-4d0c-b243-b6efc653268b)
![image](https://github.com/AFM-SPM/TopoStats/assets/86117496/e3b9bb47-1b9b-4a4a-a5e2-ccb5f6b61b04)
![image](https://github.com/AFM-SPM/TopoStats/assets/86117496/e5dbbdc8-59d6-4476-96ea-e9fb54daf649)
![image](https://github.com/AFM-SPM/TopoStats/assets/86117496/461dffb5-270c-41f6-84c0-cde9e8215a3e)
