### PR TITLE
Adds pytest exts to dev dependencies; disables some pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ dev = [
   "pre-commit",
   "pylint",
   "pyupgrade",
+  "pytest-durations",
+  "pytest-xdist",
 ]
 pypi = [
   "build",
@@ -149,6 +151,7 @@ testpaths = [
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
     "ignore::UserWarning"
 ]
 


### PR DESCRIPTION
Adding `pytest-xdist` and `pytest-durations` to the `dev` dependencies, they're useful to have and I found they were missing when I setup a clean environment to check/test #633, reduces a bit of developer friction to have these installed automatically.

I've also disabled `PendingDperecationWarning` from `pytest` reporting and made a note for myself to report this as an issue for the warnings that we now won't see (requires registering at SourceForge which is a blast from the past!)