### PR TITLE
Fix plotting in pixels for topostats files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,6 +150,13 @@ def plotting_config(default_config: Dict) -> Dict:
 
 
 @pytest.fixture
+def plotting_config_with_plot_dict(default_config: Dict) -> Dict:
+    """Plotting configuration with plot dict"""
+    config = default_config["plotting"]
+    return config
+
+
+@pytest.fixture
 def image_random() -> np.ndarray:
     """Random image as NumPy array."""
     rng = np.random.default_rng(seed=1000)

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -9,13 +9,28 @@ from skimage import io
 
 from topostats.grains import Grains
 from topostats.io import LoadScans
-from topostats.plottingfuncs import dilate_binary_image, Images
+from topostats.plottingfuncs import dilate_binary_image, Images, add_pixel_to_nm_to_plotting_config
 
 
 DPI = 300.0
 RNG = np.random.default_rng(seed=1000)
 ARRAY = RNG.random((10, 10))
 MASK = RNG.uniform(low=0, high=1, size=ARRAY.shape) > 0.5
+
+
+def test_add_pixel_to_nm_to_plotting_config(plotting_config_with_plot_dict):
+    """Test the add_pixel_to_nm_to_plotting_config function of plottingfuncs.py, ensuring
+    that every plot's config contains the pixel to nanometre scaling factor needed for
+    plotting images in nanometres rather than pixels."""
+
+    plotting_config = add_pixel_to_nm_to_plotting_config(
+        plotting_config=plotting_config_with_plot_dict, pixel_to_nm_scaling=1.23456789
+    )
+
+    # Ensure that every plot's config has the correct pixel to nm scaling factor.
+    for _, plot_config in plotting_config["plot_dict"].items():
+        if plot_config["pixel_to_nm_scaling"] != 1.23456789:
+            assert False
 
 
 @pytest.mark.parametrize(

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -25,6 +25,31 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 # pylint: disable=dangerous-default-value
 
 
+def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:
+    """Function to ensure that the plotting config has the pixel to nanometre scaling factor accessible
+    for plotting. This ensures that the plot scaling are in nanometres and not pixels.
+
+    Parameters
+    ----------
+    plotting_config: dict
+        TopoStats plotting configuration dictionary
+    pixel_to_nm_scaling: float
+        Pixel to nanometre scaling factor for the image.
+
+    Returns
+    -------
+    plotting_config: dict
+        Updated plotting config with the pixel to nanometre scaling factor
+        applied to all the image configurations.
+    """
+
+    # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
+    plot_opts = {"pixel_to_nm_scaling": pixel_to_nm_scaling}
+    for image, options in plotting_config["plot_dict"].items():
+        plotting_config["plot_dict"][image] = {**options, **plot_opts}
+    return plotting_config
+
+
 def dilate_binary_image(binary_image: np.ndarray, dilation_iterations: int) -> np.ndarray:
     """Dilate a supplied binary image a given number of times.
 

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:
     """Ensure that the plotting config has the pixel to nanometre scaling factor accessible
-    for plotting. This ensures that the plot scaling are in nanometres and not pixels.
+    for plotting so that plots are in nanometres and not pixels.
 
     Parameters
     ----------

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:
-    """Function to ensure that the plotting config has the pixel to nanometre scaling factor accessible
+    """Ensure that the plotting config has the pixel to nanometre scaling factor accessible
     for plotting. This ensures that the plot scaling are in nanometres and not pixels.
 
     Parameters

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -12,7 +12,7 @@ from topostats.grains import Grains
 from topostats.grainstats import GrainStats
 from topostats.io import get_out_path, save_array, save_topostats_file
 from topostats.logs.logs import setup_logger, LOGGER_NAME
-from topostats.plottingfuncs import Images
+from topostats.plottingfuncs import Images, add_pixel_to_nm_to_plotting_config
 from topostats.tracing.dnatracing import trace_image
 from topostats.utils import create_empty_dataframe
 from topostats.statistics import image_statistics
@@ -84,10 +84,6 @@ def run_filters(
         if plotting_config["run"]:
             plotting_config.pop("run")
             LOGGER.info(f"[{filename}] : Plotting Filtering Images")
-            # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
-            plot_opts = {"pixel_to_nm_scaling": pixel_to_nm_scaling}
-            for image, options in plotting_config["plot_dict"].items():
-                plotting_config["plot_dict"][image] = {**options, **plot_opts}
             # Generate plots
             for plot_name, array in filters.images.items():
                 if plot_name not in ["scan_raw"]:
@@ -572,6 +568,8 @@ def process_scan(
         filename=topostats_object["filename"],
         plotting_config=plotting_config,
     )
+
+    plotting_config = add_pixel_to_nm_to_plotting_config(plotting_config, topostats_object["pixel_to_nm_scaling"])
 
     # Flatten Image
     image_flattened = run_filters(


### PR DESCRIPTION
Closes #657 

This PR fixes the issue where TopoStats would output images scaled in pixels if `Filters` had not been ran.
The issue happened because the code that adds the `pixel_to_nanometre_scaling` factor into the `plotting_dictionary` was inside the `run_filters` function. I have created a function for this code, added a test for it, and moved it out front into `process_scan` as it should always be run.

See here `minicircles.spm` successfully plotted in nanometres without `Filters` being ran.
<img width="716" alt="image" src="https://github.com/AFM-SPM/TopoStats/assets/86117496/d513074e-be03-48fe-ac62-9b2df05abfde">

