### PR TITLE
Changed dict crop_size -1 names to match processing

### DIFF
--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -205,10 +205,10 @@ class GrainStats:
                 }.items():
                     grains_plot_data.append(
                         {
-                            "image": image,
-                            "output_grain": output_grain,
+                            "data": image,
+                            "output_dir": output_grain,
                             "filename": f"{self.image_name}_{name}_{index}",
-                            "plot_opts": self.plot_opts[name],
+                            "name": name,
                         }
                     )
 


### PR DESCRIPTION
Noticed that no grainstats were being made when cropped_size = -1

Was due to incorrect dictionary keys being called