### PR TITLE
Lower default DPI of individual molecule plots

### DIFF
--- a/topostats/plotting_dictionary.yaml
+++ b/topostats/plotting_dictionary.yaml
@@ -190,5 +190,5 @@ grain_mask_image:
   core_set: false
 single_molecule_trace:
   image_type: "non-binary"
-  dpi: 800
+  dpi: 100
   core_set: false

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -224,7 +224,8 @@ class Images:
                     else:
                         self.save_array_figure()
         LOGGER.info(
-            f"[{self.filename}] : Image saved to : {str(self.output_dir / self.filename)}" f".{self.save_format}"
+            f"[{self.filename}] : Image saved to : {str(self.output_dir / self.filename)}.{self.save_format}\
+ | DPI: {self.dpi}"
         )
         return fig, ax
 


### PR DESCRIPTION
Changes the DPI for individual molecule plots to `100` as the previous setting of `800` caused RAM issues and slow plotting. Thanks to @MaxGamill-Sheffield for pointing this out and @ns-rse for enabling easy configuring of DPI for each type of plot!

I have also added the DPI into the logging statement for plotting as this may be helpful for debugging.