### PR TITLE
Adding Ruff and pydocstyle to pre-commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,10 @@
 # ruff and pydocstyle - Lint code base with ruff and pydocstyle using pre-commit
+3518612caeb76df02b5313893e172db4dd159535
+e9d4e30271cbe9884e9dfaca8c739a071d373a50
+a239aa642d2a4f98d6b491e725368fecb0c93ead
+d975e08e5164a99c723dfa6bfee9a26ff2ac8df6
+22a38d80ca010959be11c64ceb5558853f2c5dec
+844f98d74d3cc5f4c091128758800baf083a9460
 b1b846722ccc89589954f89aaa617459062ffc7d
 
 # markdownlint-cli2 - Lint code base with markdownlint-cli2

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# ruff and pydocstyle - Lint code base with ruff and pydocstyle using pre-commit
+b1b846722ccc89589954f89aaa617459062ffc7d
+
 # markdownlint-cli2 - Lint code base with markdownlint-cli2
 fe5b033d027a2d0c1239025cc081f1638601c5ee
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,14 +49,14 @@ repos:
     hooks:
       - id: nbstripout
 
-  # - repo: local
-  #   hooks:
-  #     - id: pylint
-  #       args: ["--rcfile=.pylintrc"]
-  #       name: Pylint
-  #       entry: python -m pylint
-  #       language: system
-  #       files: \.py$
+  - repo: local
+    hooks:
+      - id: pylint
+        args: ["--rcfile=.pylintrc"]
+        name: Pylint
+        entry: python -m pylint
+        language: system
+        files: \.py$
 
 ci:
   autofix_prs: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,13 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.289
+    hooks:
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
+
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
@@ -42,28 +49,14 @@ repos:
     hooks:
       - id: nbstripout
 
-  - repo: https://github.com/pycqa/flake8.git
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        args: ["--extend-exclude=topostats/_version.py"]
-        additional_dependencies: [flake8-print, Flake8-pyproject]
-        types: [python]
-  # - repo: https://github.com/pycqa/pylint.git
-  #   rev: 2.15.9
+  # - repo: local
   #   hooks:
   #     - id: pylint
-  #       types: [python]
   #       args: ["--rcfile=.pylintrc"]
+  #       name: Pylint
+  #       entry: python -m pylint
+  #       language: system
   #       files: \.py$
-  - repo: local
-    hooks:
-      - id: pylint
-        args: ["--rcfile=.pylintrc"]
-        name: Pylint
-        entry: python -m pylint
-        language: system
-        files: \.py$
 
 ci:
   autofix_prs: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,7 +23,10 @@ fail-under=10.0
 ignore=CVS,
        _version.py,
        dnatracing.py,
-       conf.py
+       dnacurvature.py,
+       conf.py,
+       test_dnacurvature.py,
+       __main__.py
 
 # Add files or directories matching the regex patterns to the ignore-list. The
 # regex matches against paths and can be in Posix or Windows format.
@@ -82,6 +85,7 @@ confidence=
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable=C0103,
+        E1131,
         R0801,
         raw-checker-failed,
         bad-inline-option,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,14 +80,17 @@ documentation and testing.
 Using a consistent coding style has many benefits (see [Linting : What is all the fluff
 about?](https://rse.shef.ac.uk/blog/2022-04-19-linting/)). For this project we aim to adhere to [PEP8 - the style Guide
 for Python Code](https://pep8.org/) and do so using the formatting linters [black](https://github.com/psf/black) and
-[flake8](https://github.com/PyCQA/flake8).  Many popular IDEs such as VSCode, PyCharm, Spyder and Emacs all have support
-for integrating these linters into your workflow such that when you save a file the linting/formatting is automatically
-applied.
+[ruff](https://github.com/astral-sh/ruff). Ruff implements the checks made by
+[Flake8](https://flake8.pycqa.org/en/latest/), [isort](https://pycqa.github.io/isort/) and
+[pydocstyle](https://black.readthedocs.io/en/stable/) and has some overlap with both Black and Pylint.
 
 We also like to ensure the code passes [pylint](https://github.com/PyCQA/pylint) which helps identify code duplication
 and reduces some of the [code smells](https://en.wikipedia.org/wiki/Code_smell) that we are all prone to
 making. A `.pylintrc` is included in the repository. Currently this isn't strictly applied but it is planned for part of
 the CI/CD pipeline and so we would be grateful if you could lint your code before making Pull Requests.
+
+Many popular IDEs such as VSCode, PyCharm, Spyder and Emacs all have support for integrating these linters into your
+workflow such that when you save a file the linting/formatting is automatically applied.
 
 ### Pre-commit
 
@@ -106,9 +109,14 @@ pre-commit install --install-hooks
 ```
 
 Currently there are hooks to remove trailing whitespace, check YAML configuration files and a few other common checks as
-well as hooks for `black` and `flake8`. If these fail then you will not be able to make a commit until they are
+well as hooks for `black` and `ruff`. If these fail then you will not be able to make a commit until they are
 fixed. The `black` hook will automatically format failed files so you can simply `git add` those and try committing
 straight away. `flake8` does not correct files automatically so the errors will need manually correcting.
+
+If you do not enable and resolve issues reported by `pre-commit` locally before making a pull request you will find the
+[`pre-commit.ci`](https://pre-commit.ci) GitHub Action will fail, preventing your Pull Request from being merged. You
+can shorten the feedback loop and speed up the resolution of errors by enabling `pre-commit` locally and resolving
+issues before making your commits.
 
 ### Typing
 
@@ -123,7 +131,9 @@ defining their functionality, parameters and return values and pylint will note 
 by way of the `missing-function-docstring` condition.
 
 Further, when new methods are incorporated into the package that introduce changes to the configuration they should be
-documented under [Parameter Configuration](configuration)
+documented under [Parameter Configuration](configuration). [pre-commit](#pre-commit) has the
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) hook enabled to lint all Markdown files and will
+where possible automatically fix things, but some issues need resolving manually.
 
 ### Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,27 +105,6 @@ Source = "https://github.com/AFM-SPM/TopoStats"
 Bug_Tracker = "https://github.com/AFM-SPM/TopoStats/issues"
 Documentation = "https://AFM-SPM.github.io/TopoStats"
 
-[tool.flake8]
-max_line_length=120
-docstring-convention= "numpy"
-exclude = [
-  "*.ipynb",
-  ".git",
-  "__pycache__",
-  "docs/conf.py",
-  "build",
-  "dist",
-  "pygwytracing.py",
-  "topostats/plotting.py",
-  "topostats/tracing/tracingfuncs.py",
-  "topostats/tracing/dnatracing.py",
-  "topostats/tracing/tracing_dna.py",
-  "tests/tracing/test_dnatracing.py",
-]
-extend-ignore = [
-    "E501",
-    "T201",
-]
 
 [tool.setuptools]
 include-package-data = true
@@ -179,9 +158,11 @@ exclude = '''
 
 [tool.ruff]
 exclude = [
+  "*.ipynb",
   ".bzr",
   ".direnv",
   ".eggs",
+  ".git",
   ".git",
   ".hg",
   ".mypy_cache",
@@ -192,20 +173,48 @@ exclude = [
   ".svn",
   ".tox",
   ".venv",
+  "__pycache__",
   "__pypackages__",
   "_build",
   "buck-out",
   "build",
   "dist",
+  "docs/conf.py",
   "node_modules",
+  "pygwytracing.py",
+  "tests/tracing/test_dnacurvature.py",
+  "tests/tracing/test_dnatracing.py",
+  "tests/tracing/test_tracing_dna.py",
+  "topostats/plotting.py",
+  "topostats/tracing/dnatracing.py",
+  "topostats/tracing/tracing_dna.py",
+  "topostats/tracing/tracingfuncs.py",
   "venv",
 ]
 # per-file-ignores = []
 line-length = 120
 target-version = "py310"
+select = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
+ignore = [
+  "B905",
+  "E501",
+  "S101",
+  "T201"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "R", "S", "W", "U"]
+fixable = ["A", "B", "C", "D", "E", "F", "PT", "PTH", "R", "S", "W", "U"]
 unfixable = []
+
+[tool.ruff.flake8-quotes]
+docstring-quotes = "double"
+
+[tool.ruff.isort]
+case-sensitive = true
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = true
 
 [project.scripts]
 topostats = "topostats.entry_point:entry_point"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,6 @@ exclude = [
   ".direnv",
   ".eggs",
   ".git",
-  ".git",
   ".hg",
   ".mypy_cache",
   ".nox",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
-"""Fixtures for testing"""
+"""Fixtures for testing."""
 import importlib.resources as pkg_resources
 from pathlib import Path
-from typing import Dict
 import yaml
 
 import numpy as np
@@ -29,9 +28,12 @@ THRESHOLD = 0.5
 CHANNEL = "Height"
 
 
-@pytest.fixture
-def default_config() -> Dict:
-    """Sample configuration"""
+# ruff: noqa: D401
+
+
+@pytest.fixture()
+def default_config() -> dict:
+    """Sample configuration."""
     config = read_yaml(BASE_DIR / "topostats" / "default_config.yaml")
     plotting_dictionary = pkg_resources.open_text(topostats, "plotting_dictionary.yaml")
     config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary.read())
@@ -44,9 +46,9 @@ def default_config() -> Dict:
     return config
 
 
-@pytest.fixture
-def process_scan_config() -> Dict:
-    """Sample configuration"""
+@pytest.fixture()
+def process_scan_config() -> dict:
+    """Sample configuration."""
     config = read_yaml(BASE_DIR / "topostats" / "default_config.yaml")
     config["grains"]["threshold_std_dev"]["below"] = 1.0
     config["grains"]["absolute_area_threshold"]["above"] = [500, 800]
@@ -56,17 +58,19 @@ def process_scan_config() -> Dict:
     return config
 
 
-@pytest.fixture
-def plot_dict() -> Dict:
-    """Load the plot_dict dictionary. This is required because the above configs have the 'plot_dict' key/value
-    popped."""
+@pytest.fixture()
+def plot_dict() -> dict:
+    """Load the plot_dict dictionary.
+
+    This is required because the above configs have the 'plot_dict' key/value popped.
+    """
     plotting_dictionary = pkg_resources.open_text(topostats, "plotting_dictionary.yaml")
     return yaml.safe_load(plotting_dictionary.read())
 
 
-@pytest.fixture
-def summary_config() -> Dict:
-    """Sample summary configuration"""
+@pytest.fixture()
+def summary_config() -> dict:
+    """Sample summary configuration."""
     summary_yaml = pkg_resources.open_text(topostats, "summary_config.yaml")
     summary_config = yaml.safe_load(summary_yaml.read())
     # Tweak configuration (for now) to match the tests
@@ -83,65 +87,66 @@ def summary_config() -> Dict:
     return summary_config
 
 
-@pytest.fixture
-def toposum_object_single_directory(summary_config: Dict) -> TopoSum:
-    """Set up a TopoSum object fixture for testing plotting, using a dataframe containing data from a single
-    directory."""
-    toposum = TopoSum(csv_file=RESOURCES / "toposum_all_statistics_single_directory.csv", **summary_config)
-    return toposum
+@pytest.fixture()
+def toposum_object_single_directory(summary_config: dict) -> TopoSum:
+    """Set up a TopoSum object fixture for testing plotting.
+
+    Uses a dataframe containing data from a single directory.
+    """
+    return TopoSum(csv_file=RESOURCES / "toposum_all_statistics_single_directory.csv", **summary_config)
 
 
-@pytest.fixture
-def toposum_object_multiple_directories(summary_config: Dict) -> TopoSum:
-    """Set up a TopoSum object fixture for testing plotting, using a dataframe containing data from several
-    directories."""
-    toposum = TopoSum(csv_file=RESOURCES / "toposum_all_statistics_multiple_directories.csv", **summary_config)
-    return toposum
+@pytest.fixture()
+def toposum_object_multiple_directories(summary_config: dict) -> TopoSum:
+    """Set up a TopoSum object fixture for testing plotting.
+
+    Uses a dataframe containing data from several directories.
+    """
+    return TopoSum(csv_file=RESOURCES / "toposum_all_statistics_multiple_directories.csv", **summary_config)
 
 
-@pytest.fixture
-def loading_config(default_config: Dict) -> Dict:
-    """Configuration for loading scans"""
-    config = default_config["loading"]
-    return config
+@pytest.fixture()
+def loading_config(default_config: dict) -> dict:
+    """Configuration for loading scans."""
+    return default_config["loading"]
 
 
-@pytest.fixture
-def filter_config(default_config: Dict) -> Dict:
-    """Configurations for filtering"""
+@pytest.fixture()
+def filter_config(default_config: dict) -> dict:
+    """Configurations for filtering."""
     config = default_config["filter"]
     config.pop("run")
     return config
 
 
-@pytest.fixture
-def grains_config(default_config: Dict) -> Dict:
+@pytest.fixture()
+def grains_config(default_config: dict) -> dict:
     """Configurations for grain finding."""
     config = default_config["grains"]
     config.pop("run")
     return config
 
 
-@pytest.fixture
-def grainstats_config(default_config: Dict) -> Dict:
-    """Configurations for grainstats"""
+@pytest.fixture()
+def grainstats_config(default_config: dict) -> dict:
+    """Configurations for grainstats."""
     config = default_config["grainstats"]
     config["direction"] = "above"
     config.pop("run")
     return config
 
 
-@pytest.fixture
-def dnatracing_config(default_config: Dict) -> Dict:
-    """Configurations for dnatracing"""
+@pytest.fixture()
+def dnatracing_config(default_config: dict) -> dict:
+    """Configurations for dnatracing."""
     config = default_config["dnatracing"]
     config.pop("run")
     return config
 
 
-@pytest.fixture
-def plotting_config(default_config: Dict) -> Dict:
-    """Configurations for plotting"""
+@pytest.fixture()
+def plotting_config(default_config: dict) -> dict:
+    """Configurations for plotting."""
     config = default_config["plotting"]
     config["image_set"] = "all"
     config.pop("run")
@@ -149,117 +154,115 @@ def plotting_config(default_config: Dict) -> Dict:
     return config
 
 
-@pytest.fixture
-def plotting_config_with_plot_dict(default_config: Dict) -> Dict:
-    """Plotting configuration with plot dict"""
-    config = default_config["plotting"]
-    return config
+@pytest.fixture()
+def plotting_config_with_plot_dict(default_config: dict) -> dict:
+    """Plotting configuration with plot dict."""
+    return default_config["plotting"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random() -> np.ndarray:
     """Random image as NumPy array."""
     rng = np.random.default_rng(seed=1000)
     return rng.random((1024, 1024))
 
 
-@pytest.fixture
+@pytest.fixture()
 def small_array() -> np.ndarray:
-    """Small (10x10) image array for testing"""
+    """Small (10x10) image array for testing."""
     return RNG.random(SMALL_ARRAY_SIZE)
 
 
-@pytest.fixture
+@pytest.fixture()
 def small_mask() -> np.ndarray:
     """Small (10x10) mask array for testing."""
     return RNG.uniform(low=0, high=1, size=SMALL_ARRAY_SIZE) > 0.5
 
 
-@pytest.fixture
+@pytest.fixture()
 def synthetic_scars_image() -> np.ndarray:
     """Small synthetic image for testing scar removal."""
     return np.load(RESOURCES / "test_scars_synthetic_scar_image.npy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def synthetic_marked_scars() -> np.ndarray:
     """Small synthetic boolean array of marked scar coordinates corresponding to synthetic_scars_image."""
     return np.load(RESOURCES / "test_scars_synthetic_mark_scars.npy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_row_medians() -> np.array:
     """Expected row medians (unmasked)."""
     return np.loadtxt(RESOURCES / "image_random_row_medians.csv", delimiter=",")
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_col_medians() -> np.array:
     """Expected column medians (unmasked)."""
     return np.loadtxt(RESOURCES / "image_random_col_medians.csv", delimiter=",")
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_median_flattened() -> np.array:
     """Expected aligned rows (unmasked)."""
     df = pd.read_csv(RESOURCES / "image_random_median_flattened.csv.bz2", header=None)
     return df.to_numpy()
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_remove_x_y_tilt() -> np.array:
     """Expected removed tilt (unmasked)."""
     df = pd.read_csv(RESOURCES / "image_random_remove_x_y_tilt.csv.bz2", header=None)
     return df.to_numpy()
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_remove_quadratic() -> np.array:
-    """Expected removed quadratic (unmasked)"""
+    """Expected removed quadratic (unmasked)."""
     df = pd.read_csv(RESOURCES / "image_random_remove_quadratic.csv.bz2", header=None)
     return df.to_numpy()
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_mask() -> np.array:
     """Expected mask."""
     df = pd.read_csv(RESOURCES / "image_random_mask.csv.bz2", header=None)
     return df.to_numpy()
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_row_medians_masked() -> np.array:
     """Expected row medians (masked)."""
     return np.loadtxt(RESOURCES / "image_random_row_medians_masked.csv", delimiter=",")
 
 
-@pytest.fixture
+@pytest.fixture()
 def image_random_col_medians_masked() -> np.array:
     """Expected column medians (masked)."""
     return np.loadtxt(RESOURCES / "image_random_col_medians_masked.csv", delimiter=",")
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_filters(load_scan: LoadScans, filter_config: dict) -> Filters:
     """Filters class for testing."""
     load_scan.get_data()
-    filters = Filters(
+    return Filters(
         image=load_scan.image,
         filename=load_scan.filename,
         pixel_to_nm_scaling=load_scan.pixel_to_nm_scaling,
         **filter_config,
     )
-    return filters
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_filters_random(test_filters: Filters, image_random: np.ndarray) -> Filters:
     """Filters class for testing with pixels replaced by random image."""
     test_filters.images["pixels"] = image_random
     return test_filters
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_filters_random_with_mask(filter_config: dict, test_filters: Filters, image_random: np.ndarray) -> Filters:
     """Filters class for testing with pixels replaced by random image."""
     test_filters.images["pixels"] = image_random
@@ -272,7 +275,7 @@ def test_filters_random_with_mask(filter_config: dict, test_filters: Filters, im
     return test_filters
 
 
-@pytest.fixture
+@pytest.fixture()
 def random_filters(test_filters_random_with_mask: Filters) -> Filters:
     """Process random with filters, for use in grains fixture."""
     test_filters_random_with_mask.images["initial_median_flatten"] = test_filters_random_with_mask.median_flatten(
@@ -291,7 +294,7 @@ def random_filters(test_filters_random_with_mask: Filters) -> Filters:
     return test_filters_random_with_mask
 
 
-@pytest.fixture
+@pytest.fixture()
 def remove_scars_config(synthetic_scars_image: np.ndarray, default_config: dict) -> dict:
     """Configuration for testing scar removal."""
     config = default_config["filter"]["remove_scars"]
@@ -306,7 +309,7 @@ def remove_scars_config(synthetic_scars_image: np.ndarray, default_config: dict)
     return config
 
 
-@pytest.fixture
+@pytest.fixture()
 def random_grains(grains_config: dict, random_filters: Filters) -> Grains:
     """Grains object based on random image which has no grains."""
     grains = Grains(
@@ -319,7 +322,7 @@ def random_grains(grains_config: dict, random_filters: Filters) -> Grains:
     return grains
 
 
-@pytest.fixture
+@pytest.fixture()
 def small_array_filters(small_array: np.ndarray, load_scan: LoadScans, filter_config: dict) -> Grains:
     """Filters object based on small_array."""
     filter_obj = Filters(
@@ -334,20 +337,19 @@ def small_array_filters(small_array: np.ndarray, load_scan: LoadScans, filter_co
 
 
 # IO fixtures
-@pytest.fixture
+@pytest.fixture()
 def load_scan_dummy() -> LoadScans:
     """Instantiate a dummy LoadScans object for use in testing `.gwy` IO methods."""
     return LoadScans(img_paths="dummy", channel="dummy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan(loading_config: dict) -> LoadScans:
     """Instantiate a LoadScans object from a small .topostats image file."""
-    scan_loader = LoadScans([RESOURCES / "test_image" / "minicircle_small.topostats"], **loading_config)
-    return scan_loader
+    return LoadScans([RESOURCES / "test_image" / "minicircle_small.topostats"], **loading_config)
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_data() -> LoadScans:
     """Instance of a LoadScans object after applying the get_data func."""
     scan_data = LoadScans([RESOURCES / "test_image" / "minicircle_small.topostats"], channel="Height")
@@ -355,63 +357,57 @@ def load_scan_data() -> LoadScans:
     return scan_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_spm() -> LoadScans:
     """Instantiate a LoadScans object from a .spm file."""
-    scan_loader = LoadScans([RESOURCES / "minicircle.spm"], channel="Height")
-    return scan_loader
+    return LoadScans([RESOURCES / "minicircle.spm"], channel="Height")
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_ibw() -> LoadScans:
     """Instantiate a LoadScans object from a .ibw file."""
-    scan_loader = LoadScans([RESOURCES / "minicircle2.ibw"], channel="HeightTracee")
-    return scan_loader
+    return LoadScans([RESOURCES / "minicircle2.ibw"], channel="HeightTracee")
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_jpk() -> LoadScans:
     """Instantiate a LoadScans object from a .jpk file."""
-    scan_loader = LoadScans([RESOURCES / "file.jpk"], channel="height_trace")
-    return scan_loader
+    return LoadScans([RESOURCES / "file.jpk"], channel="height_trace")
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_gwy() -> LoadScans:
     """Instantiate a LoadScans object from a .gwy file."""
-    scan_loader = LoadScans([RESOURCES / "file.gwy"], channel="dummy_channel")
-    return scan_loader
+    return LoadScans([RESOURCES / "file.gwy"], channel="dummy_channel")
 
 
-@pytest.fixture
+@pytest.fixture()
 def load_scan_topostats() -> LoadScans:
     """Instantiate a LoadScans object from a .topostats file."""
-    scan_loader = LoadScans([RESOURCES / "file.topostats"], channel="dummy_channel")
-    return scan_loader
+    return LoadScans([RESOURCES / "file.topostats"], channel="dummy_channel")
 
 
 # Minicircle fixtures
-@pytest.fixture
+@pytest.fixture()
 def minicircle(load_scan: LoadScans, filter_config: dict) -> Filters:
     """Instantiate a Filters object, creates the output directory and loads the image."""
     load_scan.get_data()
-    filters = Filters(
+    return Filters(
         image=load_scan.image,
         filename=load_scan.filename,
         pixel_to_nm_scaling=load_scan.pixel_to_nm_scaling,
         **filter_config,
     )
-    return filters
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_initial_median_flatten(minicircle: Filters) -> Filters:
     """Initial align on unmasked data."""
     minicircle.images["initial_median_flatten"] = minicircle.median_flatten(minicircle.images["pixels"], mask=None)
     return minicircle
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_initial_tilt_removal(minicircle_initial_median_flatten: Filters) -> Filters:
     """Initial x/y tilt removal on unmasked data."""
     minicircle_initial_median_flatten.images["initial_tilt_removal"] = minicircle_initial_median_flatten.remove_tilt(
@@ -420,7 +416,7 @@ def minicircle_initial_tilt_removal(minicircle_initial_median_flatten: Filters) 
     return minicircle_initial_median_flatten
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_initial_quadratic_removal(minicircle_initial_tilt_removal: Filters) -> Filters:
     """Initial quadratic removal on unmasked data."""
     minicircle_initial_tilt_removal.images[
@@ -431,7 +427,7 @@ def minicircle_initial_quadratic_removal(minicircle_initial_tilt_removal: Filter
     return minicircle_initial_tilt_removal
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_threshold_otsu(minicircle_initial_tilt_removal: Filters, filter_config: dict) -> Filters:
     """Calculate threshold."""
     minicircle_initial_tilt_removal.thresholds = get_thresholds(
@@ -440,7 +436,7 @@ def minicircle_threshold_otsu(minicircle_initial_tilt_removal: Filters, filter_c
     return minicircle_initial_tilt_removal
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_threshold_stddev(minicircle_initial_tilt_removal: Filters) -> Filters:
     """Calculate threshold."""
     minicircle_initial_tilt_removal.thresholds = get_thresholds(
@@ -452,7 +448,7 @@ def minicircle_threshold_stddev(minicircle_initial_tilt_removal: Filters) -> Fil
     return minicircle_initial_tilt_removal
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_threshold_abs(minicircle_initial_tilt_removal: Filters) -> Filters:
     """Calculate threshold."""
     minicircle_initial_tilt_removal.thresholds = get_thresholds(
@@ -464,7 +460,7 @@ def minicircle_threshold_abs(minicircle_initial_tilt_removal: Filters) -> Filter
     return minicircle_initial_tilt_removal
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_mask(minicircle_threshold_otsu: Filters) -> Filters:
     """Derive mask based on threshold."""
     minicircle_threshold_otsu.images["mask"] = get_mask(
@@ -473,7 +469,7 @@ def minicircle_mask(minicircle_threshold_otsu: Filters) -> Filters:
     return minicircle_threshold_otsu
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_masked_median_flatten(minicircle_mask: Filters) -> Filters:
     """Secondary alignment using mask."""
     minicircle_mask.images["masked_median_flatten"] = minicircle_mask.median_flatten(
@@ -482,7 +478,7 @@ def minicircle_masked_median_flatten(minicircle_mask: Filters) -> Filters:
     return minicircle_mask
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_masked_tilt_removal(minicircle_masked_median_flatten: Filters) -> Filters:
     """Secondary x/y tilt removal using mask."""
     minicircle_masked_median_flatten.images["masked_tilt_removal"] = minicircle_masked_median_flatten.remove_tilt(
@@ -492,7 +488,7 @@ def minicircle_masked_tilt_removal(minicircle_masked_median_flatten: Filters) ->
     return minicircle_masked_median_flatten
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_masked_quadratic_removal(minicircle_masked_tilt_removal: Filters) -> Filters:
     """Secondary quadratic removal using mask."""
     minicircle_masked_tilt_removal.images["masked_quadratic_removal"] = minicircle_masked_tilt_removal.remove_quadratic(
@@ -501,7 +497,7 @@ def minicircle_masked_quadratic_removal(minicircle_masked_tilt_removal: Filters)
     return minicircle_masked_tilt_removal
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_gaussian_filter(minicircle_masked_quadratic_removal: Filters) -> Filters:
     """Apply Gaussian filter."""
     minicircle_masked_quadratic_removal.images[
@@ -513,19 +509,18 @@ def minicircle_grain_gaussian_filter(minicircle_masked_quadratic_removal: Filter
 
 
 # Derive fixtures for grain finding
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grains(minicircle_grain_gaussian_filter: Grains, grains_config: dict) -> Grains:
     """Grains object based on filtered minicircle."""
-    grains = Grains(
+    return Grains(
         image=minicircle_grain_gaussian_filter.images["gaussian_filtered"],
         filename=minicircle_grain_gaussian_filter.filename,
         pixel_to_nm_scaling=minicircle_grain_gaussian_filter.pixel_to_nm_scaling,
         **grains_config,
     )
-    return grains
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_threshold_otsu(minicircle_grains: Grains, grains_config: dict) -> Grains:
     """Calculate threshold."""
     grains_config.pop("threshold_method")
@@ -537,7 +532,7 @@ def minicircle_grain_threshold_otsu(minicircle_grains: Grains, grains_config: di
     return minicircle_grains
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_threshold_stddev(minicircle_grains: Grains, grains_config: dict) -> Grains:
     """Calculate threshold."""
     grains_config["threshold_method"] = "std_dev"
@@ -551,7 +546,7 @@ def minicircle_grain_threshold_stddev(minicircle_grains: Grains, grains_config: 
     return minicircle_grains
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_threshold_abs(minicircle_grains: Grains) -> Grains:
     """Calculate threshold."""
     minicircle_grains.thresholds = get_thresholds(
@@ -563,7 +558,7 @@ def minicircle_grain_threshold_abs(minicircle_grains: Grains) -> Grains:
     return minicircle_grains
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_mask(minicircle_grain_threshold_abs: Grains) -> Grains:
     """Boolean mask."""
     minicircle_grain_threshold_abs.directions["above"] = {}
@@ -576,7 +571,7 @@ def minicircle_grain_mask(minicircle_grain_threshold_abs: Grains) -> Grains:
     return minicircle_grain_threshold_abs
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_clear_border(minicircle_grain_mask: np.array) -> Grains:
     """Cleared borders."""
     minicircle_grain_mask.directions["above"]["tidied_border"] = minicircle_grain_mask.tidy_border(
@@ -585,7 +580,7 @@ def minicircle_grain_clear_border(minicircle_grain_mask: np.array) -> Grains:
     return minicircle_grain_mask
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_remove_noise(minicircle_grain_clear_border: Grains) -> Grains:
     """Fixture to test removing noise."""
     minicircle_grain_clear_border.directions["above"]["removed_noise"] = minicircle_grain_clear_border.remove_noise(
@@ -594,7 +589,7 @@ def minicircle_grain_remove_noise(minicircle_grain_clear_border: Grains) -> Grai
     return minicircle_grain_clear_border
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_labelled_all(minicircle_grain_remove_noise: Grains) -> Grains:
     """Labelled regions."""
     minicircle_grain_remove_noise.directions["above"][
@@ -603,7 +598,7 @@ def minicircle_grain_labelled_all(minicircle_grain_remove_noise: Grains) -> Grai
     return minicircle_grain_remove_noise
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_minimum_grain_size(minicircle_grain_labelled_all: Grains) -> Grains:
     """Minimum grain size."""
     minicircle_grain_labelled_all.calc_minimum_grain_size(
@@ -612,7 +607,7 @@ def minicircle_minimum_grain_size(minicircle_grain_labelled_all: Grains) -> Grai
     return minicircle_grain_labelled_all
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_small_objects_removed(minicircle_minimum_grain_size: Grains) -> Grains:
     """Small objects removed."""
     minicircle_minimum_grain_size.directions["above"][
@@ -623,7 +618,7 @@ def minicircle_small_objects_removed(minicircle_minimum_grain_size: Grains) -> G
     return minicircle_minimum_grain_size
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_area_thresholding(minicircle_grain_labelled_all: Grains) -> Grains:
     """Small objects removed."""
     absolute_area_thresholds = [30, 2000]
@@ -636,7 +631,7 @@ def minicircle_area_thresholding(minicircle_grain_labelled_all: Grains) -> Grain
     return minicircle_grain_labelled_all
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_labelled_post_removal(minicircle_small_objects_removed: np.array) -> Grains:
     """Labelled regions."""
     minicircle_small_objects_removed.directions["above"][
@@ -647,7 +642,7 @@ def minicircle_grain_labelled_post_removal(minicircle_small_objects_removed: np.
     return minicircle_small_objects_removed
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_region_properties_post_removal(minicircle_grain_labelled_post_removal: np.array) -> np.array:
     """Region properties."""
     return minicircle_grain_labelled_post_removal.get_region_properties(
@@ -655,7 +650,7 @@ def minicircle_grain_region_properties_post_removal(minicircle_grain_labelled_po
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grain_coloured(minicircle_grain_labelled_post_removal: np.array) -> Grains:
     """Coloured regions."""
     minicircle_grain_labelled_post_removal.directions["above"][
@@ -667,21 +662,20 @@ def minicircle_grain_coloured(minicircle_grain_labelled_post_removal: np.array) 
 
 
 # Derive fixture for grainstats
-@pytest.fixture
+@pytest.fixture()
 def grainstats(image_random: np.array, grainstats_config: dict, tmp_path) -> GrainStats:
     """Grainstats class for testing functions."""
-    gstats = GrainStats(
+    return GrainStats(
         image_random,
         image_random,
         pixel_to_nanometre_scaling=0.5,
         base_output_dir=tmp_path,
         **grainstats_config,
     )
-    return gstats
 
 
 # Minicircle
-@pytest.fixture
+@pytest.fixture()
 def minicircle_grainstats(
     minicircle_grain_gaussian_filter: Filters,
     minicircle_grain_labelled_post_removal: Grains,
@@ -721,17 +715,17 @@ GRAINS = np.array(
 FULL_IMAGE = RNG.random((GRAINS.shape[0], GRAINS.shape[1]))
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_dnatracing() -> dnaTrace:
     """Instantiate a dnaTrace object."""
     return dnaTrace(image=FULL_IMAGE, grain=GRAINS, filename="Test", pixel_to_nm_scaling=1.0)
 
 
-@pytest.fixture
+@pytest.fixture()
 def minicircle_dnatracing(
     minicircle_grain_gaussian_filter: Filters, minicircle_grain_coloured: Grains, dnatracing_config: dict
 ) -> dnaTrace:
-    """dnaTrace object instantiated with minicircle data."""
+    """DnaTrace object instantiated with minicircle data."""
     dnatracing_config.pop("pad_width")
     dna_traces = dnaTrace(
         image=minicircle_grain_coloured.image.T,
@@ -745,14 +739,14 @@ def minicircle_dnatracing(
 
 
 # DNA Tracing Fixtures
-@pytest.fixture
+@pytest.fixture()
 def minicircle_all_statistics() -> pd.DataFrame:
     """Expected statistics for minicricle."""
     return pd.read_csv(RESOURCES / "minicircle_default_all_statistics.csv", header=0)
 
 
 # Skeletonizing Fixtures
-@pytest.fixture
+@pytest.fixture()
 def skeletonize_circular() -> np.ndarray:
     """A circular molecule for testing skeletonizing."""
     return np.array(
@@ -782,13 +776,13 @@ def skeletonize_circular() -> np.ndarray:
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def skeletonize_circular_bool_int(skeletonize_circular: np.ndarray) -> np.ndarray:
     """A circular molecule for testing skeletonizing as a boolean integer array."""
     return np.array(skeletonize_circular, dtype="bool").astype(int)
 
 
-@pytest.fixture
+@pytest.fixture()
 def skeletonize_linear() -> np.ndarray:
     """A linear molecule for testing skeletonizing."""
     return np.array(
@@ -821,7 +815,7 @@ def skeletonize_linear() -> np.ndarray:
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def skeletonize_linear_bool_int(skeletonize_linear) -> np.ndarray:
     """A linear molecule for testing skeletonizing as a boolean integer array."""
     return np.array(skeletonize_linear, dtype="bool").astype(int)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -725,7 +725,7 @@ def test_dnatracing() -> dnaTrace:
 def minicircle_dnatracing(
     minicircle_grain_gaussian_filter: Filters, minicircle_grain_coloured: Grains, dnatracing_config: dict
 ) -> dnaTrace:
-    """DnaTrace object instantiated with minicircle data."""
+    """DnaTrace object instantiated with minicircle data."""  # noqa: D403
     dnatracing_config.pop("pad_width")
     dna_traces = dnaTrace(
         image=minicircle_grain_coloured.image.T,

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -14,7 +14,7 @@ from topostats.plotting import run_toposum
 
 
 # Test "help" arguments
-@pytest.mark.parametrize("option", [("-h", "--help")])
+@pytest.mark.parametrize("option", [("-h"), ("--help")])
 def test_entry_point_help(capsys, option) -> None:
     """Test the help argument of the general entry point."""
     try:
@@ -27,7 +27,7 @@ def test_entry_point_help(capsys, option) -> None:
     assert "program" in output
 
 
-@pytest.mark.parametrize("option", [("-h", "--help")])
+@pytest.mark.parametrize("option", [("-h"), ("--help")])
 def test_entry_point_process_help(capsys, option):
     """Test the help argument of the process program."""
     try:
@@ -40,7 +40,7 @@ def test_entry_point_process_help(capsys, option):
     assert "process" in output
 
 
-@pytest.mark.parametrize("option", [("-h", "--help")])
+@pytest.mark.parametrize("option", [("-h"), ("--help")])
 def test_entry_point_summary_help(capsys, option):
     """Test the help argument of the summary program."""
     try:

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -1,7 +1,7 @@
 """Test the entry point of TopoStats and its ability to correctly direct to programs."""
 
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 import pytest
 
 from topostats.entry_point import (
@@ -14,48 +14,48 @@ from topostats.plotting import run_toposum
 
 
 # Test "help" arguments
-@pytest.mark.parametrize("option", ("-h", "--help"))
+@pytest.mark.parametrize("option", [("-h", "--help")])
 def test_entry_point_help(capsys, option) -> None:
     """Test the help argument of the general entry point."""
-
     try:
         entry_point(manually_provided_args=[option])
     except SystemExit:
         pass
     output = capsys.readouterr().out
 
-    assert "usage:" in output and "program" in output
+    assert "usage:" in output
+    assert "program" in output
 
 
-@pytest.mark.parametrize("option", ("-h", "--help"))
+@pytest.mark.parametrize("option", [("-h", "--help")])
 def test_entry_point_process_help(capsys, option):
     """Test the help argument of the process program."""
-
     try:
         entry_point(manually_provided_args=["process", option])
     except SystemExit:
         pass
     output = capsys.readouterr().out
 
-    assert "usage:" in output and "process" in output
+    assert "usage:" in output
+    assert "process" in output
 
 
-@pytest.mark.parametrize("option", ("-h", "--help"))
+@pytest.mark.parametrize("option", [("-h", "--help")])
 def test_entry_point_summary_help(capsys, option):
     """Test the help argument of the summary program."""
-
     try:
         entry_point(manually_provided_args=["summary", option])
     except SystemExit:
         pass
     output = capsys.readouterr().out
 
-    assert "usage:" in output and "summary" in output
+    assert "usage:" in output
+    assert "summary" in output
 
 
 # Test that the right functions are returned with the right arguments
 @pytest.mark.parametrize(
-    "options, expected_function, expected_arg_name, expected_arg_value",
+    ("options", "expected_function", "expected_arg_name", "expected_arg_value"),
     [
         (
             [
@@ -90,9 +90,7 @@ def test_entry_point_summary_help(capsys, option):
 def test_entry_point(
     options: list, expected_function: Callable, expected_arg_name: str, expected_arg_value: str
 ) -> None:
-    """Test the entry point, ensuring the correct function is called for each program, and arguments
-    are carried through."""
-
+    """Ensure the correct function is called for each program, and arguments are carried through."""
     returned_args = entry_point(options, testing=True)
     # convert argparse's Namespace object to dictionary
     returned_args_dict = vars(returned_args)
@@ -106,7 +104,6 @@ def test_entry_point(
 
 def test_entry_point_create_config_file(tmp_path: Path) -> None:
     """Test that the entry point is able to produce a default config file when asked to."""
-
     with pytest.raises(SystemExit):
         entry_point(manually_provided_args=["process", "--create_config_file", f"{tmp_path}/test_create_config.yaml"])
 
@@ -115,7 +112,7 @@ def test_entry_point_create_config_file(tmp_path: Path) -> None:
 
 # Test that the right functions are returned with the right arguments
 @pytest.mark.parametrize(
-    "options, expected_arg_name, expected_arg_value",
+    ("options", "expected_arg_name", "expected_arg_value"),
     [
         (
             [
@@ -135,9 +132,7 @@ def test_entry_point_create_config_file(tmp_path: Path) -> None:
     ],
 )
 def test_legacy_run_topostats_entry_point(options: list, expected_arg_name: str, expected_arg_value: str) -> None:
-    """Test the run_topostats legacy entry point, ensuring the arguments
-    are parsed and carried through correctly."""
-
+    """Ensure the arguments are parsed and carried through correctly to legacy entry point."""
     returned_args = legacy_run_topostats_entry_point(options, testing=True)
     # Convert argparse's Namespace object to dictionary
     returned_args_dict = vars(returned_args)
@@ -146,9 +141,7 @@ def test_legacy_run_topostats_entry_point(options: list, expected_arg_name: str,
 
 
 def test_legacy_run_topostats_entry_point_create_config_file(tmp_path: Path) -> None:
-    """Test that the run_topostats legacy entry point is able to produce a default config file
-    when asked to."""
-
+    """Ensure legacy entry point is able to produce a default config file."""
     with pytest.raises(SystemExit):
         legacy_run_topostats_entry_point(
             args=["--create-config-file", f"{tmp_path}/test_legacy_run_topostats_create_config.yaml"]
@@ -158,9 +151,7 @@ def test_legacy_run_topostats_entry_point_create_config_file(tmp_path: Path) -> 
 
 
 def test_legacy_toposum_entry_point_create_config_file(tmp_path: Path) -> None:
-    """Test that the toposum legacy entry point is able to produce a default config file
-    when asked to."""
-
+    """Ensure the toposum legacy entry point is able to produce a default config file."""
     with pytest.raises(SystemExit):
         legacy_toposum_entry_point(
             args=["--create-config-file", f"{tmp_path}/test_legacy_toposum_create_config_file.yaml"]
@@ -170,9 +161,7 @@ def test_legacy_toposum_entry_point_create_config_file(tmp_path: Path) -> None:
 
 
 def test_legacy_toposum_entry_point_create_label_file(tmp_path: Path) -> None:
-    """Test that the toposum legacy entry point is able to produce a default label file
-    when asked to."""
-
+    """Ensure the toposum legacy entry point is able to produce a default label file."""
     with pytest.raises(SystemExit):
         legacy_toposum_entry_point(
             args=["--create-label-file", f"{tmp_path}/test_legacy_toposum_create_label_file.yaml"]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import numpy as np
-from skimage.filters import gaussian
+from skimage.filters import gaussian  # noqa: E0611
 import pytest
 
 from topostats.filters import Filters
@@ -19,7 +19,7 @@ RNG = np.random.default_rng(seed=1000)
 
 
 @pytest.mark.parametrize(
-    "row_alignment_quantile, image, expected",
+    ("row_alignment_quantile", "image", "expected"),
     [
         (0.5, RNG.random((20, 20)), np.load(RESOURCES / "test_median_flatten_0.5.npy")),
         (0.2, RNG.random((20, 20)), np.load(RESOURCES / "test_median_flatten_0.2.npy")),
@@ -58,7 +58,6 @@ def test_remove_quadratic(test_filters_random: Filters, image_random_remove_quad
 
 def test_remove_nonlinear_polynomial() -> None:
     """Test the removal of nonlinear polynomials from 2d arrays by providing a nonlinear polynomial trend."""
-
     # Create an image with a nonlinear polynomial trend
     image = np.zeros((8, 8)).astype(float)
     for y in range(image.shape[0]):
@@ -100,7 +99,7 @@ def test_calc_gradient(test_filters_random: Filters, image_random: np.ndarray) -
 # FIXME : sum of half of the array values is vastly smaller and so test fails. What is strange is that
 #         test_filters_minicircle.test_average_background() *DOESN'T* fail
 def test_non_square_img(test_filters_random: Filters):
-    """Test median flattening on non-square images"""
+    """Test median flattening on non-square images."""
     test_filters_random.images["pixels"] = test_filters_random.images["pixels"][:, 0:512]
     test_filters_random.images["zero_averaged_background"] = test_filters_random.median_flatten(
         image=test_filters_random.images["pixels"], mask=None
@@ -111,7 +110,7 @@ def test_non_square_img(test_filters_random: Filters):
 
 
 def test_average_background(test_filters_random_with_mask: Filters):
-    """Test the background averaging"""
+    """Test the background averaging."""
     test_filters_random_with_mask.images["zero_averaged_background"] = test_filters_random_with_mask.average_background(
         image=test_filters_random_with_mask.images["pixels"], mask=test_filters_random_with_mask.images["mask"]
     )

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -56,11 +56,11 @@ grain_array4 = np.array(
 
 
 @pytest.mark.parametrize(
-    "area_thresh_nm, expected",
+    ("area_thresh_nm", "expected"),
     [([None, None], grain_array), ([None, 32], grain_array2), ([12, 24], grain_array3), ([32, 44], grain_array4)],
 )
 def test_known_array_threshold(area_thresh_nm, expected) -> None:
-    "Tests that arrays are thresholded on size as expected."
+    """Tests that arrays are thresholded on size as expected."""
     grains = Grains(image=np.zeros((10, 6)), filename="xyz", pixel_to_nm_scaling=2)
     assert (grains.area_thresholding(grain_array, area_thresh_nm) == expected).all()
 
@@ -74,7 +74,6 @@ def test_known_array_threshold(area_thresh_nm, expected) -> None:
 
 def test_remove_small_objects():
     """Test the remove_small_objects method of the Grains class."""
-
     grains_object = Grains(
         image=None,
         filename="",
@@ -112,7 +111,7 @@ def test_remove_small_objects():
 
 
 @pytest.mark.parametrize(
-    "test_labelled_image, area_thresholds, expected",
+    ("test_labelled_image", "area_thresholds", "expected"),
     [
         (
             np.array(
@@ -168,7 +167,6 @@ def test_remove_small_objects():
 )
 def test_area_thresholding(test_labelled_image, area_thresholds, expected):
     """Test the area_thresholding() method of the Grains class."""
-
     grains_object = Grains(
         image=None,
         filename="",
@@ -181,7 +179,7 @@ def test_area_thresholding(test_labelled_image, area_thresholds, expected):
 
 
 @pytest.mark.parametrize(
-    "remove_edge_intersecting_grains, expected_number_of_grains",
+    ("remove_edge_intersecting_grains", "expected_number_of_grains"),
     [
         (True, 6),
         (False, 9),
@@ -190,8 +188,7 @@ def test_area_thresholding(test_labelled_image, area_thresholds, expected):
 def test_remove_edge_intersecting_grains(
     grains_config: dict, remove_edge_intersecting_grains: bool, expected_number_of_grains: int
 ) -> None:
-    """Test that Grains successfully does and doesn't remove edge intersecting grains"""
-
+    """Test that Grains successfully does and doesn't remove edge intersecting grains."""
     # Ensure that a sensible number of grains are found
     grains_config["remove_edge_intersecting_grains"] = remove_edge_intersecting_grains
     grains_config["threshold_absolute"]["above"] = 1.0

--- a/tests/test_grains_minicircle.py
+++ b/tests/test_grains_minicircle.py
@@ -8,13 +8,13 @@ from topostats.grains import Grains
 
 
 def test_threshold_otsu(minicircle_grain_threshold_otsu: Grains) -> None:
-    """Test threshold calculation"""
+    """Test threshold calculation."""
     assert isinstance(minicircle_grain_threshold_otsu.thresholds, dict)
     assert minicircle_grain_threshold_otsu.thresholds["above"] == pytest.approx(0.769617128561541)
 
 
 def test_threshold_stddev(minicircle_grain_threshold_stddev: Grains) -> None:
-    """Test threshold calculation"""
+    """Test threshold calculation."""
     assert isinstance(minicircle_grain_threshold_stddev.thresholds, dict)
     assert minicircle_grain_threshold_stddev.thresholds == pytest.approx(
         {"below": -5.896200702478787, "above": 0.9456735525628046}
@@ -22,7 +22,7 @@ def test_threshold_stddev(minicircle_grain_threshold_stddev: Grains) -> None:
 
 
 def test_threshold_abs(minicircle_grain_threshold_abs: Grains) -> None:
-    """Test threshold calculation"""
+    """Test threshold calculation."""
     assert isinstance(minicircle_grain_threshold_abs.thresholds, dict)
     assert minicircle_grain_threshold_abs.thresholds == {"above": 1.0, "below": -1.0}
 

--- a/tests/test_grainstats.py
+++ b/tests/test_grainstats.py
@@ -1,4 +1,4 @@
-"""Testing of grainstats class"""
+"""Testing of grainstats class."""
 from pathlib import Path
 
 import logging
@@ -27,7 +27,7 @@ def test_get_angle(grainstats: GrainStats) -> None:
 
 
 def test_is_clockwise_clockwise(grainstats: GrainStats) -> None:
-    """Test calculation of whether three points make a clockwise turn"""
+    """Test calculation of whether three points make a clockwise turn."""
     clockwise = grainstats.is_clockwise(POINT3, POINT2, POINT1)
 
     assert isinstance(clockwise, bool)
@@ -35,7 +35,7 @@ def test_is_clockwise_clockwise(grainstats: GrainStats) -> None:
 
 
 def test_is_clockwise_anti_clockwise(grainstats: GrainStats) -> None:
-    """Test calculation of whether three points make a clockwise turn"""
+    """Test calculation of whether three points make a clockwise turn."""
     clockwise = grainstats.is_clockwise(POINT1, POINT2, POINT3)
 
     assert isinstance(clockwise, bool)
@@ -43,7 +43,7 @@ def test_is_clockwise_anti_clockwise(grainstats: GrainStats) -> None:
 
 
 @pytest.mark.parametrize(
-    "method, grain_mask, expected_coords",
+    ("method", "grain_mask", "expected_coords"),
     [
         (
             "binary_erosion",
@@ -260,7 +260,7 @@ def test_random_grain_stats(caplog, tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "coords, shape, expected",
+    ("coords", "shape", "expected"),
     [(np.asarray([5, 5]), 10, 0), (np.asarray([-3, 12]), 10, 3), (np.asarray([-3, 14]), 10, -4)],
 )
 def test_get_shift(coords, shape, expected):
@@ -269,7 +269,7 @@ def test_get_shift(coords, shape, expected):
 
 
 @pytest.mark.parametrize(
-    "length, centre, img_len, expected",
+    ("length", "centre", "img_len", "expected"),
     [
         (5, np.asarray([10, 10]), 21, [5, 5]),
         (3, np.asarray([1, 20]), 21, [1, 6]),
@@ -286,7 +286,7 @@ def test_get_cropped_region(grainstats: GrainStats, length, centre, img_len, exp
 
 
 @pytest.mark.parametrize(
-    "base_point_1, base_point_2, top_point, expected",
+    ("base_point_1", "base_point_2", "top_point", "expected"),
     [
         (np.array([0, 0]), np.array([1, 0]), np.array([1, 1]), 1),
         (np.array([0, 0]), np.array([5, 0]), np.array([2, 5]), 5),
@@ -294,11 +294,11 @@ def test_get_cropped_region(grainstats: GrainStats, length, centre, img_len, exp
     ],
 )
 def test_grainstats_get_triangle_height(base_point_1, base_point_2, top_point, expected) -> None:
-    """Tests the Grainstats.get_triangle_height method"""
+    """Tests the Grainstats.get_triangle_height method."""
     assert GrainStats.get_triangle_height(base_point_1, base_point_2, top_point) == expected
 
 
-@pytest.mark.parametrize("edge_points, expected", [([[0, 0], [0, 1], [1, 0], [1, 1]], (1.0, 1.4142135623730951))])
+@pytest.mark.parametrize(("edge_points", "expected"), [([[0, 0], [0, 1], [1, 0], [1, 1]], (1.0, 1.4142135623730951))])
 def test_get_min_max_ferets(edge_points, expected) -> None:
-    """Tests the Grainstats.get_min_max_ferets method"""
+    """Tests the Grainstats.get_min_max_ferets method."""
     assert GrainStats.get_max_min_ferets(edge_points) == expected

--- a/tests/test_grainstats.py
+++ b/tests/test_grainstats.py
@@ -294,11 +294,11 @@ def test_get_cropped_region(grainstats: GrainStats, length, centre, img_len, exp
     ],
 )
 def test_grainstats_get_triangle_height(base_point_1, base_point_2, top_point, expected) -> None:
-    """Tests the Grainstats.get_triangle_height method."""
+    """Tests the GrainStats.get_triangle_height method."""
     assert GrainStats.get_triangle_height(base_point_1, base_point_2, top_point) == expected
 
 
 @pytest.mark.parametrize(("edge_points", "expected"), [([[0, 0], [0, 1], [1, 0], [1, 1]], (1.0, 1.4142135623730951))])
 def test_get_min_max_ferets(edge_points, expected) -> None:
-    """Tests the Grainstats.get_min_max_ferets method."""
+    """Tests the GrainStats.get_min_max_ferets method."""
     assert GrainStats.get_max_min_ferets(edge_points) == expected

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,5 @@
-"""Tests of IO"""
+"""Tests of IO."""
 from pathlib import Path
-from unittest import TestCase
 
 from datetime import datetime
 import numpy as np
@@ -51,7 +50,6 @@ CONFIG = {
 
 def test_get_date_time() -> None:
     """Test the fetching of a formatted date and time string."""
-
     assert datetime.strptime(get_date_time(), "%Y-%m-%d %H:%M:%S")
 
 
@@ -59,24 +57,20 @@ def test_read_yaml() -> None:
     """Test reading of YAML file."""
     sample_config = read_yaml(RESOURCES / "test.yaml")
 
-    TestCase().assertDictEqual(sample_config, CONFIG)
+    assert sample_config == CONFIG
 
 
 def test_write_config_with_comments(tmp_path: Path) -> None:
-    """
-    Test that the function write_yaml_with_comments successfully writes the default
-    config with comments to a file.
-    """
-
+    """Test writing of config file with comments."""
     # Read default config with comments
-    with open(BASE_DIR / "topostats" / "default_config.yaml", encoding="utf-8") as f:
+    with Path.open(BASE_DIR / "topostats" / "default_config.yaml", encoding="utf-8") as f:
         default_config_string = f.read()
 
     # Write default config with comments to file
     write_config_with_comments(config=default_config_string, output_dir=tmp_path, filename="test_config_with_comments")
 
     # Read the written config
-    with open(tmp_path / "test_config_with_comments.yaml", encoding="utf-8") as f:
+    with Path.open(tmp_path / "test_config_with_comments.yaml", encoding="utf-8") as f:
         written_config = f.read()
 
     # Validate that the written config has comments in it
@@ -133,7 +127,7 @@ def test_load_array_file_not_found(non_existant_file: str) -> None:
 
 
 def test_find_files() -> None:
-    """Test finding images"""
+    """Test finding images."""
     found_images = find_files(base_dir="tests/", file_ext=".spm")
 
     assert isinstance(found_images, list)
@@ -144,7 +138,7 @@ def test_find_files() -> None:
 
 def test_read_null_terminated_string() -> None:
     """Test reading a null terminated string from a binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         value = read_null_terminated_string(open_binary_file)
         assert isinstance(value, str)
         assert value == "test"
@@ -152,7 +146,7 @@ def test_read_null_terminated_string() -> None:
 
 def test_read_u32i() -> None:
     """Test reading an unsigned 32 bit integer from a binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(5)
         value = read_u32i(open_binary_file)
         assert isinstance(value, int)
@@ -161,7 +155,7 @@ def test_read_u32i() -> None:
 
 def test_read_64d() -> None:
     """Test reading a 64-bit double from an open binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(9)
         value = read_64d(open_binary_file)
         assert isinstance(value, float)
@@ -170,7 +164,7 @@ def test_read_64d() -> None:
 
 def test_read_char() -> None:
     """Test reading a character from an open binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(17)
         value = read_char(open_binary_file)
         assert isinstance(value, str)
@@ -179,7 +173,7 @@ def test_read_char() -> None:
 
 def test_read_gwy_component_dtype() -> None:
     """Test reading a data type of a `.gwy` file component from an open binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(18)
         value = read_gwy_component_dtype(open_binary_file)
         assert isinstance(value, str)
@@ -187,7 +181,7 @@ def test_read_gwy_component_dtype() -> None:
 
 
 @pytest.mark.parametrize(
-    "input_paths, expected_paths",
+    ("input_paths", "expected_paths"),
     [
         ([Path("a/b/c/d"), Path("a/b/e/f"), Path("a/b/g"), Path("a/b/h")], ["c/d", "e/f", "g", "h"]),
         (["a/b/c/d", "a/b/e/f", "a/b/g", "a/b/h"], ["c/d", "e/f", "g", "h"]),
@@ -198,7 +192,6 @@ def test_read_gwy_component_dtype() -> None:
 )
 def test_get_relative_paths(input_paths: list, expected_paths: list):
     """Test the get_paths_relative_to_deepest_common_path function."""
-
     relative_paths = get_relative_paths(input_paths)
 
     assert relative_paths == expected_paths
@@ -232,7 +225,7 @@ def test_convert_basename_to_relative_paths():
 
 
 @pytest.mark.parametrize(
-    "base_dir, image_path, output_dir, expected",
+    ("base_dir", "image_path", "output_dir", "expected"),
     [
         # Absolute path, nested under base_dir, with file suffix
         (
@@ -295,7 +288,7 @@ def test_convert_basename_to_relative_paths():
     ],
 )
 def test_get_out_path(image_path: Path, base_dir: Path, output_dir: Path, expected: Path) -> None:
-    """Test output directories"""
+    """Test output directories."""
     out_path = get_out_path(image_path, base_dir, output_dir)
     assert isinstance(out_path, Path)
     assert out_path == expected
@@ -308,7 +301,7 @@ def test_get_out_path_attributeerror() -> None:
 
 
 def test_save_folder_grainstats(tmp_path: Path) -> None:
-    """Test a folder-wide grainstats file is made"""
+    """Test a folder-wide grainstats file is made."""
     test_df = pd.DataFrame({"dummy1": [1, 2, 3], "dummy2": ["a", "b", "c"]})
     input_path = tmp_path / "minicircle"
     test_df["basename"] = input_path
@@ -319,7 +312,7 @@ def test_save_folder_grainstats(tmp_path: Path) -> None:
 
 
 def test_load_scan_spm(load_scan_spm: LoadScans) -> None:
-    """Test loading of Bruker .spm file"""
+    """Test loading of Bruker .spm file."""
     load_scan_spm.img_path = load_scan_spm.img_paths[0]
     load_scan_spm.filename = load_scan_spm.img_paths[0].stem
     image, px_to_nm_scaling = load_scan_spm.load_spm()
@@ -331,7 +324,7 @@ def test_load_scan_spm(load_scan_spm: LoadScans) -> None:
 
 
 def test_load_scan_ibw(load_scan_ibw: LoadScans) -> None:
-    """Test loading of Igor binarywave .ibw file"""
+    """Test loading of Igor binarywave .ibw file."""
     load_scan_ibw.img_path = load_scan_ibw.img_paths[0]
     load_scan_ibw.filename = load_scan_ibw.img_paths[0].stem
     image, px_to_nm_scaling = load_scan_ibw.load_ibw()
@@ -385,7 +378,7 @@ def test_load_scan_topostats(load_scan_topostats: LoadScans) -> None:
 
 def test_gwy_read_object(load_scan_dummy: LoadScans) -> None:
     """Test reading an object of a `.gwy` file object from an open binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(19)
         test_dict = {}
         load_scan_dummy._gwy_read_object(open_file=open_binary_file, data_dict=test_dict)
@@ -396,7 +389,7 @@ def test_gwy_read_object(load_scan_dummy: LoadScans) -> None:
 
 def test_gwy_read_component(load_scan_dummy: LoadScans) -> None:
     """Tests reading a component of a `.gwy` file object from an open binary file."""
-    with open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:
+    with Path.open(RESOURCES / "IO_binary_file.bin", "rb") as open_binary_file:  # pylint: disable=unspecified-encoding
         open_binary_file.seek(55)
         test_dict = {}
         byte_size = load_scan_dummy._gwy_read_component(
@@ -426,7 +419,7 @@ def test_gwy_read_component(load_scan_dummy: LoadScans) -> None:
 
 
 @pytest.mark.parametrize(
-    "load_scan_object, length, image_shape, image_sum, filename, pixel_to_nm_scaling",
+    ("load_scan_object", "length", "image_shape", "image_sum", "filename", "pixel_to_nm_scaling"),
     [
         ("load_scan_spm", 1, (1024, 1024), 30695369.188316286, "minicircle", 0.4940029296875),
         ("load_scan_ibw", 1, (512, 512), -218091520.0, "minicircle2", 1.5625),
@@ -458,7 +451,7 @@ def test_load_scan_get_data(
 
 
 @pytest.mark.parametrize(
-    "x, y, log_msg",
+    ("x", "y", "log_msg"),
     [
         (100, 100, "Image added to processing"),
         (9, 100, "Skipping, image too small"),
@@ -491,7 +484,7 @@ def test_load_pkl() -> None:
 
 
 @pytest.mark.parametrize(
-    "image, pixel_to_nm_scaling, grain_mask_above, grain_mask_below",
+    ("image", "pixel_to_nm_scaling", "grain_mask_above", "grain_mask_below"),
     [
         (
             np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
@@ -515,8 +508,7 @@ def test_save_topostats_file(
     grain_mask_above: np.ndarray,
     grain_mask_below: np.ndarray,
 ) -> None:
-    """Test saving a .topostats file"""
-
+    """Test saving a .topostats file."""
     topostats_object = {
         "image_flattened": image,
         "pixel_to_nm_scaling": pixel_to_nm_scaling,

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,4 +1,4 @@
-"""Tests for logging"""
+"""Tests for logging."""
 import logging
 import pytest
 
@@ -9,7 +9,7 @@ LOGGER = setup_logger(LOGGER_NAME)
 
 
 def test_setup_logger(caplog) -> None:
-    """Test logger setup"""
+    """Test logger setup."""
     info_msg = "This is a test message"
     LOGGER.info(info_msg)
     assert isinstance(LOGGER, logging.Logger)
@@ -17,13 +17,13 @@ def test_setup_logger(caplog) -> None:
 
 
 @pytest.mark.parametrize(
-    "log_level, message",
-    (
-        [logging.DEBUG, "DEBUG : This is a debug log message."],
-        [logging.INFO, "INFO : This is an info log message."],
-        [logging.WARNING, "WARNING : This is a warning log message."],
-        [logging.CRITICAL, "CRITICAL : This is a critical log message."],
-    ),
+    ("log_level", "message"),
+    [
+        (logging.DEBUG, "DEBUG : This is a debug log message."),
+        (logging.INFO, "INFO : This is an info log message."),
+        (logging.WARNING, "WARNING : This is a warning log message."),
+        (logging.CRITICAL, "CRITICAL : This is a critical log message."),
+    ],
 )
 def test_debug(caplog, log_level, message) -> None:
     """Test logging debug messages."""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -18,8 +18,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
 
 
 def test_melt_data():
-    """Test the melt_data method of the TopoSum class"""
-
+    """Test the melt_data method of the TopoSum class."""
     df_to_melt = {
         "Image": ["im1", "im1", "im1", "im2", "im2", "im3", "im3"],
         "threshold": ["above", "above", "above", "below", "below", "above", "above"],
@@ -65,7 +64,7 @@ def test_toposum_class(toposum_object_multiple_directories: TopoSum) -> None:
 
 
 def test_outfile(toposum_object_multiple_directories: TopoSum) -> None:
-    """Check fig and ax returned"""
+    """Check fig and ax returned."""
     outfile = toposum_object_multiple_directories._outfile(plot_suffix="testing")
     assert isinstance(outfile, str)
     assert outfile == "area_testing"
@@ -99,7 +98,7 @@ def test_var_to_label_config(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "var,expected_label",
+    ("var", "expected_label"),
     [
         ("contour_length", "Contour Length"),
         ("end_to_end_distance", "End to End Distance"),

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -19,10 +19,7 @@ MASK = RNG.uniform(low=0, high=1, size=ARRAY.shape) > 0.5
 
 
 def test_add_pixel_to_nm_to_plotting_config(plotting_config_with_plot_dict):
-    """Test the add_pixel_to_nm_to_plotting_config function of plottingfuncs.py, ensuring
-    that every plot's config contains the pixel to nanometre scaling factor needed for
-    plotting images in nanometres rather than pixels."""
-
+    """Test addition of pixel to nm scaling to individual plot configurations."""
     plotting_config = add_pixel_to_nm_to_plotting_config(
         plotting_config=plotting_config_with_plot_dict, pixel_to_nm_scaling=1.23456789
     )
@@ -30,11 +27,11 @@ def test_add_pixel_to_nm_to_plotting_config(plotting_config_with_plot_dict):
     # Ensure that every plot's config has the correct pixel to nm scaling factor.
     for _, plot_config in plotting_config["plot_dict"].items():
         if plot_config["pixel_to_nm_scaling"] != 1.23456789:
-            assert False
+            raise AssertionError()
 
 
 @pytest.mark.parametrize(
-    "binary_image, dilation_iterations, expected",
+    ("binary_image", "dilation_iterations", "expected"),
     [
         (
             np.array([[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 1, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]),
@@ -50,14 +47,13 @@ def test_add_pixel_to_nm_to_plotting_config(plotting_config_with_plot_dict):
 )
 def test_dilate_binary_image(binary_image: np.ndarray, dilation_iterations: int, expected: np.ndarray) -> None:
     """Test the dilate binary images function of plottingfuncs.py."""
-
     result = dilate_binary_image(binary_image=binary_image, dilation_iterations=dilation_iterations)
 
     np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(
-    "masked_array, axes_colorbar, region_properties",
+    ("masked_array", "axes_colorbar", "region_properties"),
     [(np.random.rand(10, 10), True, None), (None, True, None), (None, False, True)],
 )
 def test_save_figure(
@@ -68,7 +64,7 @@ def test_save_figure(
     minicircle_grain_region_properties_post_removal: Grains,
     tmp_path: Path,
 ):
-    """Tests that an image is saved and a figure returned"""
+    """Tests that an image is saved and a figure returned."""
     if region_properties:
         region_properties = minicircle_grain_region_properties_post_removal
     fig, ax = Images(
@@ -86,7 +82,7 @@ def test_save_figure(
 
 
 def test_save_array_figure(tmp_path: Path):
-    """Tests that the image array is saved"""
+    """Tests that the image array is saved."""
     Images(
         data=np.random.rand(10, 10),
         output_dir=tmp_path,
@@ -97,7 +93,7 @@ def test_save_array_figure(tmp_path: Path):
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_and_save_no_colorbar(load_scan_data: LoadScans, tmp_path: Path) -> None:
-    """Test plotting without colorbar"""
+    """Test plotting without colorbar."""
     fig, _ = Images(
         data=load_scan_data.image,
         output_dir=tmp_path,
@@ -113,7 +109,7 @@ def test_plot_and_save_no_colorbar(load_scan_data: LoadScans, tmp_path: Path) ->
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_histogram_and_save(load_scan_data: LoadScans, tmp_path: Path) -> None:
-    """Test plotting histograms"""
+    """Test plotting histograms."""
     fig, _ = Images(
         load_scan_data.image, output_dir=tmp_path, filename="histogram", image_set="all"
     ).plot_histogram_and_save()
@@ -122,7 +118,7 @@ def test_plot_histogram_and_save(load_scan_data: LoadScans, tmp_path: Path) -> N
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_and_save_colorbar(load_scan_data: LoadScans, tmp_path: Path) -> None:
-    """Test plotting with colorbar"""
+    """Test plotting with colorbar."""
     fig, _ = Images(
         data=load_scan_data.image,
         output_dir=tmp_path,
@@ -138,7 +134,7 @@ def test_plot_and_save_colorbar(load_scan_data: LoadScans, tmp_path: Path) -> No
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_and_save_no_axes(load_scan_data: LoadScans, plotting_config: dict, tmp_path: Path) -> None:
-    """Test plotting without axes"""
+    """Test plotting without axes."""
     plotting_config["axes"] = False
     fig, _ = Images(
         data=load_scan_data.image,
@@ -168,7 +164,7 @@ def test_plot_and_save_no_axes_no_colorbar(load_scan_data: LoadScans, plotting_c
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_and_save_colorbar_afmhot(load_scan_data: LoadScans, tmp_path: Path, plotting_config: dict) -> None:
-    """Test plotting with colorbar"""
+    """Test plotting with colorbar."""
     plotting_config["cmap"] = "afmhot"
     fig, _ = Images(
         data=load_scan_data.image,
@@ -191,7 +187,7 @@ def test_plot_and_save_bounding_box(
     plotting_config: dict,
     tmp_path: Path,
 ) -> None:
-    """Test plotting bounding boxes"""
+    """Test plotting bounding boxes."""
     plotting_config["image_type"] = "binary"
     fig, _ = Images(
         data=minicircle_grain_coloured.directions["above"]["coloured_regions"],
@@ -207,7 +203,7 @@ def test_plot_and_save_bounding_box(
 
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_plot_and_save_zrange(minicircle_grain_gaussian_filter: Grains, plotting_config: dict, tmp_path: Path) -> None:
-    """Tests plotting of the zrange scaled image"""
+    """Tests plotting of the zrange scaled image."""
     plotting_config["zrange"] = [-10, 10]
     plotting_config["core_set"] = True
     fig, _ = Images(
@@ -228,7 +224,7 @@ def test_plot_and_save_non_square_bounding_box(
     plotting_config: dict,
     tmp_path: Path,
 ) -> None:
-    """Test plotting bounding boxes"""
+    """Test plotting bounding boxes."""
     plotting_config["image_type"] = "binary"
     fig, _ = Images(
         data=minicircle_grain_coloured.image[:, 0:512],

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -326,7 +326,7 @@ def test_process_stages(
 
     Currently there is no test for having later stages (e.g. DNA Tracing or Grainstats) enabled when Filters and/or
     Grainstats are disabled. Whislt possible it is expected that users understand the need to run earlier stages before
-    later staged can run and do not disable earlier stages.
+    later stages can run and do not disable earlier stages.
     """
     img_dic = load_scan_data.img_dict
     process_scan_config["filter"]["run"] = filter_run

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -23,8 +23,7 @@ BASE_DIR = Path.cwd()
 # Can't see a way of paramterising with pytest-regtest as it writes to a file based on the file/function
 # so instead we run three regression tests.
 def test_process_scan_below(regtest, tmp_path, process_scan_config: dict, load_scan_data: LoadScans) -> None:
-    """Regression test for checking the process_scan functions correctly"""
-
+    """Regression test for checking the process_scan functions correctly."""
     # Ensure there are below grains
     process_scan_config["grains"]["threshold_std_dev"]["below"] = 0.8
     process_scan_config["grains"]["smallest_grain_size_nm2"] = 10
@@ -49,8 +48,7 @@ def test_process_scan_below(regtest, tmp_path, process_scan_config: dict, load_s
 
 
 def test_process_scan_above(regtest, tmp_path, process_scan_config: dict, load_scan_data: LoadScans) -> None:
-    """Regression test for checking the process_scan functions correctly"""
-
+    """Regression test for checking the process_scan functions correctly."""
     # Ensure there are below grains
     process_scan_config["grains"]["smallest_grain_size_nm2"] = 10
     process_scan_config["grains"]["absolute_area_threshold"]["below"] = [1, 1000000000]
@@ -73,8 +71,7 @@ def test_process_scan_above(regtest, tmp_path, process_scan_config: dict, load_s
 
 
 def test_process_scan_both(regtest, tmp_path, process_scan_config: dict, load_scan_data: LoadScans) -> None:
-    """Regression test for checking the process_scan functions correctly"""
-
+    """Regression test for checking the process_scan functions correctly."""
     # Ensure there are below grains
     process_scan_config["grains"]["threshold_std_dev"]["below"] = 0.8
     process_scan_config["grains"]["smallest_grain_size_nm2"] = 10
@@ -99,7 +96,7 @@ def test_process_scan_both(regtest, tmp_path, process_scan_config: dict, load_sc
 
 
 @pytest.mark.parametrize(
-    "image_set, expected",
+    ("image_set", "expected"),
     [
         ("core", False),
         ("all", True),
@@ -153,7 +150,7 @@ def test_save_cropped_grains(
 
 @pytest.mark.parametrize("extension", [("png"), ("tif")])
 def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, extension: str):
-    """Tests if save format applied to cropped images"""
+    """Tests if save format applied to cropped images."""
     process_scan_config["plotting"]["image_set"] = "all"
     process_scan_config["plotting"]["save_format"] = extension
     process_scan_config["plotting"] = update_plotting_config(process_scan_config["plotting"])
@@ -179,7 +176,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
 
 
 @pytest.mark.parametrize(
-    "filter_run, grains_run, grainstats_run, dnatracing_run, log_msg",
+    ("filter_run", "grains_run", "grainstats_run", "dnatracing_run", "log_msg"),
     [
         (
             False,
@@ -269,7 +266,7 @@ def test_check_run_steps(
 # noqa: disable=too-many-arguments
 # pylint: disable=too-many-arguments
 @pytest.mark.parametrize(
-    "filter_run, grains_run, grainstats_run, dnatracing_run, log_msg1, log_msg2",
+    ("filter_run", "grains_run", "grainstats_run", "dnatracing_run", "log_msg1", "log_msg2"),
     [
         (
             False,
@@ -329,7 +326,8 @@ def test_process_stages(
 
     Currently there is no test for having later stages (e.g. DNA Tracing or Grainstats) enabled when Filters and/or
     Grainstats are disabled. Whislt possible it is expected that users understand the need to run earlier stages before
-    later staged can run and do not disable earlier stages."""
+    later staged can run and do not disable earlier stages.
+    """
     img_dic = load_scan_data.img_dict
     process_scan_config["filter"]["run"] = filter_run
     process_scan_config["grains"]["run"] = grains_run
@@ -372,11 +370,14 @@ def test_process_scan_no_grains(process_scan_config: dict, load_scan_data: LoadS
 def test_process_scan_align_grainstats_dnatracing(
     process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path
 ) -> None:
-    """Test that molecule numbers from dnatracing align with those from grainstats when some grains are removed from
-    tracing because they are too small.
+    """Ensure molecule numbers from dnatracing align with those from grainstats.
+
+    Sometimes grains are removed from tracing due to small size, however we need to ensure that tracing statistics for
+    those molecules that remain align with grain statistics.
 
     By setting processing parameters as below two molecules are purged for being too small after skeletonisation and so
-    do not have DNA tracing statistics (but they do have Grain Statistics)."""
+    do not have DNA tracing statistics (but they do have Grain Statistics).
+    """
     img_dic = load_scan_data.img_dict
     process_scan_config["filter"]["remove_scars"]["run"] = False
     process_scan_config["grains"]["absolute_area_threshold"]["above"] = [150, 3000]
@@ -400,7 +401,6 @@ def test_process_scan_align_grainstats_dnatracing(
 
 def test_run_filters(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path) -> None:
     """Test the filter_wrapper function of processing.py."""
-
     img_dict = load_scan_data.img_dict
     unprocessed_image = img_dict["minicircle_small"]["image_original"]
     pixel_to_nm_scaling = img_dict["minicircle_small"]["pixel_to_nm_scaling"]
@@ -421,8 +421,7 @@ def test_run_filters(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
 
 
 def test_run_grains(process_scan_config: dict, tmp_path: Path) -> None:
-    """Test the grains_wrapper function of processing.py"""
-
+    """Test the grains_wrapper function of processing.py."""
     flattened_image = np.load("./tests/resources/minicircle_cropped_flattened.npy")
 
     grains_config = process_scan_config["grains"]
@@ -455,8 +454,7 @@ def test_run_grains(process_scan_config: dict, tmp_path: Path) -> None:
 
 
 def test_run_grainstats(process_scan_config: dict, tmp_path: Path) -> None:
-    """Test the grainstats_wrapper function of processing.py"""
-
+    """Test the grainstats_wrapper function of processing.py."""
     flattened_image = np.load("./tests/resources/minicircle_cropped_flattened.npy")
     mask_above = np.load("./tests/resources/minicircle_cropped_masks_above.npy")
     mask_below = np.load("./tests/resources/minicircle_cropped_masks_below.npy")
@@ -478,8 +476,7 @@ def test_run_grainstats(process_scan_config: dict, tmp_path: Path) -> None:
 
 
 def test_run_dnatracing(process_scan_config: dict, tmp_path: Path) -> None:
-    """Test the dnatracing_wrapper function of processing.py"""
-
+    """Test the dnatracing_wrapper function of processing.py."""
     flattened_image = np.load("./tests/resources/minicircle_cropped_flattened.npy")
     mask_above = np.load("./tests/resources/minicircle_cropped_masks_above.npy")
     mask_below = np.load("./tests/resources/minicircle_cropped_masks_below.npy")

--- a/tests/test_run_topostats.py
+++ b/tests/test_run_topostats.py
@@ -10,7 +10,7 @@ from topostats.entry_point import entry_point
 BASE_DIR = Path.cwd()
 
 
-@pytest.mark.parametrize("option", ("-h", "--help"))
+@pytest.mark.parametrize("option", [("-h", "--help")])
 def test_run_topostats_main_help(capsys, option) -> None:
     """Test the -h/--help flag to run_topostats."""
     try:
@@ -42,7 +42,7 @@ def test_run_topostats_process_all(caplog) -> None:
 
 
 def test_run_topostats_process_debug(caplog) -> None:
-    """Test run_topostats with debugging and check DEBUG messages are logged"""
+    """Test run_topostats with debugging and check DEBUG messages are logged."""
     # Set the logging level of the topostats logger
     with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
         entry_point(

--- a/tests/test_run_topostats.py
+++ b/tests/test_run_topostats.py
@@ -10,7 +10,7 @@ from topostats.entry_point import entry_point
 BASE_DIR = Path.cwd()
 
 
-@pytest.mark.parametrize("option", [("-h", "--help")])
+@pytest.mark.parametrize("option", [("-h"), ("--help")])
 def test_run_topostats_main_help(capsys, option) -> None:
     """Test the -h/--help flag to run_topostats."""
     try:

--- a/tests/test_scars.py
+++ b/tests/test_scars.py
@@ -12,8 +12,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
 
 
 def test_remove_scars(remove_scars_config: dict):
-    """Test removal of scars"""
-
+    """Test removal of scars."""
     scars_removed, scar_mask = scars.remove_scars(**remove_scars_config)
 
     target_img = np.load(RESOURCES / "test_scars_synthetic_remove_scars.npy")
@@ -24,7 +23,7 @@ def test_remove_scars(remove_scars_config: dict):
 
 
 @pytest.mark.parametrize(
-    "threshold_low, max_scar_width, potential_positive_scar, target",
+    ("threshold_low", "max_scar_width", "potential_positive_scar", "target"),
     [
         # Successful scar segment
         (
@@ -260,7 +259,6 @@ def test_remove_scars(remove_scars_config: dict):
 )
 def test_mark_if_positive_scar(potential_positive_scar, target, threshold_low, max_scar_width):
     """Test the mark_if_positive_scar method of the Scars class."""
-
     marked = np.zeros(potential_positive_scar.shape)
 
     scars._mark_if_positive_scar(
@@ -276,7 +274,7 @@ def test_mark_if_positive_scar(potential_positive_scar, target, threshold_low, m
 
 
 @pytest.mark.parametrize(
-    "threshold_low, max_scar_width, potential_negative_scar, target",
+    ("threshold_low", "max_scar_width", "potential_negative_scar", "target"),
     [
         # Successful scar segment
         (
@@ -512,7 +510,6 @@ def test_mark_if_positive_scar(potential_positive_scar, target, threshold_low, m
 )
 def test_mark_if_negative_scar(potential_negative_scar, target, threshold_low, max_scar_width):
     """Test the mark_if_negative_scar method of the Scars class."""
-
     marked = np.zeros(potential_negative_scar.shape)
 
     scars._mark_if_negative_scar(
@@ -529,7 +526,6 @@ def test_mark_if_negative_scar(potential_negative_scar, target, threshold_low, m
 
 def test_spread_scars():
     """Test the spread scars method of the Scars class."""
-
     marked_mask = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0],
@@ -571,7 +567,6 @@ def test_spread_scars():
 
 def test_remove_short_scars():
     """Test the remove_short_scars method of the Scars class."""
-
     mask = np.array(
         [
             [0, 0, 0, 0, 0, 0],
@@ -611,7 +606,6 @@ def test_remove_short_scars():
 
 def test_mark_scars(synthetic_scars_image, synthetic_marked_scars):
     """Test the mark_scars method of the Scars class."""
-
     marked = scars._mark_scars(
         img=synthetic_scars_image,
         direction="positive",
@@ -626,7 +620,6 @@ def test_mark_scars(synthetic_scars_image, synthetic_marked_scars):
 
 def test_remove_marked_scars(synthetic_scars_image, synthetic_marked_scars):
     """Test the remove_marked_scars method of the Scars class."""
-
     scars._remove_marked_scars(synthetic_scars_image, synthetic_marked_scars)
 
     target = np.load(RESOURCES / "test_scars_synthetic_remove_marked_scars.npy")

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,4 +1,4 @@
-"""Tests for image statistics"""
+"""Tests for image statistics."""
 
 import pytest
 import numpy as np
@@ -9,7 +9,6 @@ from topostats.statistics import image_statistics, roughness_rms
 
 def test_image_statistics(image_random: np.ndarray) -> None:
     """Test the image_statistics function of statistics.py."""
-
     # Construct the results dataframe that image_stats takes as an argument
     results_data = {
         "molecule_number": [0, 1, 2, 3, 4, 5],
@@ -69,7 +68,7 @@ def test_image_statistics(image_random: np.ndarray) -> None:
 
 
 @pytest.mark.parametrize(
-    "test_image, expected",
+    ("test_image", "expected"),
     [
         (
             np.array(

--- a/tests/test_thresholds.py
+++ b/tests/test_thresholds.py
@@ -1,4 +1,4 @@
-"""Test of thresholds"""
+"""Test of thresholds."""
 # pylint: disable=no-name-in-module
 import pytest
 import numpy as np
@@ -20,7 +20,7 @@ def test_threshold_invalid_method(image_random: np.array) -> None:
     image_random : np.array
         Numpy array representing an image.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         threshold(image_random, method="shoes")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,7 +42,7 @@ def test_update_config(caplog) -> None:
 
 
 @pytest.mark.parametrize(
-    "image_name, core_set, title, zrange",
+    ("image_name", "core_set", "title", "zrange"),
     [
         ("extracted_channel", False, "Raw Height", [0, 3]),
         ("z_threshed", True, "Height Thresholded", [0, 3]),
@@ -54,8 +54,7 @@ def test_update_config(caplog) -> None:
 def test_update_plotting_config(
     process_scan_config: dict, image_name: str, core_set: bool, title: str, zrange: tuple
 ) -> None:
-    """Test that update_plotting_config correctly fills in values
-    for each image in the plotting dictionary plot_dict."""
+    """Ensure values are added to each image in plot_dict."""
     process_scan_config["plotting"] = update_plotting_config(process_scan_config["plotting"])
     assert process_scan_config["plotting"]["plot_dict"][image_name]["core_set"] == core_set
     # Only check titles for images that have titles. grain_image, grain_mask, grain_mask_image don't
@@ -93,14 +92,14 @@ def test_get_thresholds_absolute(image_random: np.ndarray) -> None:
 
 
 def test_get_thresholds_type_error(image_random: np.ndarray) -> None:
-    """Test a TypeError is raised if a non-string value is passed to get_thresholds()"""
+    """Test a TypeError is raised if a non-string value is passed to get_thresholds()."""
     with pytest.raises(TypeError):
         get_thresholds(image=image_random, threshold_method=6.4, **THRESHOLD_OPTIONS)
 
 
 def test_get_thresholds_value_error(image_random: np.ndarray) -> None:
-    """Test a ValueError is raised if an invalid value is passed to get_thresholds()"""
-    with pytest.raises(ValueError):
+    """Test a ValueError is raised if an invalid value is passed to get_thresholds()."""
+    with pytest.raises(ValueError):  # noqa: PT011
         get_thresholds(image=image_random, threshold_method="mean", **THRESHOLD_OPTIONS)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,13 +11,13 @@ TEST_SCHEMA = Schema(
         "a": Path,
         "b": Or("aa", "bb", error="Invalid value in config, valid values are 'aa' or 'bb"),
         "positive_integer": lambda n: 0 < n,
-        "absolute_threshold": Or(int, float, error=("Invalid value in config should be type int or float")),
+        "absolute_threshold": Or(int, float, error="Invalid value in config should be type int or float"),
     }
 )
 
 
 @pytest.mark.parametrize(
-    "config, expectation",
+    ("config", "expectation"),
     [
         # A valid configuration
         ({"a": Path(), "b": "aa", "positive_integer": 4, "absolute_threshold": 10.0}, does_not_raise()),

--- a/tests/tracing/test_dnacurvature.py
+++ b/tests/tracing/test_dnacurvature.py
@@ -21,7 +21,15 @@ def circle_coordinates(points=4, radius=1) -> np.ndarray:
 
 
 @pytest.mark.parametrize(
-    "points, radius, edge_order, expected_variance, expected_first_derivative, expected_second_derivative, expected_local_curvature",
+    (
+        "points",
+        "radius",
+        "edge_order",
+        "expected_variance",
+        "expected_first_derivative",
+        "expected_second_derivative",
+        "expected_local_curvature",
+    ),
     [
         # 4-point circle with varying radius and edge_order
         (
@@ -277,7 +285,8 @@ def test_curvature_circle(
 ) -> None:
     """Test first and second derivatives and local curvature of a circle.
 
-    The variance of local curvature is also tested, for a circle it should be zero."""
+    The variance of local curvature is also tested, for a circle it should be zero.
+    """
     circle_points = circle_coordinates(points, radius)
     curvature = Curvature(molecule_coordinates=circle_points, circular=True)
     curvature.calculate_derivatives(edge_order=edge_order)
@@ -289,7 +298,16 @@ def test_curvature_circle(
 
 
 @pytest.mark.parametrize(
-    "points, radius, shift, edge_order, expected_variance, expected_first_derivative, expected_second_derivative, expected_local_curvature",
+    (
+        "points",
+        "radius",
+        "shift",
+        "edge_order",
+        "expected_variance",
+        "expected_first_derivative",
+        "expected_second_derivative",
+        "expected_local_curvature",
+    ),
     [
         (
             10,
@@ -412,7 +430,8 @@ def test_curvature_circle_starting_point(
     expected_local_curvature,
 ) -> None:
     """Test that the starting point for measuring local curvature of a circle gives the same first and second derivative
-    and the same overall local curvature."""
+    and the same overall local curvature.
+    """
     # Curvature for original circle
     circle_points = circle_coordinates(points, radius)
     curvature = Curvature(molecule_coordinates=circle_points, circular=True)
@@ -454,7 +473,16 @@ def ellipse_coordinates(
 
 
 @pytest.mark.parametrize(
-    "points, major, minor, displacement, edge_order, expected_first_derivative, expected_second_derivative, expected_local_curvature",
+    (
+        "points",
+        "major",
+        "minor",
+        "displacement",
+        "edge_order",
+        "expected_first_derivative",
+        "expected_second_derivative",
+        "expected_local_curvature",
+    ),
     [
         (
             10,
@@ -603,7 +631,17 @@ def test_curvature_ellipse(
 
 
 @pytest.mark.parametrize(
-    "points, major, minor, displacement, shift, edge_order, expected_first_derivative, expected_second_derivative, expected_local_curvature",
+    (
+        "points",
+        "major",
+        "minor",
+        "displacement",
+        "shift",
+        "edge_order",
+        "expected_first_derivative",
+        "expected_second_derivative",
+        "expected_local_curvature",
+    ),
     [
         (
             10,
@@ -779,7 +817,14 @@ def parabola_coordinates(points: int = 10, order: int = 2) -> np.ndarray:
 
 
 @pytest.mark.parametrize(
-    "points, order, edge_order, expected_first_derivative, expected_second_derivative, expected_local_curvature",
+    (
+        "points",
+        "order",
+        "edge_order",
+        "expected_first_derivative",
+        "expected_second_derivative",
+        "expected_local_curvature",
+    ),
     [
         (
             10,

--- a/tests/tracing/test_dnatracing_methods.py
+++ b/tests/tracing/test_dnatracing_methods.py
@@ -1,4 +1,4 @@
-"""Additional tests of dnaTracing methods"""
+"""Additional tests of dnaTracing methods."""
 from pathlib import Path
 
 import numpy as np
@@ -19,17 +19,16 @@ CIRCULAR_MASK = np.load(RESOURCES / "dnatracing_mask_circular.npy")
 MIN_SKELETON_SIZE = 10
 
 
-@pytest.fixture
+@pytest.fixture()
 def dnatrace() -> dnaTrace:
-    """Instantiated object of class dnaTrace for use in tests."""
-    _dnatrace = dnaTrace(
+    """DnaTrace object for use in tests."""
+    return dnaTrace(
         image=np.asarray([[1]]),
         grain=None,
         filename="test.spm",
         pixel_to_nm_scaling=PIXEL_SIZE,
         min_skeleton_size=MIN_SKELETON_SIZE,
     )
-    return _dnatrace
 
 
 GRAINS = {}
@@ -221,7 +220,7 @@ GRAINS["six_ends"] = np.asarray(
 
 
 @pytest.mark.parametrize(
-    "grain, mol_is_circular",
+    ("grain", "mol_is_circular"),
     [
         (GRAINS["vertical"], False),
         (GRAINS["horizontal"], False),
@@ -269,7 +268,7 @@ TEST_LABELLED = np.asarray(
 
 
 @pytest.mark.parametrize(
-    "bounding_box,target, pad_width",
+    ("bounding_box", "target", "pad_width"),
     [
         (
             (1, 1, 2, 7),

--- a/tests/tracing/test_dnatracing_methods.py
+++ b/tests/tracing/test_dnatracing_methods.py
@@ -21,7 +21,7 @@ MIN_SKELETON_SIZE = 10
 
 @pytest.fixture()
 def dnatrace() -> dnaTrace:
-    """DnaTrace object for use in tests."""
+    """dnaTrace object for use in tests."""  # noqa: D403
     return dnaTrace(
         image=np.asarray([[1]]),
         grain=None,

--- a/tests/tracing/test_dnatracing_multigrain.py
+++ b/tests/tracing/test_dnatracing_multigrain.py
@@ -1,4 +1,4 @@
-"""Tests for tracing images with multiple (2) grains"""
+"""Tests for tracing images with multiple (2) grains."""
 from pathlib import Path
 
 import numpy as np
@@ -46,7 +46,7 @@ SMALL_MASK = np.asarray(
 
 
 @pytest.mark.parametrize(
-    "pad_width, target_image, target_mask",
+    ("pad_width", "target_image", "target_mask"),
     [
         (
             0,
@@ -146,7 +146,7 @@ def test_prep_arrays(pad_width: int, target_image: np.ndarray, target_mask: np.n
     """Tests the image and masks are correctly prepared to lists."""
     images, masks = prep_arrays(image=SMALL_ARRAY, labelled_grains_mask=SMALL_MASK, pad_width=pad_width)
     grain = 0
-    for image, mask in zip(images, masks):
+    for image, mask in zip(images, masks):  # noqa: PT011
         np.testing.assert_array_almost_equal(image, target_image[grain])
         np.testing.assert_array_equal(mask, target_mask[grain])
         grain += 1
@@ -155,7 +155,7 @@ def test_prep_arrays(pad_width: int, target_image: np.ndarray, target_mask: np.n
 def test_image_trace_unequal_arrays() -> None:
     """Test arrays that are unequal throw a ValueError."""
     irregular_mask = np.zeros((MULTIGRAIN_IMAGE.shape[0] + 4, MULTIGRAIN_IMAGE.shape[1] + 5))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         trace_image(
             image=MULTIGRAIN_IMAGE,
             grains_mask=irregular_mask,
@@ -191,10 +191,10 @@ TARGET_ARRAY = np.asarray(
 
 
 @pytest.mark.parametrize(
-    "grain_anchors, ordered_traces, image_shape, expected, pad_width",
+    ("grain_anchors", "ordered_traces", "image_shape", "expected", "pad_width"),
     [
         # pad_width = 0
-        [
+        (
             [[0, 0], [0, 9], [7, 0], [5, 4], [10, 7]],
             [
                 np.asarray([[1, 1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6]]),  # Horizontal grain
@@ -221,9 +221,9 @@ TARGET_ARRAY = np.asarray(
             (16, 13),
             TARGET_ARRAY,
             0,
-        ],
+        ),
         # pad_width = 1
-        [
+        (
             [[0, 0], [0, 9], [7, 0], [4, 3], [9, 6]],
             [
                 np.asarray([[2, 2], [2, 3], [2, 4], [2, 5], [2, 6], [2, 7]]),  # Horizontal grain
@@ -250,9 +250,9 @@ TARGET_ARRAY = np.asarray(
             (16, 13),
             TARGET_ARRAY,
             1,
-        ],
+        ),
         # pad_width = 2
-        [
+        (
             [[0, 0], [0, 9], [7, 0], [4, 3], [9, 6]],
             [
                 np.asarray([[3, 3], [3, 4], [3, 5], [3, 6], [3, 7], [3, 8]]),  # Horizontal grain
@@ -279,19 +279,19 @@ TARGET_ARRAY = np.asarray(
             (16, 13),
             TARGET_ARRAY,
             2,
-        ],
+        ),
     ],
 )
 def test_trace_mask(
     grain_anchors: list, ordered_traces: list, image_shape: tuple, pad_width: int, expected: np.ndarray
 ) -> None:
-    """Test the trace_mask"""
+    """Test the trace_mask."""
     image = trace_mask(grain_anchors, ordered_traces, image_shape, pad_width)
     np.testing.assert_array_equal(image, expected)
 
 
 @pytest.mark.parametrize(
-    "image, skeletonisation_method, cores, statistics, ordered_trace_start, ordered_trace_end",
+    ("image", "skeletonisation_method", "cores", "statistics", "ordered_trace_start", "ordered_trace_end"),
     [
         (
             "multigrain_topostats",

--- a/tests/tracing/test_dnatracing_single_grain.py
+++ b/tests/tracing/test_dnatracing_single_grain.py
@@ -1,4 +1,4 @@
-"""Tests for tracing single molecules"""
+"""Tests for tracing single molecules."""
 from pathlib import Path
 
 import numpy as np
@@ -27,10 +27,10 @@ CIRCULAR_IMAGE = np.load(RESOURCES / "dnatracing_image_circular.npy")
 CIRCULAR_MASK = np.load(RESOURCES / "dnatracing_mask_circular.npy")
 
 
-@pytest.fixture
+@pytest.fixture()
 def dnatrace_linear() -> dnaTrace:
-    """dnaTrace object instantiated with a single linear grain."""
-    dnatrace = dnaTrace(
+    """DnaTrace object instantiated with a single linear grain."""
+    return dnaTrace(
         image=LINEAR_IMAGE,
         grain=LINEAR_MASK,
         filename="linear",
@@ -38,13 +38,12 @@ def dnatrace_linear() -> dnaTrace:
         min_skeleton_size=MIN_SKELETON_SIZE,
         skeletonisation_method="topostats",
     )
-    return dnatrace
 
 
-@pytest.fixture
+@pytest.fixture()
 def dnatrace_circular() -> dnaTrace:
-    """dnaTrace object instantiated with a single linear grain."""
-    dnatrace = dnaTrace(
+    """DnaTrace object instantiated with a single linear grain."""
+    return dnaTrace(
         image=CIRCULAR_IMAGE,
         grain=CIRCULAR_MASK,
         filename="circular",
@@ -52,11 +51,10 @@ def dnatrace_circular() -> dnaTrace:
         min_skeleton_size=MIN_SKELETON_SIZE,
         skeletonisation_method="topostats",
     )
-    return dnatrace
 
 
 @pytest.mark.parametrize(
-    "dnatrace, gauss_image_sum",
+    ("dnatrace", "gauss_image_sum"),
     [
         (lazy_fixture("dnatrace_linear"), 5.517763534147536e-06),
         (lazy_fixture("dnatrace_circular"), 6.126947266262167e-06),
@@ -69,7 +67,7 @@ def test_gaussian_filter(dnatrace: dnaTrace, gauss_image_sum: float) -> None:
 
 
 @pytest.mark.parametrize(
-    "dnatrace, skeletonisation_method, length, start, end",
+    ("dnatrace", "skeletonisation_method", "length", "start", "end"),
     [
         (lazy_fixture("dnatrace_linear"), "topostats", 120, np.asarray([28, 47]), np.asarray([106, 87])),
         (lazy_fixture("dnatrace_circular"), "topostats", 150, np.asarray([59, 59]), np.asarray([113, 54])),
@@ -96,21 +94,21 @@ def test_get_disordered_trace(
 
 # Currently two errors are not caught, need to improve this when refactoring, just in case.
 @pytest.mark.parametrize(
-    "min_skeleton_size, problem",
+    ("min_skeleton_size", "problem"),
     [
         (4, None),
         (4, 6),
     ],
 )
 def test_purge_obvious_crap_exceptions(dnatrace_linear: dnaTrace, min_skeleton_size: int, problem) -> None:
-    """Test exceptions to purge_obvious_crap"""
+    """Test exceptions to purge_obvious_crap."""
     dnatrace_linear.min_skeleton_size = min_skeleton_size
     dnatrace_linear.disordered_trace = problem
 
 
 # Currently linear molecule isn't detected as linear, although it was when selecting and extracting in a Notebook
 @pytest.mark.parametrize(
-    "dnatrace, mol_is_circular",
+    ("dnatrace", "mol_is_circular"),
     [
         # (lazy_fixture("dnatrace_linear"), False),
         (lazy_fixture("dnatrace_circular"), True),
@@ -126,7 +124,7 @@ def test_linear_or_circular(dnatrace: dnaTrace, mol_is_circular: int) -> None:
 
 
 @pytest.mark.parametrize(
-    "dnatrace, length, start, end",
+    ("dnatrace", "length", "start", "end"),
     [
         (lazy_fixture("dnatrace_linear"), 118, np.asarray([28, 48]), np.asarray([88, 70])),
         (lazy_fixture("dnatrace_circular"), 151, np.asarray([59, 59]), np.asarray([59, 59])),
@@ -137,7 +135,8 @@ def test_get_ordered_traces(dnatrace: dnaTrace, length: int, start: np.array, en
 
     Note the co-ordinates at the start and end differ from the fixtures for test_get_disordered_trace, but that the
     circular molecule starts and ends in the same place but the linear doesn't (even though it is currently reported as
-    being circular!)."""
+    being circular!).
+    """
     dnatrace.gaussian_filter()
     dnatrace.get_disordered_trace()
     dnatrace.linear_or_circular(dnatrace.disordered_trace)
@@ -149,7 +148,7 @@ def test_get_ordered_traces(dnatrace: dnaTrace, length: int, start: np.array, en
 
 
 @pytest.mark.parametrize(
-    "dnatrace, length, start, end",
+    ("dnatrace", "length", "start", "end"),
     [
         (lazy_fixture("dnatrace_linear"), 118, np.asarray([28, 49]), np.asarray([88, 75])),
         (lazy_fixture("dnatrace_circular"), 151, np.asarray([58, 58]), np.asarray([58, 58])),
@@ -170,7 +169,7 @@ def test_get_fitted_traces(dnatrace: dnaTrace, length: int, start: np.array, end
 
 
 @pytest.mark.parametrize(
-    "dnatrace, length, start, end",
+    ("dnatrace", "length", "start", "end"),
     [
         (
             lazy_fixture("dnatrace_linear"),
@@ -202,7 +201,7 @@ def test_get_splined_traces(dnatrace: dnaTrace, length: int, start: np.array, en
 
 
 @pytest.mark.parametrize(
-    "dnatrace, contour_length",
+    ("dnatrace", "contour_length"),
     [
         (lazy_fixture("dnatrace_linear"), 9.040267985905399e-08),
         (lazy_fixture("dnatrace_circular"), 7.617314045334366e-08),
@@ -223,7 +222,7 @@ def test_measure_contour_length(dnatrace: dnaTrace, contour_length: float) -> No
 
 # Currently need an actual linear grain to test this.
 @pytest.mark.parametrize(
-    "dnatrace, end_to_end_distance",
+    ("dnatrace", "end_to_end_distance"),
     [
         (lazy_fixture("dnatrace_linear"), 0),
         (lazy_fixture("dnatrace_circular"), 0),
@@ -243,9 +242,9 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
 
 
 @pytest.mark.parametrize(
-    "bounding_box, pad_width, target_array",
+    ("bounding_box", "pad_width", "target_array"),
     [
-        [
+        (
             # Top right, no padding, does not extend beyond border
             (1, 1, 4, 4),
             0,
@@ -256,8 +255,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 1],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Top right, 1 cell padding, does not extend beyond border
             (1, 1, 4, 4),
             1,
@@ -270,8 +269,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 0, 0, 0],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Top right, 2 cell padding, extends beyond border
             (1, 1, 4, 4),
             2,
@@ -285,8 +284,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 0, 0, 0, 0],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Bottom left, no padding, does not extend beyond border
             (6, 6, 9, 9),
             0,
@@ -297,8 +296,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 1],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Bottom left, one cell padding, does not extend beyond border
             (6, 6, 9, 9),
             1,
@@ -311,8 +310,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 0, 0, 0],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Bottom left, two cell padding, extends beyond border
             (6, 6, 9, 9),
             2,
@@ -326,8 +325,8 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 0, 0, 0, 0],
                 ]
             ),
-        ],
-        [
+        ),
+        (
             # Bottom left, three cell padding, extends beyond border
             (6, 6, 9, 9),
             3,
@@ -342,7 +341,7 @@ def test_measure_end_to_end_distance(dnatrace: dnaTrace, end_to_end_distance: fl
                     [0, 0, 0, 0, 0, 0, 0],
                 ]
             ),
-        ],
+        ),
     ],
 )
 def test_crop_array(bounding_box: tuple, pad_width: int, target_array: list) -> None:
@@ -357,13 +356,13 @@ def test_crop_array(bounding_box: tuple, pad_width: int, target_array: list) -> 
 
 
 @pytest.mark.parametrize(
-    "array_shape, bounding_box, pad_width, target_coordinates",
+    ("array_shape", "bounding_box", "pad_width", "target_coordinates"),
     [
-        [(10, 10), [1, 1, 5, 5], 1, [0, 0, 6, 6]],
-        [(10, 10), [1, 1, 5, 5], 3, [0, 0, 8, 8]],
-        [(10, 10), [4, 4, 5, 5], 1, [3, 3, 6, 6]],
-        [(10, 10), [4, 4, 5, 5], 3, [1, 1, 8, 8]],
-        [(10, 10), [4, 4, 5, 5], 6, [0, 0, 10, 10]],
+        ((10, 10), [1, 1, 5, 5], 1, [0, 0, 6, 6]),
+        ((10, 10), [1, 1, 5, 5], 3, [0, 0, 8, 8]),
+        ((10, 10), [4, 4, 5, 5], 1, [3, 3, 6, 6]),
+        ((10, 10), [4, 4, 5, 5], 3, [1, 1, 8, 8]),
+        ((10, 10), [4, 4, 5, 5], 6, [0, 0, 10, 10]),
     ],
 )
 def test_pad_bounding_box(array_shape: tuple, bounding_box: list, pad_width: int, target_coordinates: tuple) -> None:
@@ -373,13 +372,13 @@ def test_pad_bounding_box(array_shape: tuple, bounding_box: list, pad_width: int
 
 
 @pytest.mark.parametrize(
-    "array_shape, bounding_box, pad_width, target_coordinates",
+    ("array_shape", "bounding_box", "pad_width", "target_coordinates"),
     [
-        [(10, 10), [1, 1, 5, 5], 1, (0, 0)],
-        [(10, 10), [1, 1, 5, 5], 3, (0, 0)],
-        [(10, 10), [4, 4, 5, 5], 1, (3, 3)],
-        [(10, 10), [4, 4, 5, 5], 3, (1, 1)],
-        [(10, 10), [4, 4, 5, 5], 6, (0, 0)],
+        ((10, 10), [1, 1, 5, 5], 1, (0, 0)),
+        ((10, 10), [1, 1, 5, 5], 3, (0, 0)),
+        ((10, 10), [4, 4, 5, 5], 1, (3, 3)),
+        ((10, 10), [4, 4, 5, 5], 3, (1, 1)),
+        ((10, 10), [4, 4, 5, 5], 6, (0, 0)),
     ],
 )
 def test_grain_anchor(array_shape: tuple, bounding_box: list, pad_width: int, target_coordinates: tuple) -> None:
@@ -389,7 +388,15 @@ def test_grain_anchor(array_shape: tuple, bounding_box: list, pad_width: int, ta
 
 
 @pytest.mark.parametrize(
-    "cropped_image, cropped_mask, filename, skeletonisation_method, end_to_end_distance, circular, contour_length",
+    (
+        "cropped_image",
+        "cropped_mask",
+        "filename",
+        "skeletonisation_method",
+        "end_to_end_distance",
+        "circular",
+        "contour_length",
+    ),
     [
         (
             LINEAR_IMAGE,
@@ -474,7 +481,7 @@ def test_trace_grain(
     circular: bool,
     contour_length: float,
 ) -> None:
-    """Test trace_grain function for tracing a single grain"""
+    """Test trace_grain function for tracing a single grain."""
     trace_stats = trace_grain(
         cropped_image=cropped_image,
         cropped_mask=cropped_mask,

--- a/tests/tracing/test_dnatracing_single_grain.py
+++ b/tests/tracing/test_dnatracing_single_grain.py
@@ -29,7 +29,7 @@ CIRCULAR_MASK = np.load(RESOURCES / "dnatracing_mask_circular.npy")
 
 @pytest.fixture()
 def dnatrace_linear() -> dnaTrace:
-    """DnaTrace object instantiated with a single linear grain."""
+    """DnaTrace object instantiated with a single linear grain."""  # noqa: D403
     return dnaTrace(
         image=LINEAR_IMAGE,
         grain=LINEAR_MASK,

--- a/tests/tracing/test_skeletonize.py
+++ b/tests/tracing/test_skeletonize.py
@@ -35,7 +35,7 @@ CIRCULAR_TARGET = np.array(
 
 def test_skeletonize_method(skeletonize_circular_bool_int: np.ndarray) -> None:
     """Test unsupported method raises the appropriate error."""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         get_skeleton(skeletonize_circular_bool_int, method="nonsense")
 
 

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -1,4 +1,4 @@
-"""Topostats"""
+"""Topostats."""
 from importlib.metadata import version
 
 from .logs.logs import setup_logger

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -1,4 +1,5 @@
 """Topostats."""
+from __future__ import annotations
 from importlib.metadata import version
 
 from .logs.logs import setup_logger

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -1,5 +1,4 @@
 """Topostats."""
-from __future__ import annotations
 from importlib.metadata import version
 
 from .logs.logs import setup_logger

--- a/topostats/__main__.py
+++ b/topostats/__main__.py
@@ -1,3 +1,4 @@
+"""Main Module."""
 import topostats.topotracing as topotracing
 
 topotracing.main()

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -1,5 +1,6 @@
-"""Entry point for all TopoStats programs. Parses command-line arguments and passes input on to the relevant
-functions / modules.
+"""Entry point for all TopoStats programs.
+
+Parses command-line arguments and passes input on to the relevant functions / modules.
 """
 
 import sys
@@ -158,7 +159,6 @@ def create_parser() -> arg.ArgumentParser:
 
 def entry_point(manually_provided_args=None, testing=False) -> None:
     """Entry point for all TopoStats programs."""
-
     # Parse command line options, load config (or default) and update with command line options
     parser = create_parser()
     args = parser.parse_args() if manually_provided_args is None else parser.parse_args(manually_provided_args)
@@ -315,7 +315,6 @@ def create_legacy_toposum_parser() -> arg.ArgumentParser:
 
 def legacy_run_topostats_entry_point(args=None, testing=False) -> None:
     """Legacy entry point for the run_topostats processing function."""
-
     parser = create_legacy_run_topostats_parser()
     args = parser.parse_args() if args is None else parser.parse_args(args)
 
@@ -329,7 +328,6 @@ def legacy_run_topostats_entry_point(args=None, testing=False) -> None:
 
 def legacy_toposum_entry_point(args=None, testing=False) -> None:
     """Legacy entry point for the toposum summarizing function."""
-
     parser = create_legacy_toposum_parser()
     args = parser.parse_args() if args is None else parser.parse_args(args)
 

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -1,9 +1,7 @@
-"""Contains filter functions that take a 2D array representing an image as an input, as well as necessary parameters,
-and return a 2D array of the same size representing the filtered image."""
+"""Module for filtering 2D Numpy arrays."""
 import logging
-from typing import Union
 
-# noqa: disable=no-name-in-module
+# ruff: noqa: disable=no-name-in-module
 # pylint: disable=no-name-in-module
 from skimage.filters import gaussian
 from scipy.optimize import curve_fit
@@ -16,8 +14,8 @@ from topostats import scars
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
-# noqa: disable=too-many-instance-attributes
-# noqa: disable=too-many-arguments
+# ruff: noqa: disable=too-many-instance-attributes
+# ruff: noqa: disable=too-many-arguments
 # pylint: disable=fixme
 # pylint: disable=broad-except
 # pylint: disable=too-many-instance-attributes
@@ -107,9 +105,11 @@ class Filters:
     def median_flatten(
         self, image: np.ndarray, mask: np.ndarray = None, row_alignment_quantile: float = 0.5
     ) -> np.ndarray:
-        """
-        Uses the method of median differences to flatten the rows of an image, aligning the rows and centering the
-        median around zero. When used with a mask, this has the effect of centering the background data on zero.
+        """Flatten images using median differences.
+
+        Flatten the rows of an image, aligning the rows and centering the median around zero. When used with a mask,
+        this has the effect of centering the background data on zero.
+
         Note this function does not handle scars.
 
         Parameters
@@ -149,9 +149,10 @@ processed, please refer to <url to page where we document common problems> for m
 
     def remove_tilt(self, image: np.ndarray, mask: np.ndarray = None):
         """
-        Removes planar tilt from an image (linear in 2D space). It uses a linear fit of the medians
-        of the rows and columns to determine the linear slants in x and y directions and then subtracts
-        the fit from the columns.
+        Remove planar tilt from an image (linear in 2D space).
+
+        Uses a linear fit of the medians of the rows and columns to determine the linear slants in x and y directions
+        and then subtracts the fit from the columns.
 
         Parameters
         ----------
@@ -161,6 +162,7 @@ processed, please refer to <url to page where we document common problems> for m
             Boolean array of points to mask out (ignore).
         img_name: str
             Name of the image (to be able to print information in the console).
+
         Returns
         -------
         np.ndarray
@@ -211,12 +213,15 @@ processed, please refer to <url to page where we document common problems> for m
 
         return image
 
-    def remove_nonlinear_polynomial(self, image: np.ndarray, mask: Union[np.ndarray, None] = None) -> np.ndarray:
+    def remove_nonlinear_polynomial(self, image: np.ndarray, mask: np.ndarray | None = None) -> np.ndarray:
         # Script has a lot of locals but I feel this is necessary for readability?
         # pylint: disable=too-many-locals
-        """Fit and remove a "saddle" shaped nonlinear polynomial trend of the form a + b * x * y - c * x - d * y
-        from the supplied image. AFM images sometimes contain a "saddle" shape trend to their background,
-        and so to remove them we fit a nonlinear polynomial of x and y and then subtract the fit from the image.
+        """Fit and remove a "saddle" shaped nonlinear polynomial from the image.
+
+        "Saddles" with the form a + b * x * y - c * x - d * y from the supplied image. AFM images sometimes contain a
+        "saddle" shape trend to their background, and so to remove them we fit a nonlinear polynomial of x and y and
+        then subtract the fit from the image.
+
         If these trends are not removed, then the image will not flatten properly and will leave opposite diagonal
         corners raised or lowered.
 
@@ -285,8 +290,10 @@ processed, please refer to <url to page where we document common problems> for m
 
     def remove_quadratic(self, image: np.ndarray, mask: np.ndarray = None) -> np.ndarray:
         """
-        Removes the quadratic bowing that can be seen in some large-scale AFM images. It uses a simple quadratic fit
-        on the medians of the columns of the image and then subtracts the calculated quadratic from the columns.
+        Remove the quadratic bowing that can be seen in some large-scale AFM images.
+
+        Use a simple quadratic fit on the medians of the columns of the image and then subtracts the calculated
+        quadratic from the columns.
 
         Parameters
         ----------

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -1,4 +1,5 @@
 """Module for filtering 2D Numpy arrays."""
+from __future__ import annotations
 import logging
 
 # ruff: noqa: disable=no-name-in-module

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -1,4 +1,5 @@
 """Contains class for calculating the statistics of grains - 2d raster images."""
+from __future__ import annotations
 import logging
 from pathlib import Path
 from random import randint

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -1,8 +1,7 @@
-"""Contains class for calculating the statistics of grains - 2d raster images"""
+"""Contains class for calculating the statistics of grains - 2d raster images."""
 import logging
 from pathlib import Path
 from random import randint
-from typing import Union, List, Tuple, Dict
 
 import numpy as np
 import skimage.measure as skimage_measure
@@ -63,7 +62,7 @@ class GrainStats:
         labelled_data: np.ndarray,
         pixel_to_nanometre_scaling: float,
         direction: str,
-        base_output_dir: Union[str, Path],
+        base_output_dir: str | Path,
         image_name: str = None,
         edge_detection_method: str = "binary_erosion",
         cropped_size: float = -1,
@@ -97,7 +96,6 @@ class GrainStats:
             Multiplier to convert the current length scale to metres. Default: 1e-9 for the
             usual AFM length scale of nanometres.
         """
-
         self.data = data
         self.labelled_data = labelled_data
         self.pixel_to_nanometre_scaling = pixel_to_nanometre_scaling
@@ -112,7 +110,7 @@ class GrainStats:
 
     @staticmethod
     def get_angle(point_1: tuple, point_2: tuple) -> float:
-        """Function that calculates the angle in radians between two points.
+        """Calculate the angle in radians between two points.
 
         Parameters
         ----------
@@ -126,12 +124,11 @@ class GrainStats:
         angle : float
             The angle in radians between the two input vectors.
         """
-
         return np.arctan2(point_1[1] - point_2[1], point_1[0] - point_2[0])
 
     @staticmethod
     def is_clockwise(p_1: tuple, p_2: tuple, p_3: tuple) -> bool:
-        """Function to determine if three points make a clockwise or counter-clockwise turn.
+        """Determine if three points make a clockwise or counter-clockwise turn.
 
         Parameters
         ----------
@@ -153,7 +150,7 @@ class GrainStats:
         rotation_matrix = np.array(((p_1[0], p_1[1], 1), (p_2[0], p_2[1], 1), (p_3[0], p_3[1], 1)))
         return not np.linalg.det(rotation_matrix) > 0
 
-    def calculate_stats(self) -> Dict:
+    def calculate_stats(self) -> dict:
         """Calculate the stats of grains in the labelled image.
 
         Returns
@@ -163,7 +160,6 @@ class GrainStats:
         grains_plot_data:
             A list of dictionaries containing grain data to be plotted.
         """
-
         grains_plot_data = []
         if self.labelled_data is None:
             LOGGER.info(
@@ -303,9 +299,7 @@ class GrainStats:
 
     @staticmethod
     def calculate_points(grain_mask: np.ndarray):
-        """Class method that takes a 2D boolean numpy array image of a grain and returns a list containing the
-        co-ordinates of the points in the grain.
-
+        """Convert a 2D boolean array to a list of co-ordinates.
 
         Parameters
         ----------
@@ -315,7 +309,8 @@ class GrainStats:
         Returns
         -------
         points : list
-            A python list containing the coordinates of the pixels in the grain."""
+        A python list containing the coordinates of the pixels in the grain.
+        """
         nonzero_coordinates = grain_mask.nonzero()
         points = []
         for point in np.transpose(nonzero_coordinates):
@@ -325,8 +320,7 @@ class GrainStats:
 
     @staticmethod
     def calculate_edges(grain_mask: np.ndarray, edge_detection_method: str):
-        """Class method that takes a 2D boolean numpy array image of a grain and returns a python list of the
-        coordinates of the edges of the grain.
+        """Convert 2D boolean array to list of the coordinates of the edges of the grain.
 
         Parameters
         ----------
@@ -370,9 +364,10 @@ class GrainStats:
         # return edges
         return [list(vector) for vector in np.transpose(nonzero_coordinates)]
 
-    def calculate_radius_stats(self, edges: list, points: list) -> Tuple:
-        """Class method that calculates the statistics relating to the radius. The radius in this context
-        is the distance from the centroid to points on the edge of the grain.
+    def calculate_radius_stats(self, edges: list, points: list) -> tuple:
+        """Calculate the radius of grains.
+
+        The radius in this context is the distance from the centroid to points on the edge of the grain.
 
         Parameters
         ----------
@@ -419,13 +414,13 @@ class GrainStats:
 
     @staticmethod
     def _calculate_displacement(edges: np.array, centroid: tuple) -> np.array:
-        """Calculate the displacement between the centroid and edges"""
+        """Calculate the displacement between the centroid and edges."""
         # FIXME : Remove once we have a numpy array returned by calculate_edges
         return np.array(edges) - centroid
 
     @staticmethod
     def _calculate_radius(displacements) -> np.array:
-        """Calculate the radius of each point from the centroid
+        """Calculate the radius of each point from the centroid.
 
         Parameters
         ----------
@@ -438,8 +433,9 @@ class GrainStats:
         return np.array([np.sqrt(radius[0] ** 2 + radius[1] ** 2) for radius in displacements])
 
     def convex_hull(self, edges: list, base_output_dir: Path, debug: bool = False):
-        """Class method that takes a grain mask and the edges of the grain and returns the grain's convex hull. Based
-        off of the Graham Scan algorithm and should ideally scale in time with O(nlog(n)).
+        """Calculate a grain's convex hull.
+
+        Based off of the Graham Scan algorithm and should ideally scale in time with O(nlog(n)).
 
         Parameters
         ----------
@@ -473,8 +469,9 @@ class GrainStats:
         return hull, hull_indices, simplexes
 
     def calculate_squared_distance(self, point_2: tuple, point_1: tuple = None) -> float:
-        """Function that calculates the distance squared between two points. Used for distance sorting purposes and
-        therefore does not perform a square root in the interests of efficiency.
+        """Calculate the squared distance between two points.
+
+        Used for distance sorting purposes and therefore does not perform a square root in the interests of efficiency.
 
         Parameters
         ----------
@@ -496,9 +493,9 @@ class GrainStats:
         # Don't need the sqrt since just sorting for dist
         return float(delta_x**2 + delta_y**2)
 
-    def sort_points(self, points: List) -> List:
+    def sort_points(self, points: list) -> list:
         #    def sort_points(self, points: np.array) -> List:
-        """Function to sort points in counter-clockwise order of angle made with the starting point.
+        """Sort points in counter-clockwise order of angle made with the starting point.
 
         Parameters
         ----------
@@ -516,7 +513,7 @@ class GrainStats:
         # Lists that allow sorting of points relative to a current comparision point
         smaller, equal, larger = [], [], []
         # Get a random point in the array to calculate the pivot angle from. This sorts the points relative to this point.
-        pivot_angle = self.get_angle(points[randint(0, len(points) - 1)], self.start_point)
+        pivot_angle = self.get_angle(points[randint(0, len(points) - 1)], self.start_point)  # noqa: S311
         for point in points:
             point_angle = self.get_angle(point, self.start_point)
             # If the
@@ -530,28 +527,24 @@ class GrainStats:
         # relative to that and _then_ sort it.
         # pivot_angles = self.get_angle(points, self.start_point)
         # Recursively sort the arrays until each point is sorted
-        sorted_points = (
-            self.sort_points(smaller) + sorted(equal, key=self.calculate_squared_distance) + self.sort_points(larger)
-        )
+        return self.sort_points(smaller) + sorted(equal, key=self.calculate_squared_distance) + self.sort_points(larger)
         # Return sorted array where equal angle points are sorted by distance
-        return sorted_points
 
-    def get_start_point(self, edges) -> int:
+    def get_start_point(self, edges) -> None:
         """Determine the index of the bottom most point of the hull when sorted by x-position.
 
         Parameters
         ----------
         edges: np.array
 
-        Returns
-        -------
         """
         min_y_index = np.argmin(edges[:, 1])
         self.start_point = edges[min_y_index]
 
     def graham_scan(self, edges: list):
-        """A function based on the Graham Scan algorithm that constructs a convex hull from points in 2D cartesian
-        space. Ideally this algorithm will take O( n * log(n) ) time.
+        """Construct the convex hull using the  Graham Scan algorithm.
+
+        Ideally this algorithm will take O( n * log(n) ) time.
 
         Parameters
         ----------
@@ -591,7 +584,7 @@ class GrainStats:
 
         # Iterate through each point, checking if this point would cause a clockwise rotation if added to the hull, and
         # if so, backtracking.
-        for index, point in enumerate(points_sorted_by_angle[1:]):
+        for _, point in enumerate(points_sorted_by_angle[1:]):
             # Determine if the proposed point demands a clockwise rotation
             while self.is_clockwise(hull[-2], hull[-1], point) is True:
                 # Delete the failed point
@@ -614,9 +607,8 @@ class GrainStats:
         return hull, hull_indices, simplices
 
     @staticmethod
-    def plot(edges: list, convex_hull: list = None, file_path: Path = None):
-        """A function that plots and saves the coordinates of the edges in the grain and optionally the hull. The
-        plot is saved as the file name that is provided.
+    def plot(edges: list, convex_hull: list = None, file_path: Path = None) -> None:
+        """Plot and save the coordinates of the edges in the grain and optionally the hull.
 
         Parameters
         ----------
@@ -628,7 +620,6 @@ class GrainStats:
         file_path : Path
             Path of the file to save the plot as.
         """
-
         _, ax = plt.subplots(1, 1, figsize=(8, 8))
         x_s, y_s = zip(*edges)
         ax.scatter(x_s, y_s)
@@ -645,8 +636,7 @@ class GrainStats:
         plt.close()
 
     def calculate_aspect_ratio(self, edges: list, hull_simplices: np.ndarray, path: Path, debug: bool = False) -> tuple:
-        """Class method that takes a list of edge points for a grain, and convex hull simplices and returns the width,
-           length and aspect ratio of the smallest bounding rectangle for the grain.
+        """Calculate the width, length and aspect ratio of the smallest bounding rectangle of a grain.
 
         Parameters
         ----------
@@ -867,7 +857,7 @@ class GrainStats:
         return smallest_bounding_width, smallest_bounding_length, aspect_ratio
 
     @staticmethod
-    def find_cartesian_extremes(rotated_points: np.ndarray) -> Dict:
+    def find_cartesian_extremes(rotated_points: np.ndarray) -> dict:
         """Find the limits of x and y of rotated points.
 
         Parameters
@@ -889,7 +879,7 @@ class GrainStats:
 
     @staticmethod
     def get_shift(coords: np.ndarray, shape: np.ndarray) -> int:
-        """Obtains the coordinate shift to reflect the cropped image box for molecules near the edges of the image.
+        """Obtain the coordinate shift to reflect the cropped image box for molecules near the edges of the image.
 
         Parameters
         ----------
@@ -940,7 +930,8 @@ class GrainStats:
 
     @staticmethod
     def get_triangle_height(base_point_1: np.array, base_point_2: np.array, top_point: np.array) -> float:
-        """Returns the height of a triangle defined by the input point vectors.
+        """Return the height of a triangle defined by the input point vectors.
+
         Parameters
         ----------
         base_point_1: np.ndarray
@@ -958,24 +949,24 @@ class GrainStats:
             The height of the triangle - ie the shortest distance between the top point and the line between the two
         base points.
         """
-
         # Height of triangle = A/b = ||AB X AC|| / ||AB||
         a_b = base_point_1 - base_point_2
         a_c = base_point_1 - top_point
         return np.linalg.norm(np.cross(a_b, a_c)) / np.linalg.norm(a_b)
 
     @staticmethod
-    def get_max_min_ferets(edge_points: list):
-        """Returns the minimum and maximum feret diameters for a grain.
-        These are defined as the smallest and greatest distances between
-        a pair of callipers that are rotating around a 2d object, maintaining
-        contact at all times.
+    def get_max_min_ferets(edge_points: list):  # noqa: C901
+        """Return the minimum and maximum feret diameters for a grain.
+
+        These are defined as the smallest and greatest distances between a pair of callipers that are rotating around a
+        2d object, maintaining contact at all times.
 
         Parameters
         ----------
         edge_points: list
             a list of the vector positions of the pixels comprising the edge of the
             grain. Eg: [[0, 0], [1, 0], [2, 1]]
+
         Returns
         -------
         min_feret: float
@@ -985,22 +976,17 @@ class GrainStats:
 
         Notes
         -----
-        The method starts out by calculating the upper and lower convex hulls using
-        an algorithm based on the Graham Scan Algorithm [1]. Using these upper and
-        lower hulls, the callipers are simulated as rotating clockwise around the grain.
-        We determine the order in which vertices are encountered by comparing the
-        gradients of the slopes between vertices. An array of pairs of points that
-        are in contact with either calliper at a given time is created in order to
-        be able to calculate the maximum feret diameter. The minimum diameter is a
-        little tricky, since it won't simply be the shortest distance between two
-        contact points, but it will occur somewhere during the rotation around a
-        pair of contact points. It turns out that the point will always be such
-        that two points are in contact with one calliper while the other calliper
-        is in contact with another point. We can use this fact to be sure of finding
-        the smallest feret diameter, simply by testing each triangle of 3 contact points
-        as we iterate, finding the height of the triangle that is formed between the
-        three aforementioned points, as this will be the perpendicular distance between
-        the callipers.
+        The method starts out by calculating the upper and lower convex hulls using  an algorithm based on the Graham
+        Scan Algorithm [1]. Using these upper and lower hulls, the callipers are simulated as rotating clockwise around
+        the grain. We determine the order in which vertices are encountered by comparing the gradients of the slopes
+        between vertices. An array of pairs of points that are in contact with either calliper at a given time is
+        created in order to be able to calculate the maximum feret diameter. The minimum diameter is a little tricky,
+        since it won't simply be the shortest distance between two contact points, but it will occur somewhere during
+        the rotation around a pair of contact points. It turns out that the point will always be such that two points
+        are in contact with one calliper while the other calliper is in contact with another point. We can use this fact
+        to be sure of finding the smallest feret diameter, simply by testing each triangle of 3 contact points as we
+        iterate, finding the height of the triangle that is formed between the three aforementioned points, as this will
+        be the perpendicular distance between the callipers.
 
         References
         ----------
@@ -1009,7 +995,6 @@ class GrainStats:
             Information Processing Letters. 1 (4): 132-133.
             doi:10.1016/0020-0190(72)90045-2.
         """
-
         # Sort the vectors by their x coordinate and then by their y coordinate.
         # The conversion between list and numpy array can be removed, though it would be harder
         # to read.

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -6,7 +6,7 @@ import io
 import struct
 from pathlib import Path
 import pickle as pkl
-from typing import Any, Dict, List, Union
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -29,7 +29,7 @@ CONFIG_DOCUMENTATION_REFERENCE = """For more information on configuration and ho
 # pylint: disable=too-many-lines
 
 
-def read_yaml(filename: Union[str, Path]) -> Dict:
+def read_yaml(filename: str | Path) -> dict:
     """Read a YAML file.
 
     Parameters
@@ -42,7 +42,6 @@ def read_yaml(filename: Union[str, Path]) -> Dict:
     Dict
         Dictionary of the file.
     """
-
     with Path(filename).open(encoding="utf-8") as f:
         try:
             yaml_file = YAML(typ="safe")
@@ -65,12 +64,11 @@ def get_date_time() -> str:
     str
         A string of the current date and time, formatted appropriately.
     """
-
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
 
 def write_yaml(
-    config: dict, output_dir: Union[str, Path], config_file: str = "config.yaml", header_message: str = None
+    config: dict, output_dir: str | Path, config_file: str = "config.yaml", header_message: str = None
 ) -> None:
     """Write a configuration (stored as a dictionary) to a YAML file.
 
@@ -106,8 +104,7 @@ def write_yaml(
 
 def write_config_with_comments(config: str, output_dir: Path, filename: str = "config.yaml") -> None:
     """
-    Create a config file, retaining the comments by writing it as a string
-    rather than using a yaml handling package.
+    Write a sample configuration with in-line comments.
 
     Parameters
     ----------
@@ -118,13 +115,12 @@ def write_config_with_comments(config: str, output_dir: Path, filename: str = "c
     filename: str
         A name for the configuration file. Can have a ".yaml" on the end.
     """
-
     if ".yaml" not in filename and ".yml" not in filename:
         create_config_path = output_dir / f"{filename}.yaml"
     else:
         create_config_path = output_dir / filename
 
-    with open(f"{create_config_path}", "w", encoding="utf-8") as f:
+    with Path.open(f"{create_config_path}", "w", encoding="utf-8") as f:
         f.write(f"# Config file generated {get_date_time()}\n")
         f.write(f"# {CONFIG_DOCUMENTATION_REFERENCE}")
         f.write(config)
@@ -151,7 +147,7 @@ def save_array(array: np.ndarray, outpath: Path, filename: str, array_type: str)
     LOGGER.info(f"[{filename}] Numpy array saved to : {outpath}/{filename}_{array_type}.npy")
 
 
-def load_array(array_path: Union[str, Path]) -> np.ndarray:
+def load_array(array_path: str | Path) -> np.ndarray:
     """Load a Numpy array from file.
 
     Should have been saved using save_array() or numpy.save().
@@ -172,7 +168,7 @@ def load_array(array_path: Union[str, Path]) -> np.ndarray:
         raise e
 
 
-def path_to_str(config: dict) -> Dict:
+def path_to_str(config: dict) -> dict:
     """Recursively traverse a dictionary and convert any Path() objects to strings for writing to YAML.
 
     Parameters
@@ -194,10 +190,8 @@ def path_to_str(config: dict) -> Dict:
     return config
 
 
-def get_out_path(
-    image_path: Union[str, Path] = None, base_dir: Union[str, Path] = None, output_dir: Union[str, Path] = None
-) -> Path:
-    """Adds the image path relative to the base directory to the output directory.
+def get_out_path(image_path: str | Path = None, base_dir: str | Path = None, output_dir: str | Path = None) -> Path:
+    """Add the image path relative to the base directory to the output directory.
 
     Parameters
     ----------
@@ -231,7 +225,7 @@ def get_out_path(
         raise
 
 
-def find_files(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> List:
+def find_files(base_dir: str | Path = None, file_ext: str = ".spm") -> list:
     """Recursively scan the specified directory for images with the given file extension.
 
     Parameters
@@ -250,10 +244,8 @@ def find_files(base_dir: Union[str, Path] = None, file_ext: str = ".spm") -> Lis
     return list(base_dir.glob("**/*" + file_ext))
 
 
-def save_folder_grainstats(
-    output_dir: Union[str, Path], base_dir: Union[str, Path], all_stats_df: pd.DataFrame
-) -> None:
-    """Saves a data frame of grain and tracing statictics at the folder level.
+def save_folder_grainstats(output_dir: str | Path, base_dir: str | Path, all_stats_df: pd.DataFrame) -> None:
+    """Save a data frame of grain and tracing statictics at the folder level.
 
     Parameters
     ----------
@@ -288,8 +280,7 @@ def save_folder_grainstats(
 
 
 def read_null_terminated_string(open_file: io.TextIOWrapper) -> str:
-    """Read an open file from the current position in the open binary file,
-    until the next null value.
+    """Read an open file from the current position in the open binary file, until the next null value.
 
     Parameters
     ----------
@@ -359,7 +350,9 @@ def read_char(open_file: io.TextIOWrapper) -> str:
 
 def read_gwy_component_dtype(open_file: io.TextIOWrapper) -> str:
     """Read the data type of a `.gwy` file component.
+
     Possible data types are as follows:
+
     - 'b': boolean
     - 'c': character
     - 'i': 32-bit integer
@@ -367,15 +360,16 @@ def read_gwy_component_dtype(open_file: io.TextIOWrapper) -> str:
     - 'd': double
     - 's': string
     - 'o': `.gwy` format object
-    Capitalised versions of some of these data types represent arrays of values of that
-    data type. Arrays are stored as an unsigned 32 bit integer, describing the size of the array,
-    followed by the unseparated array values.
+
+    Capitalised versions of some of these data types represent arrays of values of that data type. Arrays are stored as
+    an unsigned 32 bit integer, describing the size of the array, followed by the unseparated array values:
+
     - 'C': array of characters
     - 'I': array of 32-bit integers
     - 'Q': array of 64-bit integers
     - 'D': array of doubles
     - 'S': array of strings
-    - 'O': array of objects
+    - 'O': array of objects.
 
     Parameters
     ----------
@@ -391,10 +385,11 @@ def read_gwy_component_dtype(open_file: io.TextIOWrapper) -> str:
     return open_file.read(1).decode("ascii")
 
 
-def get_relative_paths(paths: List[Path]) -> List[str]:
-    """From a list of paths, create a list of these paths but where
-    each path is relative to all path's closest common parent. For
-    example, ['a/b/c', 'a/b/d', 'a/b/e/f'] would return ['c', 'd', 'e/f']
+def get_relative_paths(paths: list[Path]) -> list[str]:
+    """Extract a list of relative paths, removing the common suffix.
+
+    From a list of paths, create a list where each path is relative to all path's closest common parent. For
+    example, ['a/b/c', 'a/b/d', 'a/b/e/f'] would return ['c', 'd', 'e/f'].
 
     Parameters
     ----------
@@ -406,7 +401,6 @@ def get_relative_paths(paths: List[Path]) -> List[str]:
     relative_paths: list
         List of string paths, relative to the common parent.
     """
-
     # Ensure paths are all pathlib paths, and not strings
     paths = [Path(path) for path in paths]
 
@@ -423,10 +417,10 @@ def get_relative_paths(paths: List[Path]) -> List[str]:
 
 
 def convert_basename_to_relative_paths(df: pd.DataFrame):
-    """Converts the paths in the 'basename' column in a dataframe from being
-    absolute paths, to paths relative to the deepest common parent. For example
-    if the 'basename' column has the following paths: ['/usr/topo/data/a/b', '/usr
-    /topo/data/c/d'], the output will be: ['a/b', 'c/d'].
+    """Convert paths in the 'basename' column of a dataframe to relative paths.
+
+    If the 'basename' column has the following paths: ['/usr/topo/data/a/b', '/usr/topo/data/c/d'], the output will be:
+    ['a/b', 'c/d'].
 
     Parameters
     ----------
@@ -440,7 +434,6 @@ def convert_basename_to_relative_paths(df: pd.DataFrame):
         A pandas dataframe where the 'basename' column has paths relative to a common
         parent.
     """
-
     paths = df["basename"].tolist()
     paths = [Path(path) for path in paths]
     relative_paths = get_relative_paths(paths=paths)
@@ -537,16 +530,18 @@ class LoadScans:
         return pixel_to_nm_scaling
 
     def load_topostats(self) -> tuple:
-        """Load a .topostats file (hdf5 format), extracting the image, pixel to nanometre scaling
-        factor and any grain masks. Note that grain masks are stored via self.grain_masks rather
-        than returned due to how we extract information for all other file loading functions.
+        """Load a .topostats file (hdf5 format).
+
+        Loads and extracts the image, pixel to nanometre scaling factor and any grain masks.
+
+        Note that grain masks are stored via self.grain_masks rather than returned due to how we extract information for
+        all other file loading functions.
 
         Returns
         -------
         tuple(np.ndarray, float)
             A tuple containing the image and its pixel to nanometre scaling value.
         """
-
         LOGGER.info(f"Loading image from : {self.img_path}")
         try:
             with h5py.File(self.img_path, "r") as f:
@@ -571,14 +566,13 @@ class LoadScans:
         return (image, pixel_to_nm_scaling)
 
     def load_ibw(self) -> tuple:
-        """Loads image from Asylum Research (Igor) .ibw files
+        """Load image from Asylum Research (Igor) .ibw files.
 
         Returns
         -------
         tuple(np.ndarray, float)
             A tuple containing the image and its pixel to nanometre scaling value.
         """
-
         LOGGER.info(f"Loading image from : {self.img_path}")
         try:
             scan = binarywave.load(self.img_path)
@@ -631,7 +625,7 @@ class LoadScans:
         return pixel_to_nm_scaling
 
     def load_jpk(self) -> tuple:
-        """Loads image from JPK Instruments .jpk files.
+        """Load image from JPK Instruments .jpk files.
 
         Returns
         -------
@@ -702,8 +696,7 @@ class LoadScans:
 
     @staticmethod
     def _gwy_read_object(open_file: io.TextIOWrapper, data_dict: dict) -> None:
-        """Parse and extract data from a `.gwy` file object, starting at the current
-        open file read position.
+        """Parse and extract data from a `.gwy` file object, starting at the current open file read position.
 
         Parameters
         ----------
@@ -731,8 +724,7 @@ class LoadScans:
 
     @staticmethod
     def _gwy_read_component(open_file: io.TextIOWrapper, initial_byte_pos: int, data_dict: dict) -> int:
-        """Parse and extract data from a `.gwy` file object, starting at the current
-        open file read position.
+        """Parse and extract data from a `.gwy` file object, starting at the current open file read position.
 
         Parameters
         ----------
@@ -785,8 +777,9 @@ class LoadScans:
 
     @staticmethod
     def _gwy_print_dict(gwy_file_dict: dict, pre_string: str) -> None:
-        """A developer function to print the nested object / component structure. Can
-        be used to find labels and values of objects / components in the `.gwy` file.
+        """Print the nested object / component structure.
+
+        Can be used to find labels and values of objects / components in the `.gwy` file.
 
         Parameters
         ----------
@@ -804,7 +797,9 @@ class LoadScans:
 
     @staticmethod
     def _gwy_print_dict_wrapper(gwy_file_dict: dict) -> None:
-        """Wrapper for the `_print_gwy_dict` function.
+        """Print dictionaries.
+
+        This is a wrapper for the _gwy_print_dict() method.
 
         Parameters
         ----------
@@ -825,7 +820,7 @@ class LoadScans:
         LOGGER.info(f"Loading image from : {self.img_path}")
         try:
             image_data_dict = {}
-            with open(self.img_path, "rb") as open_file:
+            with Path.open(self.img_path, "rb") as open_file:  # pylint: disable=unspecified-encoding
                 # Read header
                 header = open_file.read(4)
                 LOGGER.debug(f"Gwy file header: {header}")
@@ -867,10 +862,7 @@ class LoadScans:
         return (image, px_to_nm)
 
     def get_data(self) -> None:
-        """Method to extract image, filepath and pixel to nm scaling value, and append these to the
-        img_dic object.
-        """
-
+        """Extract image, filepath and pixel to nm scaling value, and append these to the img_dic object."""
         suffix_to_loader = {
             ".spm": self.load_spm,
             ".jpk": self.load_jpk,
@@ -916,8 +908,7 @@ class LoadScans:
             LOGGER.info(f"[{self.filename}] Image added to processing.")
 
     def add_to_dict(self) -> None:
-        """Adds the image, image path and pixel to nanometre scaling value to the img_dic dictionary under
-        the key filename.
+        """Add image, image path and pixel to nanometre scaling to the img_dic dictionary under key filename.
 
         Parameters
         ----------
@@ -953,7 +944,6 @@ def save_topostats_file(output_dir: Path, filename: str, topostats_object: dict)
         Dictionary of the topostats data to save. Must include a flattened image and
         pixel to nanometre scaling factor. May also include grain masks.
     """
-
     LOGGER.info(f"[{filename}] : Saving image to .topostats file")
 
     if ".topostats" not in filename:
@@ -1036,5 +1026,4 @@ def load_pkl(infile: Path) -> Any:
 
     """
     with infile.open("rb", encoding=None) as f:
-        images = pkl.load(f)
-    return images
+        return pkl.load(f)  # noqa: S301

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -121,7 +121,7 @@ def write_config_with_comments(config: str, output_dir: Path, filename: str = "c
     else:
         create_config_path = output_dir / filename
 
-    with Path.open(f"{create_config_path}", "w", encoding="utf-8") as f:
+    with create_config_path.open("w", encoding="utf-8") as f:
         f.write(f"# Config file generated {get_date_time()}\n")
         f.write(f"# {CONFIG_DOCUMENTATION_REFERENCE}")
         f.write(config)

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1,4 +1,5 @@
 """Functions for reading and writing data."""
+from __future__ import annotations
 import os
 import logging
 from datetime import datetime

--- a/topostats/logs/__init__.py
+++ b/topostats/logs/__init__.py
@@ -1,0 +1,1 @@
+"""Initialise login module."""

--- a/topostats/logs/logs.py
+++ b/topostats/logs/logs.py
@@ -1,6 +1,4 @@
-"""
-Standardise logging.
-"""
+"""Standardise logging."""
 import sys
 from pathlib import Path
 from datetime import datetime
@@ -21,7 +19,7 @@ LOGGER_NAME = "topostats"
 
 
 def setup_logger(log_name: str = LOGGER_NAME) -> logging.Logger:
-    """Setup a standard logger.
+    """Logger setup.
 
     The logger for the module is initialised when the module is loaded (as this functions is called from
     __init__.py). This creates two stream handlers, one for general output and one for errors which are formatted
@@ -41,7 +39,6 @@ def setup_logger(log_name: str = LOGGER_NAME) -> logging.Logger:
 
     Examples
     --------
-
     To use the logger in (sub-)modules have the following.
 
         import logging

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -1,4 +1,5 @@
 """Plotting data."""
+from __future__ import annotations
 from pathlib import Path
 import logging
 

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -1,6 +1,5 @@
 """Plotting data."""
 from pathlib import Path
-from typing import Union
 import logging
 
 from matplotlib.patches import Rectangle, Patch
@@ -26,8 +25,9 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:
-    """Ensure that the plotting config has the pixel to nanometre scaling factor accessible
-    for plotting so that plots are in nanometres and not pixels.
+    """Addf the pixel to nanometre scaling factor to plotting configs.
+
+    Ensures plots are in nanometres and not pixels.
 
     Parameters
     ----------
@@ -42,7 +42,6 @@ def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scalin
         Updated plotting config with the pixel to nanometre scaling factor
         applied to all the image configurations.
     """
-
     # Update PLOT_DICT with pixel_to_nm_scaling (can't add _output_dir since it changes)
     plot_opts = {"pixel_to_nm_scaling": pixel_to_nm_scaling}
     for image, options in plotting_config["plot_dict"].items():
@@ -65,7 +64,6 @@ def dilate_binary_image(binary_image: np.ndarray, dilation_iterations: int) -> n
     binary_image: np.ndarray
         Dilated binary image
     """
-
     binary_image = binary_image.copy()
     for _ in range(dilation_iterations):
         binary_image = binary_dilation(binary_image)
@@ -74,12 +72,12 @@ def dilate_binary_image(binary_image: np.ndarray, dilation_iterations: int) -> n
 
 
 class Images:
-    """Plots image arrays"""
+    """Plots image arrays."""
 
     def __init__(
         self,
         data: np.array,
-        output_dir: Union[str, Path],
+        output_dir: str | Path,
         filename: str,
         pixel_to_nm_scaling: float = 1.0,
         masked_array: np.array = None,
@@ -87,18 +85,18 @@ class Images:
         image_type: str = "non-binary",
         image_set: str = "core",
         core_set: bool = False,
-        pixel_interpolation: Union[str, None] = None,
+        pixel_interpolation: str | None = None,
         cmap: str = "nanoscope",
         mask_cmap: str = "jet_r",
         region_properties: dict = None,
-        zrange: list = [None, None],
+        zrange: list = None,
         colorbar: bool = True,
         axes: bool = True,
         save: bool = True,
         save_format: str = "png",
         histogram_log_axis: bool = True,
         histogram_bins: int = 200,
-        dpi: Union[str, float] = "figure",
+        dpi: str | float = "figure",
     ) -> None:
         """
         Initialise the class.
@@ -148,6 +146,8 @@ class Images:
         dpi: Union[str, float]
             The resolution of the saved plot (default 'figure').
         """
+        if zrange is None:
+            zrange = [None, None]
         self.data = data
         self.output_dir = Path(output_dir)
         self.filename = filename
@@ -172,7 +172,7 @@ class Images:
 
     def plot_histogram_and_save(self):
         """
-        Plot and save a histogram of the height map
+        Plot and save a histogram of the height map.
 
         Returns
         -------
@@ -230,8 +230,7 @@ class Images:
         return fig, ax
 
     def save_figure(self):
-        """
-        This function saves figures as plt.savefig objects.
+        """Save figures as plt.savefig objects.
 
         Returns
         -------
@@ -310,7 +309,7 @@ class Images:
         return fig, ax
 
     def save_array_figure(self) -> None:
-        """This function saves only the image array as an image using plt.imsave"""
+        """Save the image array as an image using plt.imsave()."""
         plt.imsave(
             (self.output_dir / f"{self.filename}.{self.save_format}"),
             self.data,

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:
-    """Addf the pixel to nanometre scaling factor to plotting configs.
+    """Add the pixel to nanometre scaling factor to plotting configs.
 
     Ensures plots are in nanometres and not pixels.
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1,7 +1,6 @@
 """Functions for procesing data."""
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Union, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -38,10 +37,9 @@ def run_filters(
     filter_config: dict,
     plotting_config: dict,
 ) -> np.ndarray:
-    """Function for running image flattening and plotting the results.
+    """Filter and flatten an image.
 
-    Instantiates a Filters object and flattens the image then optionally
-    plots the results, returning the flattened image.
+    Optionally plots the results, returning the flattened image.
 
     Parameters
     ----------
@@ -67,7 +65,6 @@ def run_filters(
         Either a numpy array of the flattened image, or None if an error occurs or
         flattening is disabled in the configuration.
     """
-
     if filter_config["run"]:
         filter_config.pop("run")
         LOGGER.info(f"[{filename}] Image dimensions: {unprocessed_image.shape}")
@@ -123,7 +120,7 @@ def run_filters(
     return None
 
 
-def run_grains(
+def run_grains(  # noqa: C901
     image: np.ndarray,
     pixel_to_nm_scaling: float,
     filename: str,
@@ -132,10 +129,9 @@ def run_grains(
     plotting_config: dict,
     grains_config: dict,
 ):
-    """Function for running grain finding and plotting the results.
+    """Find grains within an image.
 
-    Instantiates a Grains object and runs grain finding, then optionally
-    plots the results, returning the grain masks in a dictionary.
+    Identifies grains (molecules) and optionally plots the results.
 
     Parameters
     ----------
@@ -246,11 +242,9 @@ def run_grainstats(
     plotting_config: dict,
     grain_out_path: Path,
 ):
-    """Function for calculating grain statistics and optionally plotting the results.
+    """Calculate grain statistics.
 
-    Instantiates a GrainStats object and calculates grain statsistics for supplied
-    grain masks, then optionally plots the results and returns a dataframe of
-    grain statsistics.
+    Calculates grain statistics for an image and optionally plots the results.
 
     Parameters
     ----------
@@ -350,7 +344,7 @@ def run_grainstats(
         return create_empty_dataframe()
 
 
-def run_dnatracing(
+def run_dnatracing(  # noqa: C901
     image: np.ndarray,
     grain_masks: dict,
     pixel_to_nm_scaling: float,
@@ -362,10 +356,9 @@ def run_dnatracing(
     plotting_config: dict,
     results_df: pd.DataFrame = None,
 ):
-    """Function for calculating dna traces.
+    """Calculate DNA traces.
 
-    Runs dna tracing for the grain masks supplied, adds resulting statistics to
-    the supplied grain statsistics DataFrame and plots the molecule traces.
+    Traces DNA molecules for the supplied grains adding results to statistics data frames and optionally plots results.
 
     Parameters
     ----------
@@ -399,7 +392,6 @@ def run_dnatracing(
         Pandas DataFrame containing grain statistics and dna tracing statistics.
         Keys are file path and molecule number.
     """
-
     # Create empty dataframe is none is passed
     if results_df is None:
         results_df = create_empty_dataframe()
@@ -486,7 +478,7 @@ def run_dnatracing(
 
 
 def get_out_paths(image_path: Path, base_dir: Path, output_dir: Path, filename: str, plotting_config: dict):
-    """Returns various output paths for a given image and plotting config.
+    """Determine components of output paths for a given image and plotting config.
 
     Parameters
     ----------
@@ -507,7 +499,6 @@ def get_out_paths(image_path: Path, base_dir: Path, output_dir: Path, filename: 
         Core output path for general file outputs, filter output path for flattening related files and
         grain output path for grain finding related files.
     """
-
     LOGGER.info(f"Processing : {filename}")
     core_out_path = get_out_path(image_path, base_dir, output_dir).parent / "processed"
     core_out_path.mkdir(parents=True, exist_ok=True)
@@ -523,14 +514,14 @@ def get_out_paths(image_path: Path, base_dir: Path, output_dir: Path, filename: 
 
 def process_scan(
     topostats_object: dict,
-    base_dir: Union[str, Path],
+    base_dir: str | Path,
     filter_config: dict,
     grains_config: dict,
     grainstats_config: dict,
     dnatracing_config: dict,
     plotting_config: dict,
-    output_dir: Union[str, Path] = "output",
-) -> Tuple[dict, pd.DataFrame, dict]:
+    output_dir: str | Path = "output",
+) -> tuple[dict, pd.DataFrame, dict]:
     """Process a single image, filtering, finding grains and calculating their statistics.
 
     Parameters
@@ -560,7 +551,6 @@ def process_scan(
         TopoStats dictionary object, DataFrame containing grain statistics and dna tracing statistics,
         and dictionary containing general image statistics
     """
-
     core_out_path, filter_out_path, grain_out_path = get_out_paths(
         image_path=topostats_object["img_path"],
         base_dir=base_dir,
@@ -697,7 +687,7 @@ def check_run_steps(filter_run: bool, grains_run: bool, grainstats_run: bool, dn
         LOGGER.info("Configuration run options are consistent, processing can proceed.")
 
 
-def completion_message(config: Dict, img_files: List, summary_config: Dict, images_processed: int) -> None:
+def completion_message(config: dict, img_files: list, summary_config: dict, images_processed: int) -> None:
     """Print a completion message summarising images processed.
 
     Parameters
@@ -715,7 +705,6 @@ def completion_message(config: Dict, img_files: List, summary_config: Dict, imag
     -------
     None
     """
-
     if summary_config is not None:
         distribution_plots_message = str(summary_config["output_dir"])
     else:

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1,4 +1,5 @@
 """Functions for procesing data."""
+from __future__ import annotations
 from collections import defaultdict
 from pathlib import Path
 

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -1,4 +1,4 @@
-"""Run TopoStats
+"""Run TopoStats.
 
 This provides an entry point for running TopoStats as a command line programme.
 """
@@ -44,9 +44,8 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 # pylint: disable=too-many-nested-blocks
 
 
-def run_topostats(args=None):
+def run_topostats(args=None):  # noqa: C901
     """Find and process all files."""
-
     # Parse command line options, load config (or default) and update with command line options
     if args.config_file is not None:
         config = read_yaml(args.config_file)

--- a/topostats/scars.py
+++ b/topostats/scars.py
@@ -1,5 +1,4 @@
-"""Contains image artefact correction functions that take a 2D np.ndarray image, and return the image with
-interpolated values filling the space of any detected scars."""
+"""Image artefact correction functions that interpolates values filling the space of any detected scars."""
 import logging
 import numpy as np
 from topostats.logs.logs import LOGGER_NAME
@@ -18,10 +17,12 @@ def _mark_if_positive_scar(
     threshold_low: float,
     max_scar_width: int,
 ) -> None:
-    """
+    """Mark scars as positive (i.e. a ridge rather than a dip).
+
     Determine if the points below and including the pixel at the specified row and column are a positive scar (a
-    ridge rather than a dip).
-    If they are, mark them in the marked 2d np.ndarray. Note that this only detects positive scars.
+    ridge rather than a dip). If they are, mark them in the marked 2d np.ndarray. Note that this only detects positive
+    scars.
+
     Parameters
     ----------
     row_col: tuple
@@ -48,7 +49,6 @@ def _mark_if_positive_scar(
     -------
     None
     """
-
     # Unpack row, col
     row = row_col[0]
     col = row_col[1]
@@ -81,10 +81,11 @@ def _mark_if_negative_scar(
     threshold_low: float,
     max_scar_width: int,
 ) -> None:
-    """
+    """Mark scars as negative (i.e. a dip rather than a ridge).
+
     Determine if the points below and including the pixel at the specified row and column are a negative scar (a
-    dip rather than a ridge).
-    If they are, mark them in the marked 2d np.ndarray. Note that this only detects negative scars.
+    dip rather than a ridge). If they are, mark them in the marked 2d np.ndarray. Note that this only detects negative
+    scars.
 
     Parameters
     ----------
@@ -112,7 +113,6 @@ def _mark_if_negative_scar(
     -------
     None
     """
-
     # Unpack row, col
     row = row_col[0]
     col = row_col[1]
@@ -142,10 +142,11 @@ def _spread_scars(
     threshold_low: float,
     threshold_high: float,
 ) -> None:
-    """Spread high-marked pixels into adjacent low-marked pixels. This is a smudging function that attempts to catch
-    any pixels that are parts of scars that might not have been extreme enough to get marked above the
-    high_threshold.
-    Any remaining marked pixels below high_threshold are considered not to be scars and are removed from the mask.
+    """Spread high-marked pixels into adjacent low-marked pixels.
+
+    This is a smudging function that attempts to catch any pixels that are parts of scars that might not have been
+    extreme enough to get marked above the high_threshold. Any remaining marked pixels below high_threshold are
+    considered not to be scars and are removed from the mask.
 
     Parameters
     ----------
@@ -167,7 +168,6 @@ def _spread_scars(
     -------
     None
     """
-
     # Spread scars that have close to threshold edge-points
     for row in range(marked.shape[0]):
         # Spread right
@@ -183,7 +183,7 @@ def _spread_scars(
 
 def _remove_short_scars(marked: np.ndarray, threshold_high: float, min_scar_length: int) -> None:
     """
-    Removes scars that are too short (horizontally), based on the min_scar_length argument.
+    Remove scars that are too short (horizontally), based on the minimum length.
 
     Parameters
     ----------
@@ -206,7 +206,6 @@ def _remove_short_scars(marked: np.ndarray, threshold_high: float, min_scar_leng
     -------
     None
     """
-
     # Remove too-short scars
     for row in range(marked.shape[0]):
         k = 0
@@ -270,6 +269,7 @@ def _mark_scars(
         An integer that restricts the algorithm to only mark scars that are as long or longer than this length.
         This is important for ensuring that noise or legitimate but sharp datapoints do not get detected as scars.
         Note that length here is horizontal, as scars are thin, horizontal features.
+
     Returns
     -------
     marked: np.ndarray
@@ -277,7 +277,6 @@ def _mark_scars(
         a metric for how strongly that pixel is considered to be a scar. Higher values mean more likely
         to be a scar.
     """
-
     image = np.copy(img)
 
     stddev = np.std(image)
@@ -316,9 +315,10 @@ def _mark_scars(
 
 
 def _remove_marked_scars(img: np.ndarray, scar_mask: np.ndarray) -> None:
-    """
-    Interpolate values covered by marked scars. Takes an image, and a marked scar boolean mask for that
-    image. Returns the image where the marked scars are replaced by interpolated values.
+    """Interpolate values covered by marked scars.
+
+    Takes an image, and a marked scar boolean mask for that image. Returns the image where the marked scars are replaced
+    by interpolated values.
 
     Parameters
     ----------
@@ -332,7 +332,6 @@ def _remove_marked_scars(img: np.ndarray, scar_mask: np.ndarray) -> None:
     -------
     None
     """
-
     for row, col in np.ndindex(img.shape):
         if scar_mask[row, col] == 1.0:
             # Determine how wide the scar is by incrementing scar_width until either the bottom
@@ -364,6 +363,7 @@ def remove_scars(
 ):
     """
     Remove scars from an image.
+
     Scars are long, typically 1-4 pixels wide streaks of high or low data in AFM images. They are a problem
     resulting from random errors in the AFM data collection process and are hard to avoid. This function
     detects and removes these artefacts by interpolating over them between the pixels above and below them.
@@ -401,7 +401,6 @@ def remove_scars(
         The original 2-D image with scars removed, unless the config has run set to False, in which case it
         will not remove the scars.
     """
-
     LOGGER.info(f"[{filename}] : Removing scars")
 
     first_marked_mask = None

--- a/topostats/statistics.py
+++ b/topostats/statistics.py
@@ -14,8 +14,10 @@ def image_statistics(
     pixel_to_nm_scaling: float,
     results_df: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Calculate statistics pertaining to the whole image, for example the size of the image in pixels and
-    metres, the root-mean-squared roughness and the grains per metre squared.
+    """Calculate statistics pertaining to the whole image.
+
+    Calculates the size of the image in pixels and metres, the root-mean-squared roughness and the grains per metre
+    squared.
 
     Parameters
     ----------
@@ -34,7 +36,6 @@ def image_statistics(
     dict
         Dictionary of image statistics.
     """
-
     image_stats = {
         "image": filename,
         "image_size_x_m": None,
@@ -86,7 +87,8 @@ def roughness_rms(image: np.ndarray) -> float:
     image: np.ndarray
         2D numpy array of heightmap data to calculate the roughness of
 
-    Returns:
+    Returns
+    -------
     float
         The RMS roughness of the input array.
     """

--- a/topostats/theme.py
+++ b/topostats/theme.py
@@ -10,17 +10,18 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class Colormap:
-    """Class for setting the COlormap"""
+    """Class for setting the COlormap."""
 
     def __init__(self, name: str = "nanoscope"):
         self.name = name
         self.cmap = None
-        self.set(self.name)
+        self.set_cmap(self.name)
 
     def __str__(self):
+        """Return string representation of object."""
         return f"TopoStats Colormap: {self.name}"
 
-    def set(self, name: str):
+    def set_cmap(self, name: str):
         """Set the ColorMap.
 
         Parameters
@@ -40,14 +41,15 @@ class Colormap:
         LOGGER.debug(f"[theme] Colormap set to : {name}")
 
     def get_cmap(self):
-        """Return the matplotlib.cm colormap object"""
+        """Return the matplotlib.cm colormap object."""
         return self.cmap
 
     @staticmethod
     def nanoscope():
         """
-        Returns a matplotlib compatible colormap that replicates the Bruker Nanoscope colorscale
-        The colormap is implemented in Gwyddion's GwyGradient via 'Nanoscope.txt'
+        Matplotlib compatible colormap that replicates the Bruker Nanoscope colorscale.
+
+        The colormap is implemented in Gwyddion's GwyGradient via 'Nanoscope.txt'.
         """
         cdict = {
             "red": (
@@ -100,12 +102,11 @@ class Colormap:
             ),
         }
 
-        colormap = LinearSegmentedColormap("nanoscope", cdict)
-        return colormap
+        return LinearSegmentedColormap("nanoscope", cdict)
 
     @staticmethod
     def gwyddion():
-        """The RGBA colour map for the Gwyddion.net colour gradient."""
+        """Set RGBA colour map for the Gwyddion.net colour gradient."""
         N = 4  # Number of values
         vals = np.ones((N, 4))  # Initialise the array to be full of 1.0
         vals[0] = [0.0, 0.0, 0.0, 1]
@@ -113,10 +114,9 @@ class Colormap:
         vals[2] = [243 / 256, 194 / 256, 93 / 256, 1.0]
         vals[3] = [1.0, 1.0, 1.0, 1.0]
 
-        colormap = LinearSegmentedColormap.from_list("gwyddion", vals, N=256)
-        return colormap
+        return LinearSegmentedColormap.from_list("gwyddion", vals, N=256)
 
     @staticmethod
     def blu():
-        "RGBA colour map of just the colour blue."
+        """Set RGBA colour map of just the colour blue."""
         return ListedColormap([[32 / 256, 226 / 256, 205 / 256]], "blu", N=256)

--- a/topostats/theme.py
+++ b/topostats/theme.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class Colormap:
-    """Class for setting the COlormap."""
+    """Class for setting the Colormap."""
 
     def __init__(self, name: str = "nanoscope"):
         self.name = name

--- a/topostats/thresholds.py
+++ b/topostats/thresholds.py
@@ -1,7 +1,7 @@
 """Functions for calculating thresholds."""
 # pylint: disable=no-name-in-module
 import logging
-from typing import Callable
+from collections.abc import Callable
 import numpy as np
 from skimage.filters import threshold_mean, threshold_minimum, threshold_otsu, threshold_yen, threshold_triangle
 
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 def threshold(image: np.ndarray, method: str = None, otsu_threshold_multiplier: float = None, **kwargs: dict) -> float:
-    """Factory method for thresholding.
+    """Thresholding for producing masks.
 
     Parameters
     ----------
@@ -66,17 +66,17 @@ def _threshold_otsu(image: np.ndarray, otsu_threshold_multiplier: float = None, 
     return threshold_otsu(image, **kwargs) * otsu_threshold_multiplier
 
 
-def _threshold_mean(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
+def _threshold_mean(image: np.ndarray, **kwargs) -> float:
     return threshold_mean(image, **kwargs)
 
 
-def _threshold_minimum(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
+def _threshold_minimum(image: np.ndarray, **kwargs) -> float:
     return threshold_minimum(image, **kwargs)
 
 
-def _threshold_yen(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
+def _threshold_yen(image: np.ndarray, **kwargs) -> float:
     return threshold_yen(image, **kwargs)
 
 
-def _threshold_triangle(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
+def _threshold_triangle(image: np.ndarray, **kwargs) -> float:
     return threshold_triangle(image, **kwargs)

--- a/topostats/thresholds.py
+++ b/topostats/thresholds.py
@@ -10,6 +10,7 @@ from topostats.logs.logs import LOGGER_NAME
 LOGGER = logging.getLogger(LOGGER_NAME)
 
 # pylint: disable=no-else-return
+# pylint: disable=unused-argument
 
 
 def threshold(image: np.ndarray, method: str = None, otsu_threshold_multiplier: float = None, **kwargs: dict) -> float:
@@ -66,17 +67,17 @@ def _threshold_otsu(image: np.ndarray, otsu_threshold_multiplier: float = None, 
     return threshold_otsu(image, **kwargs) * otsu_threshold_multiplier
 
 
-def _threshold_mean(image: np.ndarray, **kwargs) -> float:
+def _threshold_mean(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
     return threshold_mean(image, **kwargs)
 
 
-def _threshold_minimum(image: np.ndarray, **kwargs) -> float:
+def _threshold_minimum(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
     return threshold_minimum(image, **kwargs)
 
 
-def _threshold_yen(image: np.ndarray, **kwargs) -> float:
+def _threshold_yen(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
     return threshold_yen(image, **kwargs)
 
 
-def _threshold_triangle(image: np.ndarray, **kwargs) -> float:
+def _threshold_triangle(image: np.ndarray, otsu_threshold_multiplier: float = None, **kwargs) -> float:
     return threshold_triangle(image, **kwargs)

--- a/topostats/tracing/__init__.py
+++ b/topostats/tracing/__init__.py
@@ -1,0 +1,1 @@
+"""Initialise tracing sub-module."""

--- a/topostats/tracing/dnacurvature.py
+++ b/topostats/tracing/dnacurvature.py
@@ -13,6 +13,8 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 class Curvature:
+    """Class for determining the curvature of molecules."""
+
     def __init__(
         self,
         molecule_coordinates: np.ndarray,

--- a/topostats/tracing/skeletonize.py
+++ b/topostats/tracing/skeletonize.py
@@ -1,6 +1,6 @@
-"""Skeletonize molecules"""
+"""Skeletonize molecules."""
 import logging
-from typing import Callable
+from collections.abc import Callable
 import numpy as np
 from skimage.morphology import skeletonize, thin
 
@@ -10,11 +10,10 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 
 def get_skeleton(image: np.ndarray, method: str) -> np.ndarray:
-    """Factory method for skeletonizing molecules.
+    """Skeletonizing masked molecules.
 
     Parameters
     ----------
-
     image : np.ndarray
         Image of molecule to be skeletonized.
 
@@ -28,7 +27,6 @@ def get_skeleton(image: np.ndarray, method: str) -> np.ndarray:
 
     Notes
     -----
-
     This is a thin wrapper to the methods provided
     by the `skimage.morphology
     <https://scikit-image.org/docs/stable/api/skimage.morphology.html?highlight=skeletonize>`_

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -1,8 +1,7 @@
-"""Utilities"""
+"""Utilities."""
 from argparse import Namespace
 import logging
 from pathlib import Path
-from typing import Union, Dict
 from collections import defaultdict
 
 import numpy as np
@@ -45,7 +44,7 @@ ALL_STATISTICS_COLUMNS = (
 )
 
 
-def convert_path(path: Union[str, Path]) -> Path:
+def convert_path(path: str | Path) -> Path:
     """Ensure path is Path object.
 
     Parameters
@@ -61,8 +60,8 @@ def convert_path(path: Union[str, Path]) -> Path:
     return Path().cwd() if path == "./" else Path(path).expanduser()
 
 
-def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
-    """Update the configuration with any arguments
+def update_config(config: dict, args: dict | Namespace) -> dict:
+    """Update the configuration with any arguments.
 
     Parameters
     ----------
@@ -70,6 +69,7 @@ def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
         Dictionary of configuration (typically read from YAML file specified with '-c/--config <filename>')
     args: Namespace
         Command line arguments
+
     Returns
     -------
     Dict
@@ -94,9 +94,10 @@ def update_config(config: dict, args: Union[dict, Namespace]) -> Dict:
 
 
 def update_plotting_config(plotting_config: dict) -> dict:
-    """Update the plotting config for each of the plots in plot_dict to ensure that each
-    entry has all the plotting configuration values that are needed."""
+    """Update the plotting config for each of the plots in plot_dict.
 
+    Ensures that each entry has all the plotting configuration values that are needed.
+    """
     main_config = plotting_config.copy()
     for opt in ["plot_dict", "run"]:
         main_config.pop(opt)
@@ -111,7 +112,7 @@ def update_plotting_config(plotting_config: dict) -> dict:
 
 
 def _get_mask(image: np.ndarray, thresh: float, threshold_direction: str, img_name: str = None) -> np.ndarray:
-    """Calculate a mask for pixels that exceed the threshold
+    """Calculate a mask for pixels that exceed the threshold.
 
     Parameters
     ----------
@@ -170,14 +171,14 @@ def get_mask(image: np.ndarray, thresholds: dict, img_name: str = None) -> np.nd
 
 
 # pylint: disable=unused-argument
-def get_thresholds(
+def get_thresholds(  # noqa: C901
     image: np.ndarray,
     threshold_method: str,
     otsu_threshold_multiplier: float = None,
     threshold_std_dev: dict = None,
     absolute: dict = None,
     **kwargs,
-) -> Dict:
+) -> dict:
     """Obtain thresholds for masking data points.
 
     Parameters
@@ -239,5 +240,4 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple =
         Empty Pandas DataFrame.
     """
     empty_df = pd.DataFrame(columns=columns)
-    empty_df = empty_df.set_index(index)
-    return empty_df
+    return empty_df.set_index(index)

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -1,4 +1,5 @@
 """Utilities."""
+from __future__ import annotations
 from argparse import Namespace
 import logging
 from pathlib import Path

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -22,7 +22,6 @@ def validate_config(config: dict, schema: Schema, config_type: str) -> None:
         A schema against which the configuration is to be compared.
     config_type: str
     """
-
     try:
         schema.validate(config)
         LOGGER.info(f"The {config_type} is valid.")


### PR DESCRIPTION
Closes #446
Closes #663

Rather than adding a specific `pydocstyle` pre-commit hook we can use [ruff](https://github.com/charliermarsh/ruff) and its suite of rules which includes [pydocstyle](https://docs.astral.sh/ruff/rules/#pydocstyle-d) and is available as a [pre-commit hook](https://github.com/charliermarsh/ruff-pre-commit) too.

Thus Ruff has been added to `.pre-commit-config.yaml` and configured to carry out `pydocstyle` checks using the `numpy` docstyle via the project configuration file `pyproject.toml`.

The code base has been linted in light of these additions using `pre-commit run --all-files ruff` (I've also taken the opportunity to address errors reported by `pylint` too).

To avoid attributing blame across all linted files to @ns-rse the commit has been added to `.git-blame-ignore-revs`.