### PR TITLE
Switch to igor2 for .ibw and unpeg NumPy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "igor",
+  "igor2",
   "matplotlib",
-  "numpy==1.23.4",
+  "numpy",
   "pandas",
   "pySPM",
   "pyyaml",
@@ -78,10 +78,8 @@ docs = [
   "sphinxcontrib-napoleon",
 ]
 dev = [
-  "Flake8-pyproject",
   "black",
-  "flake8",
-  "flake8-print",
+  "ipython",
   "pre-commit",
   "pylint",
   "pyupgrade",

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pySPM
-from igor import binarywave
+from igor2 import binarywave
 import tifffile
 import h5py
 from ruamel.yaml import YAML, YAMLError


### PR DESCRIPTION
Closes #682

We had pegged `numpy==1.23.4` because the unmaintained [igor](https://pypi.org/project/igor/) used the now deprecated `np.complex`. By switching to the continuation project [igor2](https://pypi.org/project/igor2/) which still sees active maintenance we are able to remove the fixed numpy version.

I've also taken the liberty to remove `flake8` packages from the list of `dev` optional-dependencies as we no longer have `pre-commit` hooks in place and the task is done by `ruff` and added `ipython` as its a commonly used alternative to plain Python interface (I prefer it as it has additional/commands but always forget to install it in new VirtualEnvs I setup for testing).