### PR TITLE
Switch to igor2 for .ibw and unpeg NumPy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Upgrade pip and install test dependencies
         run: |
-          pip install -e .
+          pip install --upgrade pip
           pip install -e .[tests]
       - name: Test with pytest
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "igor",
+  "igor2",
   "matplotlib",
-  "numpy==1.23.4",
+  "numpy",
   "pandas",
   "pySPM",
   "pyyaml",
@@ -78,10 +78,8 @@ docs = [
   "sphinxcontrib-napoleon",
 ]
 dev = [
-  "Flake8-pyproject",
   "black",
-  "flake8",
-  "flake8-print",
+  "ipython",
   "pre-commit",
   "pylint",
   "pyupgrade",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "igor2",
+  "igor2>=0.5.3",
   "matplotlib",
   "numpy",
   "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ keywords = [
   "afm",
   "image processing"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
-  "igor2>=0.5.3",
+  "igor2",
   "matplotlib",
   "numpy",
   "pandas",

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pySPM
-from igor import binarywave
+from igor2 import binarywave
 import tifffile
 import h5py
 from ruamel.yaml import YAML, YAMLError


### PR DESCRIPTION
Closes #682

We had pegged `numpy==1.23.4` because the unmaintained [igor](https://pypi.org/project/igor/) used the now deprecated `np.complex`. By switching to the continuation project [igor2](https://pypi.org/project/igor2/) which still sees active maintenance we are able to remove the fixed numpy version.

I've also taken the liberty to remove `flake8` packages from the list of `dev` optional-dependencies as we no longer have `pre-commit` hooks in place and the task is done by `ruff` and added `ipython` as its a commonly used alternative to plain Python interface (I prefer it as it has additional/commands but always forget to install it in new VirtualEnvs I setup for testing).

## Why were tests failing

My initial thought on why tests were failing with my attempt to upgrade to `igor2` and remove `numpy==1.23.4` were wrong (I thought I'd branched off an old commit, but that wasn't the case, good to know I'm not going mad or doing silly things!).

It seems that for some reason under `python==3.8` `igor2==0.5.2` gets installed rather than `igor==0.5.3` as happens on other Python versions (3.9, 3.10, 3.11), we see the line....

```
INFO: pip is looking at multiple versions of igor2 to determine which version is compatible with other requirements. This could take a while.
Collecting igor2 (from topostats==0.1.dev1+geaa9029)
101
  Downloading igor2-0.5.2-py3-none-any.whl (31 kB)
```

_after_ `igor2-0.5.3` has been installed in the logs for Python 3.8 under Linux/OSX/Windows but not for other versions of Python across platforms they all install.

A bit of digging however reveals that if I try to force `igor==0.5.3` then `pip` can't resolve dependencies because....

```bash
The conflict is caused by:
    topostats[tests] 0.1.dev1+g3ef231c depends on numpy
    igor2 0.5.3 depends on numpy>=1.25.1
```

...and versions `numpy>=1.25.0` only supports python>=3.9 (see [release notes](https://numpy.org/doc/stable/release/1.25.0-notes.html)).

I've therefore set the minimum Python >= 3.9 for TopoStats and will with the update to support recent versions of Seaborn and once #678 and 681 are merged in make a new release to PyPI, but only after I add support for [Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html) which was released two days ago (see #686)