### PR TITLE
Explicit request of Python packages in Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -95,7 +95,7 @@ Please let us know the version of Python you are using, paste the results of `py
 <-- PASTE PYTHON VERSION -->
 ```
 
-### Optional : Python Packages
+### Python Packages
 
 If you are able to provide a list of your installed packages that may be useful. The best way to get this is to copy and
 paste the results of typing `pip freeze`.


### PR DESCRIPTION
Closes #120

Removing `Optional` from the bug report template as its really useful to have details of all installed packages when investigating.