### PR TITLE
Fix flattening step not running when scar removal disabled

### DIFF
--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -431,7 +431,7 @@ processed, please refer to <url to page where we document common problems> for m
             )
         else:
             LOGGER.info(f"[{self.filename}] : Skipping scar removal as requested from config")
-            self.images["initial_scar_removal"] = self.images["initial_quadratic_removal"]
+            self.images["initial_scar_removal"] = self.images["initial_nonlinear_polynomial_removal"]
 
         # Zero the data before thresholding, helps with absolute thresholding
         self.images["initial_zero_average_background"] = self.average_background(

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -424,7 +424,7 @@ processed, please refer to <url to page where we document common problems> for m
         run_scar_removal = self.remove_scars_config.pop("run")
         if run_scar_removal:
             LOGGER.info(f"[{self.filename}] : Initial scar removal")
-            self.images["initial_scar_removal"], _scar_mask = scars.remove_scars(
+            self.images["initial_scar_removal"], _ = scars.remove_scars(
                 self.images["initial_nonlinear_polynomial_removal"],
                 filename=self.filename,
                 **self.remove_scars_config,

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -477,7 +477,7 @@ processed, please refer to <url to page where we document common problems> for m
             self.images["scar_mask"] = scar_mask
         else:
             LOGGER.info(f"[{self.filename}] : Skipping scar removal as requested from config")
-            self.images["secondary_scar_removal"] = self.images["masked_quadratic_removal"]
+            self.images["secondary_scar_removal"] = self.images["masked_nonlinear_polynomial_removal"]
         self.images["final_zero_average_background"] = self.average_background(
             self.images["secondary_scar_removal"], self.images["mask"]
         )


### PR DESCRIPTION
This PR just fixes an issue I introduced accidentally when implementing `nonlinear_polynomial_removal`, where that flattening step is not run when scar removal is disabled. I initially only incorporated the nonlinear polynomial removal into the pipeline when scar removal is enabled.

This happened because I forgot to add the "initial_nonlinear_polynomial_removal" and "masked_nonlinear_polynomial_removal" to the `else` branch of the checks to see if scar removal is enabled. This resulted in the scar removal result images, "initial_scar_removal" and "secondary_scar_removal" to be set to the flattening step before the nonlinear polynomial removal, ignoring the nonlinear polynomial removal.

I have fixed this by simply switching the images that "initial_scar_removal" and "secondary_scar_removal" are set to when scar removal is disabled, from "initial_quadratic_removal" and "secondary_quadratic_removal" to "initial_nonlinear_polynomial_removal" and "masked_nonlinear_polynomial_removal". This means that nonlinear polynomial removal is now incorporated when skipping scar removal.

I've tried to explain this clearly, but there's a lot of words! Let me know if I've not been clear.