### PR TITLE
Add snoop as a dependency but disable by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dev = [
   "pyupgrade",
   "pytest-durations",
   "pytest-xdist",
+  "snoop",
 ]
 pypi = [
   "build",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,21 +36,22 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+  "h5py",
   "igor2",
   "matplotlib",
   "numpy",
   "pandas",
   "pySPM",
+  "pyfiglet",
   "pyyaml",
   "ruamel.yaml",
   "schema",
   "scikit-image",
   "scipy",
   "seaborn",
+  "snoop",
   "tifffile",
   "tqdm",
-  "pyfiglet",
-  "h5py"
 ]
 
 [project.optional-dependencies]
@@ -85,7 +86,6 @@ dev = [
   "pyupgrade",
   "pytest-durations",
   "pytest-xdist",
-  "snoop",
 ]
 pypi = [
   "build",

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -2,6 +2,7 @@
 from importlib.metadata import version
 
 import matplotlib.pyplot as plt
+import snoop
 
 from .logs.logs import setup_logger
 from .theme import Colormap
@@ -13,3 +14,6 @@ __version__ = ".".join(release.split("."[:2]))
 
 plt.register_cmap(cmap=Colormap("nanoscope").get_cmap())
 plt.register_cmap(cmap=Colormap("gwyddion").get_cmap())
+
+# Disable snoop
+snoop.install(enabled=False)


### PR DESCRIPTION
I came across [snoop](https://github.com/alexmojaki/snoop) which provides a powerful set of debuggin tools and think it would be useful to use it in TopoStats.

This PR adds it as a dependency and imports during package initialisation. By default though it is disabled so that performance in not impacted, this is done by `snoop.install(enabled=False)` in `__init__.py`.

To enable and using during development add the `@snoop` decorator to a function, method or class and in the same file re-enable dynamically by calling `snoop.install(enabled=True)`. See the documentation for more information on usage.