### PR TITLE
reduced max trace coord idx by 1 so within image bounds

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,12 @@
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from topostats.utils import (
     ALL_STATISTICS_COLUMNS,
+    bound_padded_coordinates_to_image,
     convert_path,
     create_empty_dataframe,
     get_thresholds,
@@ -110,3 +112,142 @@ def test_create_empty_dataframe() -> None:
     assert "molecule_number" not in empty_df.columns
     assert empty_df.shape == (0, 26)
     assert {"image", "basename", "area"}.intersection(empty_df.columns)
+
+
+@pytest.mark.parametrize(
+    ("image", "padding", "expected"),
+    [
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            1,  # Padding
+            (2, 2),
+        ),
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # Padding is 3 which means the range of values this is inteded to be used with would be the co-ordinates (2, 2),
+        # minus the padding which would give (-1, -1), and so instead we shift the co-ordinates over so that the padding
+        # will start at (0, 0)
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (3, 3),
+        ),
+        # With a padding of 2 the resulting co-ordinates to start the padding would be outside of the image range, so
+        # again we want to have this point shifted so that padding starts at (0, 0)
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        (
+            np.asarray(
+                [
+                    [1, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # We now check the other corners
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 1],
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 0, 1, 0],
+                    [1, 0, 0, 0, 1],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # And for completness check the edges
+        (
+            np.asarray(
+                [
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [1, 1, 0, 1, 1],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # Check with larger padding (have to split these)
+        (
+            np.asarray(
+                [
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (3, 3),
+        ),
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 1],
+                    [0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (2, 2),
+        ),
+    ],
+)
+def test_bound_padded_coordinates_to_image(image: npt.NDArray, padding: int, expected: tuple) -> None:
+    """Test that padding points does not exceed the image dimensions."""
+    coordinates = np.argwhere(image == 1)
+    for coordinate in coordinates:
+        padded_coords = bound_padded_coordinates_to_image(coordinate, padding, image.shape)
+        assert padded_coords == expected

--- a/tests/tracing/test_dnatracing_multigrain.py
+++ b/tests/tracing/test_dnatracing_multigrain.py
@@ -377,7 +377,7 @@ def test_trace_mask(
                 }
             ),
             [np.asarray([5, 23]), np.asarray([10, 58])],
-            [np.asarray([71, 78]), np.asarray([83, 30])],
+            [np.asarray([71, 81]), np.asarray([83, 30])],
         ),
     ],
 )

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -305,14 +305,6 @@ class dnaTrace:
 
             # Use the perp array to index the guassian filtered image
             perp_array = np.column_stack((x_coords, y_coords))
-            print(
-                "EDDIE: ",
-                perp_array[:, 0].min(),
-                perp_array[:, 1].min(),
-                perp_array[:, 0].max(),
-                perp_array[:, 1].max(),
-                self.gauss_image.shape,
-            )
             try:
                 height_values = self.gauss_image[perp_array[:, 0], perp_array[:, 1]]
             except IndexError:

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -249,12 +249,12 @@ class dnaTrace:
                 trace_coordinate[0] = index_width
             elif trace_coordinate[0] >= (self.number_of_rows - index_width):
                 # prevents indexing above image range causing IndexError
-                trace_coordinate[0] = self.number_of_rows - index_width
+                trace_coordinate[0] = self.number_of_rows - index_width - 1
             # do same for y coordinate
             elif trace_coordinate[1] < 0:
                 trace_coordinate[1] = index_width
             elif trace_coordinate[1] >= (self.number_of_columns - index_width):
-                trace_coordinate[1] = self.number_of_columns - index_width
+                trace_coordinate[1] = self.number_of_columns - index_width - 1
 
             # calculate vector to n - 2 coordinate in trace
             if self.mol_is_circular:
@@ -305,6 +305,7 @@ class dnaTrace:
 
             # Use the perp array to index the guassian filtered image
             perp_array = np.column_stack((x_coords, y_coords))
+            print("EDDIE: ", perp_array[:,0].min(), perp_array[:,1].min(), perp_array[:,0].max(), perp_array[:,1].max(), self.gauss_image.shape)
             try:
                 height_values = self.gauss_image[perp_array[:, 0], perp_array[:, 1]]
             except IndexError:

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -305,7 +305,14 @@ class dnaTrace:
 
             # Use the perp array to index the guassian filtered image
             perp_array = np.column_stack((x_coords, y_coords))
-            print("EDDIE: ", perp_array[:,0].min(), perp_array[:,1].min(), perp_array[:,0].max(), perp_array[:,1].max(), self.gauss_image.shape)
+            print(
+                "EDDIE: ",
+                perp_array[:, 0].min(),
+                perp_array[:, 1].min(),
+                perp_array[:, 0].max(),
+                perp_array[:, 1].max(),
+                self.gauss_image.shape,
+            )
             try:
                 height_values = self.gauss_image[perp_array[:, 0], perp_array[:, 1]]
             except IndexError:

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 from topostats.logs.logs import LOGGER_NAME
 from topostats.tracing.skeletonize import get_skeleton
 from topostats.tracing.tracingfuncs import genTracingFuncs, getSkeleton, reorderTrace
+from topostats.utils import bound_padded_coordinates_to_image
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -241,20 +242,12 @@ class dnaTrace:
         for coord_num, trace_coordinate in enumerate(individual_skeleton):
             height_values = None
 
-            # Block of code to prevent indexing outside image limits
-            # e.g. indexing self.gauss_image[130, 130] for 128x128 image
-            if trace_coordinate[0] < 0:
-                # prevents negative number indexing
-                # i.e. stops (trace_coordinate - index_width) < 0
-                trace_coordinate[0] = index_width
-            elif trace_coordinate[0] >= (self.number_of_rows - index_width):
-                # prevents indexing above image range causing IndexError
-                trace_coordinate[0] = self.number_of_rows - index_width - 1
-            # do same for y coordinate
-            elif trace_coordinate[1] < 0:
-                trace_coordinate[1] = index_width
-            elif trace_coordinate[1] >= (self.number_of_columns - index_width):
-                trace_coordinate[1] = self.number_of_columns - index_width - 1
+            # Ensure that padding will not exceed the image boundaries
+            trace_coordinate = bound_padded_coordinates_to_image(
+                coordinates=trace_coordinate,
+                padding=index_width,
+                image_shape=(self.number_of_rows, self.number_of_columns),
+            )
 
             # calculate vector to n - 2 coordinate in trace
             if self.mol_is_circular:

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from topostats.logs.logs import LOGGER_NAME
@@ -243,3 +244,45 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple =
     """
     empty_df = pd.DataFrame(columns=columns)
     return empty_df.set_index(index)
+
+
+def bound_padded_coordinates_to_image(coordinates: npt.NDArray, padding: int, image_shape: tuple) -> tuple:
+    """Ensure the padding of co-ordinates points does not fall outside of the image shape.
+
+    This function is primarly used in the dnaTrace.get_fitted_traces() method which aims to adjust the points of a
+    skeleton to sit on the highest points of a traced molecule. In order to do so it takes the ordered skeleton, which
+    may not lie on the highest points as it is generated from a binary mask that is unaware of the heights, and then
+    defines a padded boundary of 3nm profile perpendicular to the backbone of the DNA (which at this point is the
+    skeleton based on a mask). Each point along the skeleton therefore needs padding by a minimum of 2 pixels (in this
+    case each pixel equates to a cell in a NumPy array). If a point is within 2 pixels (i.e. 2 cells) of the border then
+    we can not pad beyond this region, we have to stop at the edge of the image and so the co-ordinates is adjusted such
+    that the padding will lie on the edge of the image/array.
+
+    Parameters
+    ----------
+    coordinates : npt.NDArray
+        Co-ordinates of a point on the mask based skeleton.
+    padding : int
+        Number of pixels/cells to pad around the point.
+    image_shape : tuple
+        The shape of the original image from which the pixel is obtained.
+
+    Returns
+    -------
+    tuple
+        Returns a tuple of co-ordinates that ensure that when the point is padded by the noted padding width in
+        subsequent calculations it will not be outside of the image shape.
+    """
+    # Calculate the maximum row and column indexes
+    max_row = image_shape[0] - 1
+    max_col = image_shape[1] - 1
+    row_coord, col_coord = coordinates
+
+    def check(coord, max_val):
+        if coord - padding < 0:
+            coord = padding
+        elif coord + padding > max_val:
+            coord = max_val - padding
+        return coord
+
+    return check(row_coord, max_row), check(col_coord, max_col)


### PR DESCRIPTION
fixes #751

Ensures that if the max fitted coord looks outside the image, it's max is the end of the image. 

Previously this matched the max shape of the array i.e. arr.shape=(10,10), but index was set to 10 which is outside the max index.

Seems like it was only an issue now because Eddie's images are very zoomed in and the `index_width` was set to 3nm which is quite a few pixels and exceeds the padding value of 1.