### PR TITLE
reduced max trace coord idx by 1 so within image bounds

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,12 @@
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pytest
 
 from topostats.utils import (
     ALL_STATISTICS_COLUMNS,
+    bound_padded_coordinates_to_image,
     convert_path,
     create_empty_dataframe,
     get_thresholds,
@@ -110,3 +112,142 @@ def test_create_empty_dataframe() -> None:
     assert "molecule_number" not in empty_df.columns
     assert empty_df.shape == (0, 26)
     assert {"image", "basename", "area"}.intersection(empty_df.columns)
+
+
+@pytest.mark.parametrize(
+    ("image", "padding", "expected"),
+    [
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            1,  # Padding
+            (2, 2),
+        ),
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # Padding is 3 which means the range of values this is inteded to be used with would be the co-ordinates (2, 2),
+        # minus the padding which would give (-1, -1), and so instead we shift the co-ordinates over so that the padding
+        # will start at (0, 0)
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (3, 3),
+        ),
+        # With a padding of 2 the resulting co-ordinates to start the padding would be outside of the image range, so
+        # again we want to have this point shifted so that padding starts at (0, 0)
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        (
+            np.asarray(
+                [
+                    [1, 0, 0, 0, 0],
+                    [0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # We now check the other corners
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 1],
+                    [0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 0, 1, 0],
+                    [1, 0, 0, 0, 1],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # And for completness check the edges
+        (
+            np.asarray(
+                [
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [1, 1, 0, 1, 1],
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                ]
+            ),
+            2,  # Padding
+            (2, 2),
+        ),
+        # Check with larger padding (have to split these)
+        (
+            np.asarray(
+                [
+                    [0, 0, 1, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (3, 3),
+        ),
+        (
+            np.asarray(
+                [
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 1],
+                    [0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 0],
+                ]
+            ),
+            3,  # Padding
+            (2, 2),
+        ),
+    ],
+)
+def test_bound_padded_coordinates_to_image(image: npt.NDArray, padding: int, expected: tuple) -> None:
+    """Test that padding points does not exceed the image dimensions."""
+    coordinates = np.argwhere(image == 1)
+    for coordinate in coordinates:
+        padded_coords = bound_padded_coordinates_to_image(coordinate, padding, image.shape)
+        assert padded_coords == expected

--- a/tests/tracing/test_dnatracing_multigrain.py
+++ b/tests/tracing/test_dnatracing_multigrain.py
@@ -377,7 +377,7 @@ def test_trace_mask(
                 }
             ),
             [np.asarray([5, 23]), np.asarray([10, 58])],
-            [np.asarray([71, 78]), np.asarray([83, 30])],
+            [np.asarray([71, 81]), np.asarray([83, 30])],
         ),
     ],
 )

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 from topostats.logs.logs import LOGGER_NAME
 from topostats.tracing.skeletonize import get_skeleton
 from topostats.tracing.tracingfuncs import genTracingFuncs, getSkeleton, reorderTrace
+from topostats.utils import bound_padded_coordinates_to_image
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -241,20 +242,12 @@ class dnaTrace:
         for coord_num, trace_coordinate in enumerate(individual_skeleton):
             height_values = None
 
-            # Block of code to prevent indexing outside image limits
-            # e.g. indexing self.gauss_image[130, 130] for 128x128 image
-            if trace_coordinate[0] < 0:
-                # prevents negative number indexing
-                # i.e. stops (trace_coordinate - index_width) < 0
-                trace_coordinate[0] = index_width
-            elif trace_coordinate[0] >= (self.number_of_rows - index_width):
-                # prevents indexing above image range causing IndexError
-                trace_coordinate[0] = self.number_of_rows - index_width - 1
-            # do same for y coordinate
-            elif trace_coordinate[1] < 0:
-                trace_coordinate[1] = index_width
-            elif trace_coordinate[1] >= (self.number_of_columns - index_width):
-                trace_coordinate[1] = self.number_of_columns - index_width - 1
+            # Ensure that padding will not exceed the image boundaries
+            trace_coordinate = bound_padded_coordinates_to_image(
+                coordinates=trace_coordinate,
+                padding=index_width,
+                image_shape=(self.number_of_rows, self.number_of_columns),
+            )
 
             # calculate vector to n - 2 coordinate in trace
             if self.mol_is_circular:

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from topostats.logs.logs import LOGGER_NAME
@@ -243,3 +244,45 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: tuple =
     """
     empty_df = pd.DataFrame(columns=columns)
     return empty_df.set_index(index)
+
+
+def bound_padded_coordinates_to_image(coordinates: npt.NDArray, padding: int, image_shape: tuple) -> tuple:
+    """Ensure the padding of co-ordinates points does not fall outside of the image shape.
+
+    This function is primarly used in the dnaTrace.get_fitted_traces() method which aims to adjust the points of a
+    skeleton to sit on the highest points of a traced molecule. In order to do so it takes the ordered skeleton, which
+    may not lie on the highest points as it is generated from a binary mask that is unaware of the heights, and then
+    defines a padded boundary of 3nm profile perpendicular to the backbone of the DNA (which at this point is the
+    skeleton based on a mask). Each point along the skeleton therefore needs padding by a minimum of 2 pixels (in this
+    case each pixel equates to a cell in a NumPy array). If a point is within 2 pixels (i.e. 2 cells) of the border then
+    we can not pad beyond this region, we have to stop at the edge of the image and so the co-ordinates is adjusted such
+    that the padding will lie on the edge of the image/array.
+
+    Parameters
+    ----------
+    coordinates : npt.NDArray
+        Co-ordinates of a point on the mask based skeleton.
+    padding : int
+        Number of pixels/cells to pad around the point.
+    image_shape : tuple
+        The shape of the original image from which the pixel is obtained.
+
+    Returns
+    -------
+    tuple
+        Returns a tuple of co-ordinates that ensure that when the point is padded by the noted padding width in
+        subsequent calculations it will not be outside of the image shape.
+    """
+    # Calculate the maximum row and column indexes
+    max_row = image_shape[0] - 1
+    max_col = image_shape[1] - 1
+    row_coord, col_coord = coordinates
+
+    def check(coord, max_val):
+        if coord - padding < 0:
+            coord = padding
+        elif coord + padding > max_val:
+            coord = max_val - padding
+        return coord
+
+    return check(row_coord, max_row), check(col_coord, max_col)


### PR DESCRIPTION
Further to #752 I've worked through this for my own clarity, apologies for the protracted length and [Rubber Duck](https://en.wikipedia.org/wiki/Rubber_duck_debugging) debugging.

From #752 [comment](https://github.com/AFM-SPM/TopoStats/pull/752#issuecomment-1855640458)

>
> I agree that the coords should not be < 0.

This is the easy bit! Given image...

``` python
import numpy as np

test = np.asarray([[0, 0, 0, 0, 0],
                   [0, 1, 0, 0, 0],
                   [0, 0, 1, 0, 0],
                   [0, 0, 0, 1, 0],
                   [0, 0, 0, 0, 0],
                   ])
co_ordinates = np.argwhere(test == 1)
index_width = 2
nrows, ncols = test.shape
trace_coordinate = co_ordinates[0]
```
Taking the first co-ordinate, currently what we test is...

```python
trace_coordinate[0] < 0
```

We know that `trace_coordinate[0]` (and in turn `trace_coordinate[1]`) will never be < 0 so the inequality currently in place `if trace_coordinate[0] < 0:` doesn't make sense.

What we want to know is if the value of `trace_coordinate[0]` _minus_ the `index_width`, which will be the left/upper padding area, will be outside of the image, so we can update our inequality to reflect this.

```python
trace_coordinate[0] - index_width < 0
```

Now lets consider the other side of the image (the right side and bottom)...

> So my initial thought was that because number_of_rows and number_of_columns come from the np.ndarray.shape property,
> the index of this would be off by 1 when indexing.
>
> i.e. with a shape of (10,10), the variables number_of_rows etc would be 10 but only be indexed upto 9. Thus if the
> coord value satisfied: trace_x >= (self.number_of_rows - index_width), the value cannot be set to self.number_of_rows
> - index_width as the diagonals would exceed the bounds. If index_width=0, condition: trace_x >= self.number_of_rows >>
> trace_x = self.number_of_rows and x would exceed the index bounds.

I'll stick with the smaller example above and take the last point

``` python
trace_coordinate = co_ordinates[-1]
```

Now further down the code in lines 259-304 the `x_coords` and `y_coords` are calculated using `trace_coordinate[0] - index_width` and  `trace_coordinate[0] + index_width` (and the same for columns `trace_coordinate[1] - index_width` and  `trace_coordinate[1] + index_width`). It is this second value (the resulting of adding the `ìndex_width`) that we want to test in a similar manner is not outside the bounds of the image, i.e. `trace_coordinate[0] + index_width` does not exceed the width (in indices!) of the image.

Thus I think the `elif:` should be the following (NB `nrow` is equivalent to `self.number_of_rows`)...

``` python
trace_coordinate[0] + index_width > nrow - 1
```

As we don't want either the `x_coords` nor `y_coords` to exceed the image dimensions (in terms on Numpy indexing). Ok we now have that check in place, but what do we want to do if this inequality is met? We want it to be equal to the number of rows/columns minus the `index_width` but since we obtain the number of rows/columns from the `nrow`/`ncol` we have to subtract another `1` from this, which is the solution you came up with @MaxGamill-Sheffield. :+1:

At this point the tests still fail, but I've no way of knowing if the logic is correct. Further we have duplication of code, there are two sets of essentially the same thing, one dealing with rows and one dealing with columns. How to check this is working and reduce the amount of code? Simple we break it out into its own function and write a test!

To this end I've introduced a new function `topostats.utils.bound_padded_coordinates_to_image()` which does this and have tried to explain in the docstring why this function is needed and what it does (slightly challenging without knowing what the subsequent steps taken are but hopefully clear enough). The tests demonstrate that the co-ordinate is adjusted such that if the padding goes outside of the image boundary the position of the initial point is adjusted so that the subsequent padding to get the heights of a 3nm boundary will stop at on the edge of the image.

The tests all pass for this function and now that I've convinced myself that the co-ordinates are correctly adjusted if the padding (`image_width`) would take the points used subsequently outside of the images boundaries I'm happy to substitute this function in the `get_fitted_traces()` and run our tests that were previously failing again  (`tests/tracing/test_dnatracing_multigrain.py::test_trace_image`).

On doing so we find that the first three of the parametisation work, but the last (which uses thinning method of skeletonisation) fails as the co-ordinates of the start of first image (not the array sizes as I incorrectly wrote in #752) are slightly different (they were previously as `71, 78` but are returned as `71, 81` on my system and were `71, 77` in the CI that failed). BUT as noted in the docstring to the function that test is actually incomplete and it only checks the start and end coordinates of the ordered trace and not the fitted trace that these changes impact.

This is a _very_ roundabout way to have...

1) Discovered why the tests were failing.
2) That the tests are incomplete and need improving. 
3) That we had some incorrect logic in place that meant fitting of traces was incorrect.

Fortunately 1) and 3) have been addressed in this Pull Request. Its not entirely clear to me why the thinning algorithm should have changed the end location of the thinned skeleton but I do have a vague recollection that some of the thinning algorithms didn't give consistent results.

However, this has been a very useful exercise as it identified problems and hopefully by breaking out the code into its own function and writing tests we can have greater confidence that the padding used in fitting traces is more robust and behaves correctly when points are very close to the border of the image.