### PR TITLE
Auto-cancel repeated PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})


### PR DESCRIPTION
As per advice in #721 this PR will mean that there will only ever be [one run per Pull Request/branch at a time](https://learn.scientific-python.org/development/guides/gha-basic/#advanced-usage) cancelling older runs when new ones are triggered e.g. by new pushes to an open Pull Request.

Closes #763