### PR TITLE
Adds numpydoc-validation to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,11 @@ repos:
     hooks:
       - id: nbstripout
 
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.6.0
+    hooks:
+      - id: numpydoc-validation
+
   - repo: local
     hooks:
       - id: pylint


### PR DESCRIPTION
Further configuration can be undertaken by adding options to [`docs/conf.py`](https://numpydoc.readthedocs.io/en/latest/install.html).