### PR TITLE
Adds entry point to create matplotlibrc parameters file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ _build/
 
 # Ignore topostats/_version.py as per setuptools_scm
 topostats/_version.py
+
+# default output directory, often common from testing
+output/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,59 @@ Configuration files are validated against a schema to check that the values in t
 expected ranges or valid parameters. This helps capture problems early and should provide informative messages as to
 what needs correcting if there are errors.
 
+## Matplotlib Style
+
+TopoStats generates a number of images of the scans at various steps in the processing. These are plotted using the
+Python library [Matplotlib](matplotlib.org/stable/). A custom
+[`matplotlibrc`](https://matplotlib.org/stable/users/explain/customizing.html#the-matplotlibrc-file) file is included in
+TopoStats which defines the default parameters for generating images. This covers _all_ aspects of a plot that can be
+customised, for example we define custom colour maps `nanoscope` and `afmhot` and by default the former is configured to
+be used in this file. Other parameters that are customised are the `font.size` which affects axis labels and titles.
+
+If you wish to modify the look of all images that are output you can generate a copy of the default configuration using
+`topostats create-matplotlibrc` command which will write the output to `topostats.mplstyle` by default (**NB** there are
+flags which allow you to specify the location and filename to write to, see `topostats create-matplotlibrc --help` for
+further details).
+
+You should read and understand this commented file in detail. Once changes have been made you can run TopoStats using
+this custom file using the following command (substituting `my_custom_topostats.mplstyle` for whatever you have saved
+your file as).
+
+```bash
+topostats process --matplotlibrc my_custom_topostats.mplstyle
+```
+
+**NB** Plotting with Matplotlib is highly configurable and there are a plethora of options that you may wish to
+tweak. Before delving into customising `matplotlibrc` files it is recommended that you develop and build the style of
+plot you wish to generate using Jupyter Notebooks and then translate them to the configuration file. Detailing all of
+the possible options is beyond the scope of TopoStats but the [Matplotlib documentation](https://matplotlib.org/) is
+comprehensive and there are some sample Jupyter Notebooks (see `notebooks/03-plotting-scans.ipynb`) that guide you
+through the basics.
+
+### Further customisation
+
+Whilst the broad overall look of images is controlled in this manner there is one additional file that controls how
+images are plotted in terms of filenames, titles and image types and whether an image is part of the `core` subset that
+are always generated or not.
+
+During development it was found that setting high DPI took a long time to generate and save some of the images which
+slowed down the overall processing time. The solution we have implemented is a file `topostats/plotting_dictionary.yaml`
+which sets these parameters on a per-image basis and these over-ride settings defined in default `topostats.mplstyle` or
+any user generated document.
+
+If you have to change these, for example if there is a particular image not included in the `core` set that you always
+want produced or you wish to change the DPI (Dots Per Inch) of a particular image you will have to locate this file and
+manually edit it. Where this is depends on how you have installed TopoStats, if it is from a clone of the Git repository
+then it can be found in `TopoStats/topostats/plotting_dictionary.yaml`. If you have installed from PyPI using `pip
+install topostats` then it will be under the virtual environment you have created
+e.g. `~/.virtualenvs/topostats/lib/python3.11/site-packages/topostats/topostats/plotting_dictionary.yaml` if you are
+using plain virtual environments or
+`~/miniconda3/envs/topostats/lib/python3.11/site-packages/topostats/topostats/plotting_dictionary.yaml` if you are using
+Conda environments and chose `~/miniconda3` as the base directory when installing Conda.
+
+**NB** The exact location will be highly specific to your system so the above are just guides as to where to find
+things.
+
 [^1] When writing file paths you can use absolute or relative paths. On Windows systems absolute paths start with the
 drive letter (e.g. `c:/`) on Linux and OSX systems they start with `/`. Relative paths are started either with a `./`
 which denotes the current directory or one or more `../` which means the higher level directory from the current

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -26,7 +26,7 @@ def create_parser() -> arg.ArgumentParser:
 
     subparsers = parser.add_subparsers(title="program", description="Available programs, listed below:", dest="program")
 
-    # process parser
+    # Create a sub-parsers for different stages of processing and tasks
     process_parser = subparsers.add_parser(
         "process",
         description="Process AFM images. Additional arguments over-ride those in the configuration file.",
@@ -117,7 +117,6 @@ def create_parser() -> arg.ArgumentParser:
     )
     process_parser.set_defaults(func=run_topostats)
 
-    # toposum parser
     toposum_parser = subparsers.add_parser(
         "summary",
         description="Plotting and summary of TopoStats output statistics.",
@@ -154,7 +153,6 @@ def create_parser() -> arg.ArgumentParser:
     )
     toposum_parser.set_defaults(func=run_toposum)
 
-    # load parser
     load_parser = subparsers.add_parser(
         "load",
         description="Load and save all images as .topostats files for subsequent processing.",
@@ -168,7 +166,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # filter parser
     filter_parser = subparsers.add_parser(
         "filter",
         description="Load and filter images, saving as .topostats files for subsequent processing.",
@@ -182,7 +179,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # grain parser
     grain_parser = subparsers.add_parser(
         "grains",
         description="Load filtered images from '.topostats' files and detect grains.",
@@ -196,7 +192,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # grainstats parser
     grainstats_parser = subparsers.add_parser(
         "grainstats",
         description="Load images with grains from '.topostats' files and calculate statistics.",
@@ -210,7 +205,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # dnatracing parser
     dnatracing_parser = subparsers.add_parser(
         "dnatracing",
         description="Load images with grains from '.topostats' files and trace DNA molecules.",
@@ -224,7 +218,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # tracingstats parser
     tracingstats_parser = subparsers.add_parser(
         "tracingstats",
         description="Load images with grains from '.topostats' files and trace DNA molecules.",
@@ -238,7 +231,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Path to a YAML configuration file.",
     )
 
-    # create_config parser
     create_config_parser = subparsers.add_parser(
         "create-config",
         description="Create a configuration file using the defaults.",
@@ -268,6 +260,36 @@ def create_parser() -> arg.ArgumentParser:
         help="Configuration to use, currently only one is supported, the 'default'.",
     )
     create_config_parser.set_defaults(func=write_config_with_comments)
+
+    create_matplotlibrc_parser = subparsers.add_parser(
+        "create-matplotlibrc",
+        description="Create a Matplotlibrc parameters file.",
+        help="Create a Matplotlibrc parameters file using the defaults.",
+    )
+    create_matplotlibrc_parser.add_argument(
+        "-f",
+        "--filename",
+        dest="filename",
+        required=False,
+        default="topostats.mplstyle",
+        help="Name of file to save Matplotlibrc configuration to (default 'topostats.mplstyle').",
+    )
+    create_matplotlibrc_parser.add_argument(
+        "-o",
+        "--output-dir",
+        dest="output_dir",
+        required=False,
+        default="./",
+        help="Path to where the YAML file should be saved (default './' the current directory).",
+    )
+    create_matplotlibrc_parser.add_argument(
+        "-c",
+        "--config",
+        dest="config",
+        default="topostats.mplstyle",
+        help="Matplotlibrc style file to use, currently only one is supported, the 'topostats.mplstyle'.",
+    )
+    create_matplotlibrc_parser.set_defaults(func=write_config_with_comments)
 
     return parser
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -123,9 +123,13 @@ def write_config_with_comments(args=None) -> None:
     filename = "config" if args.filename is None else args.filename
     output_dir = Path("./") if args.output_dir is None else Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+    logger_msg = "A sample configuration has been written to"
     # If no config or default is requested we load the default_config.yaml
     if args.config is None or args.config == "default":
         config = pkg_resources.open_text(__package__, "default_config.yaml").read()
+    elif args.config == "topostats.mplstyle":
+        config = pkg_resources.open_text(__package__, "topostats.mplstyle").read()
+        logger_msg = "A sample matplotlibrc parameters file has been written to"
     # Otherwise we have scope for loading different configs based on the argument, add future dictionaries to
     # topostats/<sample_type>_config.yaml
     else:
@@ -134,7 +138,7 @@ def write_config_with_comments(args=None) -> None:
         except FileNotFoundError as e:
             raise UserWarning(f"There is no configuration for samples of type : {args.config}") from e
 
-    if ".yaml" not in filename and ".yml" not in filename:
+    if ".yaml" not in filename and ".yml" not in filename and ".mplstyle" not in filename:
         create_config_path = output_dir / f"{filename}.yaml"
     else:
         create_config_path = output_dir / filename
@@ -143,7 +147,7 @@ def write_config_with_comments(args=None) -> None:
         f.write(f"# Config file generated {get_date_time()}\n")
         f.write(f"# {CONFIG_DOCUMENTATION_REFERENCE}")
         f.write(config)
-    LOGGER.info(f"A sample configuration has been written to : {str(create_config_path)}")
+    LOGGER.info(f"{logger_msg} : {str(create_config_path)}")
     LOGGER.info(CONFIG_DOCUMENTATION_REFERENCE)
 
 


### PR DESCRIPTION
Closes #761

Introduces the `topostats create-matplotlibrc` sub-command/entry point to write the default style file (`topostats/topostats.mplstyle`) to disk for modification and subsequent usage. The path and filename can be customised when invoking.

This doesn't necessarily mean that all aspects of image plotting are controlled since we set default filenames, titles and DPI and whether an image is in the `core` set via the `topostats/plotting_dictionary.yaml` file.

Documentation has been added that, hopefully, clarifies how to use this in light of this and points users to the relevant Matplotlib documentation for customising parameters in the generated configuration file.

@derollins : I've included you as a reviewer as you requested this feature in #761. I've tested and it seems to work from my perspective in that I can create a sample configuration file of a given name in a given location but I would be very grateful if you could give it a whirl and provide feedback.

To do so you need to something similar to the following...

```bash
cd path/to/TopoStats/git/repo  # modify to reflect your system
git checkout main
git pull
git checkout ns-rse/761-create-maplotlibrc
conda create matplotlibrc   # assuming you are using Conda environments
pip install -e .
topostats create-matplotlibrc --help    # Instructions should be useful to guide usage
```

Once done you can remove the conda environment with...

```bash
conda env remove -n matplotlibrc
```