### PR TITLE
Check for Numpy2 deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ output/config.yaml
 *.csv
 *.spm
 
+# Notebook checkpoints
+notebooks/.ipynb_checkpoints/
+
 # Example Data
 !minicircle.spm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ tests = [
   "pytest-github-actions-annotate-failures",
   "pytest-lazy-fixture",
   "pytest-mpl",
-  "pytest-regtest",
+  "pytest-regtest<2.0.0",
   "filetype",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,10 @@ lint.fixable = [
 ]
 lint.unfixable = []
 
+# Numpy2 deprecation checks
+lint.extend-select = ["NPY201"]
+preview = true
+
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"
 


### PR DESCRIPTION
Closes #774

+ Adds [NPY201](https://docs.astral.sh/ruff/rules/numpy2-deprecation/) linting to `ruff` which checks for Numpy2 deprecations.
+ Also ignores Notebook checkpoints directory.

Ruff has been run against the code-base and no problems reported. This doesn't mean TopoStats will work with Numpy2 is released as some dependencies may be affected. A useful summary of how to handle potential problems is provided at [Numpy #24300](https://github.com/numpy/numpy/issues/24300) and broadly suggests pinning `numpy<2.0` for releases whilst development proceeds on resolving issues.