### PR TITLE
Unpeg pytest-regtest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ tests = [
   "pytest-github-actions-annotate-failures",
   "pytest-lazy-fixture",
   "pytest-mpl",
-  "pytest-regtest<2.0.0",
+  "pytest-regtest",
   "filetype",
 ]
 docs = [


### PR DESCRIPTION
The upstream [issue](https://gitlab.com/uweschmitt/pytest-regtest/-/issues/20) has been resolved with the release of pytest-regtest-2.0.2 so unpegging the dependency.