### PR TITLE
Add environment to pypi.yaml publishing workflow

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,4 +1,5 @@
 name: Publish package to PyPi
+# See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
 on:
   push:
@@ -9,6 +10,7 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
+    environment: pypi-publish
     name: Publish package to PyPi
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
PyPI have introduced the option to publish from trusted environments using [OpenID Connect](https://docs.pypi.org/trusted-publishers/adding-a-publisher/).

Following the [instructions](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) it is recommended to include an `environment` under which the workflow runs.

To this end `pypi-publish` environment has been created for the TopoStats repository and this PR adds the `environment: pypi-publish` configuration to the `jobs.build-release`. At the same time a trusted publisher has been [added](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to the `topostats` account on PyPI.