### PR TITLE
Removes py as a test dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-  "py",
   "pytest",
   "pytest-cov",
   "pytest-github-actions-annotate-failures",


### PR DESCRIPTION
Author of [pytest-regtest](https://gitlab.com/uweschmitt/pytest-regtest/-/issues/19) has suggested this is no longer needed. I've checked in a clean environment and with `pytest-regtest-2.0.3` and `pytest-7.4.4` this is indeed no longer the case.

Thus we can remove it as a required (optional) dependency.