### PR TITLE
Added 'pm' and 'mm' for very small and large scans

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import pySPM
 import yaml
 
 import topostats
@@ -365,6 +366,12 @@ def load_scan_data() -> LoadScans:
 def load_scan_spm() -> LoadScans:
     """Instantiate a LoadScans object from a .spm file."""
     return LoadScans([RESOURCES / "minicircle.spm"], channel="Height")
+
+@pytest.fixture()
+def spm_channel_data() -> pySPM.SPM.SPM_image:
+    """Instantiate channel data from a LoadScans object."""
+    scan = pySPM.Bruker(RESOURCES / "minicircle.spm")
+    return scan.get_channel("Height")
 
 
 @pytest.fixture()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -481,8 +481,10 @@ def test_gwy_read_component(load_scan_dummy: LoadScans) -> None:
 @pytest.mark.parametrize(
     ("unit", "x", "y", "expected_px2nm"),
     [
+        ("mm", 0.01, 0.01, 10000),
         ("um", 1.5, 1.5, 1500),
         ("nm", 50, 50, 50),
+        ("pm", 233, 233, 0.233),
     ],
 )
 def test__spm_pixel_to_nm_scaling(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -478,7 +478,7 @@ def test_gwy_read_component(load_scan_dummy: LoadScans) -> None:
 
 @patch('pySPM.SPM.SPM_image.pxs')
 @pytest.mark.parametrize(
-    ("unit, x, y, expected_px2nm"),
+    ("unit", "x", "y", "expected_px2nm"),
     [
         ("um", 1.5, 1.5, 1500),
         ("nm", 50, 50, 50),

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -538,8 +538,10 @@ class LoadScans:
             Pixel to nm scaling factor.
         """
         unit_dict = {
+            "pm": 1e-3,
             "nm": 1,
             "um": 1e3,
+            "mm": 1e6,
         }
         px_to_real = channel_data.pxs()
         # Has potential for non-square pixels but not yet implemented


### PR DESCRIPTION
2 line fix! (No issue made as it would take so much longer)

Code broke on very small scans when e.g. a 1x512px scan came through and thus the scale bar of one side was 'pm' not 'nm' or 'um'. Although these are removed due to the image size limits, they currently the rest of the code from running.

This fix adds no tests because these come from the channel data (a pySPM object) and the values identified here that could be tested are returned from a pySPM function and not a child object thus cannot be overwritten.

We are fine with this not being tested.