### PR TITLE
Added 'pm' and 'mm' for very small and large scans

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -481,10 +481,12 @@ def test_gwy_read_component(load_scan_dummy: LoadScans) -> None:
 @pytest.mark.parametrize(
     ("unit", "x", "y", "expected_px2nm"),
     [
-        ("mm", 0.01, 0.01, 10000),
-        ("um", 1.5, 1.5, 1500),
-        ("nm", 50, 50, 50),
-        ("pm", 233, 233, 0.233),
+        pytest.param("mm", 0.01, 0.01, 10000, id="mm units; square"),
+        pytest.param("um", 1.5, 1.5, 1500, id="um units; square"),
+        pytest.param("nm", 50, 50, 50, id="nm units; square"),
+        pytest.param("pm", 233, 233, 0.233, id="pm units; square"),
+        pytest.param("pm", 1, 512, 0.001, id="pm units; rectangular (thin)"),
+        pytest.param("pm", 512, 1, 0.512, id="pm units; rectangular (tall)"),
     ],
 )
 def test__spm_pixel_to_nm_scaling(


### PR DESCRIPTION
As #796 seeks to address an issue with non-square images that were 1 pixel wide it makes sense to have such scenarios
tested.

+ The `pytest.param()` function is used to add meaningful identifiers to each of the tests.
+ Adds a `1x512` pixel scan to the parameters (denoted `pn units; rectangular (thin)`).
+ Conversely adds a `512x1` pixel scan to the parameters (denoted `pm units; rectangular (tall)`)

I'm unsure...

+ whether the `tall` test makes sense but then I'm also don't know why there would be an image that is only 1 pixel wide.
+ why the `expected_px2nm` is always based on the x-axis size and whether this would be an issue?