### PR TITLE
Remove saving of gaussian filtered arrays to .npy files

### DIFF
--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -12,7 +12,7 @@ from topostats import __version__
 from topostats.filters import Filters
 from topostats.grains import Grains
 from topostats.grainstats import GrainStats
-from topostats.io import get_out_path, save_array, save_topostats_file
+from topostats.io import get_out_path, save_topostats_file
 from topostats.logs.logs import LOGGER_NAME, setup_logger
 from topostats.plottingfuncs import Images, add_pixel_to_nm_to_plotting_config
 from topostats.statistics import image_statistics
@@ -104,13 +104,6 @@ def run_filters(
             filename=filename,
             **plotting_config["plot_dict"][plot_name],
         ).plot_and_save()
-        # Save the z_threshed image (aka "Height_Thresholded") numpy array
-        save_array(
-            array=filters.images["gaussian_filtered"],
-            outpath=core_out_path,
-            filename=filename,
-            array_type="height_thresholded",
-        )
 
         return filters.images["gaussian_filtered"]
 


### PR DESCRIPTION
Closes #802

Arrays and data are now saved in HDF5 files (#790) and so `.npy` arrays are somewhat redundant. This PR leaves the `io.save_array()` function in place should interactive use require saving of arrays but removes its use from `topostats.processing.run_filters()` so that the `.npy` files are no longer saved to disk.

Users wishing to access processed data should load it from the HDF5 formatted `.topostats` files that are saved during processing.