### PR TITLE
Fixing DPI settings

### DIFF
--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -62,7 +62,7 @@ plotting:
   run: true # Options : true, false
   style: topostats.mplstyle # Options : topostats.mplstyle or path to a matplotlibrc params file
   savefig_format: null # Options : null, png, svg or pdf. tif is also available although no metadata will be saved. (defaults to png) See https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
-  savefig_dpi: null # Options : null (defaults to figure) see https://afm-spm.github.io/TopoStats/main/configuration.html#further-customisation and https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
+  savefig_dpi: null # Options : null (defaults to the value in topostats/plotting_dictionary.yaml), see https://afm-spm.github.io/TopoStats/main/configuration.html#further-customisation and https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html
   pixel_interpolation: null # Options : https://matplotlib.org/stable/gallery/images_contours_and_fields/interpolation_methods.html
   image_set: core # Options : all, core
   zrange: [null, null] # low and high height range for core images (can take [null, null]). low <= high

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1015,7 +1015,7 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
     None
     """
     for key, item in dictionary.items():
-        LOGGER.info(f"Saving key: {key}")
+        LOGGER.debug(f"Saving key: {key}")
 
         if item is None:
             LOGGER.warning(f"Item '{key}' is None. Skipping.")

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -6,6 +6,7 @@ import logging
 from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
+from pprint import pformat
 
 import numpy as np
 import numpy.typing as npt
@@ -105,8 +106,20 @@ def update_plotting_config(plotting_config: dict) -> dict:
     main_config = plotting_config.copy()
     for opt in ["plot_dict", "run"]:
         main_config.pop(opt)
+    LOGGER.debug(
+        f"Main plotting options that need updating/adding to plotting dict :\n{pformat(main_config, indent=4)}"
+    )
     for image, options in plotting_config["plot_dict"].items():
-        plotting_config["plot_dict"][image] = {**options, **main_config}
+        LOGGER.debug(f"Dictionary for image : {image}")
+        LOGGER.debug(f"{pformat(options, indent=4)}")
+        # First update options with values that exist in main_config
+        plotting_config["plot_dict"][image] = update_config(options, main_config)
+        LOGGER.debug(f"Updated values :\n{pformat(plotting_config['plot_dict'][image])}")
+        # Then combine the remaining key/values we need from main_config that don't already exist
+        for key_main, value_main in main_config.items():
+            if key_main not in plotting_config["plot_dict"][image]:
+                plotting_config["plot_dict"][image][key_main] = value_main
+        LOGGER.debug(f"After adding missing configuration options :\n{pformat(plotting_config['plot_dict'][image])}")
         # Make it so that binary images do not have the user-defined z-scale
         # applied, but non-binary images do.
         if plotting_config["plot_dict"][image]["image_type"] == "binary":


### PR DESCRIPTION
Closes #807

Current process is...

1. `topostats/entry_point.create_parser` : get arguments from commandline via the `process_parser` subparser (includes DPI)
2. `topostats/run_topostats.run_topostats()` : loads the dictionary and updates it with any values from `arg`, will update `savefig_dpi` with `--savefig-dpi` value.
3. Validate the updated configuration.
4. Load the default `topostats/plotting_dictionary.yaml` to the main `config["plotting"]["plot_dict"]"`. This adds in all the image specific settings such as title and importantly DPI values for each image.
5. Validate the `config["plotting"]` configuration.
6. Update the plotting configuration with via `utils.update_plotting_config()`. This adds all the options _not_ defined in the `plotting_dictionary` with those from `topostats/default_config.yaml`.

This was wrong because we have `plotting_config["plot_dict"][image] = {**options, **main_config}` and so the options from `**main_config` override those from `**options` as you can not have dictionaries with duplicate keys.

This has been fixed by...

1. Updating the values from `plot_dictionary` with any that exist in the `default_config.yaml` under the `plotting` section. Importantly this means that if any are `None` they do not update, logic that already existed in `update_config()`.
2. Then adding to each image within `plot_dictionary` any values from the `plotting` section of `default_config.yaml` that do _not_ already exist.

This avoids replacing the defaults from `plot_dictionary` with `None` values from the `plotting` section of `default_config.yaml`.

Tests included which check equality  of dictionaries and that `LOGGER.info()` is included when changes are made to the DPI.

Other Changes

+ `LOGGER.info()` to `LOGGER.debug()` in `topostats.io.dict_to_hdf5` as I don't think printing the keys is that informative.