### PR TITLE
Sets the type of all arguments that are files/paths to Path

### DIFF
--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -68,25 +68,29 @@ def test_entry_point_subprocess_help(capsys, argument: str, option: str) -> None
 @pytest.mark.parametrize(
     ("options", "expected_function", "expected_arg_name", "expected_arg_value"),
     [
-        (
+        pytest.param(
             [
                 "process",
-                "-c dummy/config/dir/config.yaml",
+                "-c",
+                "dummy/config/dir/config.yaml",
             ],
             run_topostats,
             "config_file",
-            " dummy/config/dir/config.yaml",
+            Path("dummy/config/dir/config.yaml"),
+            id="Process with config file argument",
         ),
-        (
+        pytest.param(
             [
                 "process",
-                "-b /tmp/",
+                "-b",
+                "/tmp/",  # noqa: S108
             ],
             run_topostats,
             "base_dir",
-            " /tmp/",
+            Path("/tmp/"),  # noqa: S108
+            id="Process with base dir argument",
         ),
-        (
+        pytest.param(
             [
                 "create-config",
                 "--filename",
@@ -94,16 +98,19 @@ def test_entry_point_subprocess_help(capsys, argument: str, option: str) -> None
             ],
             write_config_with_comments,
             "filename",
-            "dummy/config/dir/config.yaml",
+            Path("dummy/config/dir/config.yaml"),
+            id="Create config with output filename",
         ),
-        (
+        pytest.param(
             [
                 "summary",
-                "-l dummy/config/dir/var_to_label.yaml",
+                "-l",
+                "dummy/config/dir/var_to_label.yaml",
             ],
             run_toposum,
             "var_to_label",
-            " dummy/config/dir/var_to_label.yaml",
+            Path("dummy/config/dir/var_to_label.yaml"),
+            id="Summary with label file.",
         ),
     ],
 )
@@ -114,10 +121,8 @@ def test_entry_point(
     returned_args = entry_point(options, testing=True)
     # convert argparse's Namespace object to dictionary
     returned_args_dict = vars(returned_args)
-
     # check that the correct function is collected
     assert returned_args.func == expected_function
-
     # check that the argument has successfully been passed through into the dictionary
     assert returned_args_dict[expected_arg_name] == expected_arg_value
 
@@ -133,7 +138,6 @@ def test_entry_point_create_config_file(tmp_path: Path) -> None:
             f"{tmp_path}",
         ]
     )
-
     assert Path(f"{tmp_path}/test_create_config.yaml").is_file()
 
 
@@ -141,20 +145,23 @@ def test_entry_point_create_config_file(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("options", "expected_arg_name", "expected_arg_value"),
     [
-        (
+        pytest.param(
             [
-                "-c dummy/config/dir/config.yaml",
+                "-c",
+                "dummy/config/dir/config.yaml",
             ],
             "config_file",
-            " dummy/config/dir/config.yaml",
+            Path("dummy/config/dir/config.yaml"),
+            id="Test using -c flag for config file",
         ),
-        (
+        pytest.param(
             [
                 "--config",
                 "dummy/config/dir/config.yaml",
             ],
             "config_file",
-            "dummy/config/dir/config.yaml",
+            Path("dummy/config/dir/config.yaml"),
+            id="Test using --config flag for config file",
         ),
     ],
 )

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -5,6 +5,7 @@ Parses command-line arguments and passes input on to the relevant functions / mo
 
 import argparse as arg
 import sys
+from pathlib import Path
 
 from topostats import __version__
 from topostats.io import write_config_with_comments
@@ -39,6 +40,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -52,6 +54,7 @@ def create_parser() -> arg.ArgumentParser:
     process_parser.add_argument(
         "--matplotlibrc",
         dest="matplotlibrc",
+        type=Path,
         required=False,
         help="Path to a matplotlibrc file.",
     )
@@ -59,7 +62,7 @@ def create_parser() -> arg.ArgumentParser:
         "-b",
         "--base-dir",
         dest="base_dir",
-        type=str,
+        type=Path,
         required=False,
         help="Base directory to scan for images.",
     )
@@ -98,7 +101,7 @@ def create_parser() -> arg.ArgumentParser:
         "-o",
         "--output-dir",
         dest="output_dir",
-        type=str,
+        type=Path,
         required=False,
         help="Output directory to write results to.",
     )
@@ -151,6 +154,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML plotting dictionary that maps variable names to labels.",
     )
@@ -158,20 +162,21 @@ def create_parser() -> arg.ArgumentParser:
         "-l",
         "--var-to-label",
         dest="var_to_label",
+        type=Path,
         required=False,
         help="Path to a YAML plotting dictionary that maps variable names to labels.",
     )
     toposum_parser.add_argument(
         "--create-config-file",
         dest="create_config_file",
-        type=str,
+        type=Path,
         required=False,
         help="Filename to write a sample YAML configuration file to (should end in '.yaml').",
     )
     toposum_parser.add_argument(
         "--create-label-file",
         dest="create_label_file",
-        type=str,
+        type=Path,
         required=False,
         help="Filename to write a sample YAML label file to (should end in '.yaml').",
     )
@@ -193,6 +198,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -206,6 +212,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -219,6 +226,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -232,6 +240,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -245,6 +254,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -258,6 +268,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config-file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -271,6 +282,7 @@ def create_parser() -> arg.ArgumentParser:
         "-f",
         "--filename",
         dest="filename",
+        type=Path,
         required=False,
         default="config.yaml",
         help="Name of YAML file to save configuration to (default 'config.yaml').",
@@ -279,6 +291,7 @@ def create_parser() -> arg.ArgumentParser:
         "-o",
         "--output-dir",
         dest="output_dir",
+        type=Path,
         required=False,
         default="./",
         help="Path to where the YAML file should be saved (default './' the current directory).",
@@ -287,6 +300,7 @@ def create_parser() -> arg.ArgumentParser:
         "-c",
         "--config",
         dest="config",
+        type=str,
         default=None,
         help="Configuration to use, currently only one is supported, the 'default'.",
     )
@@ -301,6 +315,7 @@ def create_parser() -> arg.ArgumentParser:
         "-f",
         "--filename",
         dest="filename",
+        type=Path,
         required=False,
         default="topostats.mplstyle",
         help="Name of file to save Matplotlibrc configuration to (default 'topostats.mplstyle').",
@@ -309,6 +324,7 @@ def create_parser() -> arg.ArgumentParser:
         "-o",
         "--output-dir",
         dest="output_dir",
+        type=Path,
         required=False,
         default="./",
         help="Path to where the YAML file should be saved (default './' the current directory).",
@@ -354,6 +370,7 @@ def create_legacy_run_topostats_parser() -> arg.ArgumentParser:
         "-c",
         "--config_file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -361,6 +378,7 @@ def create_legacy_run_topostats_parser() -> arg.ArgumentParser:
         "-s",
         "--summary_config",
         dest="summary_config",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file for summary plots and statistics.",
     )
@@ -368,7 +386,7 @@ def create_legacy_run_topostats_parser() -> arg.ArgumentParser:
         "-b",
         "--base_dir",
         dest="base_dir",
-        type=str,
+        type=Path,
         required=False,
         help="Base directory to scan for images.",
     )
@@ -407,7 +425,7 @@ def create_legacy_run_topostats_parser() -> arg.ArgumentParser:
         "-o",
         "--output_dir",
         dest="output_dir",
-        type=str,
+        type=Path,
         required=False,
         help="Output directory to write results to.",
     )
@@ -448,6 +466,7 @@ def create_legacy_toposum_parser() -> arg.ArgumentParser:
         "-c",
         "--config_file",
         dest="config_file",
+        type=Path,
         required=False,
         help="Path to a YAML configuration file.",
     )
@@ -455,20 +474,21 @@ def create_legacy_toposum_parser() -> arg.ArgumentParser:
         "-l",
         "--var_to_label",
         dest="var_to_label",
+        type=Path,
         required=False,
         help="Path to a YAML plotting dictionary that maps variable names to labels.",
     )
     parser.add_argument(
         "--create-config-file",
         dest="create_config_file",
-        type=str,
+        type=Path,
         required=False,
         help="Filename to write a sample YAML configuration file to (should end in '.yaml').",
     )
     parser.add_argument(
         "--create-label-file",
         dest="create_label_file",
-        type=str,
+        type=Path,
         required=False,
         help="Filename to write a sample YAML label file to (should end in '.yaml').",
     )

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -139,7 +139,7 @@ def write_config_with_comments(args=None) -> None:
         except FileNotFoundError as e:
             raise UserWarning(f"There is no configuration for samples of type : {args.config}") from e
 
-    if ".yaml" not in filename and ".yml" not in filename and ".mplstyle" not in filename:
+    if ".yaml" not in str(filename) and ".yml" not in str(filename) and ".mplstyle" not in str(filename):
         create_config_path = output_dir / f"{filename}.yaml"
     else:
         create_config_path = output_dir / filename


### PR DESCRIPTION
I noticed that the type of arguments could be set to Path and so have updated our `entry_point` `argparse` to use this.

This also required a small change to convert `Path() > str` when creating output files and tweaks to the tests to ensure targets were of type `Path()`. Whilst updating these I noticed that some of the targets had spaces at the start, this was caused by flags and arguments being combined in the list that are passed (i.e. `"-c default_config.yaml"`) has been corrected so that they are separate items in the list (i.e. `"-c", "default_config.yaml"`) and the spaces at the start of the targets are no longer required.