### PR TITLE
chore(tracing,skeleton): Line length linting; correcting tpyos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,7 @@ convention = "numpy"
 fixture-parentheses = true
 
 [tool.codespell]
-skip = '*.spm*,*.mplstyle,*.svg,*nodestats.py,*dnatracing.py'
+skip = '*.spm*,*.mplstyle,*.svg,*nodestats.py'
 count = ''
 quiet-level = 3
 

--- a/topostats/tracing/dnatracing.py
+++ b/topostats/tracing/dnatracing.py
@@ -242,7 +242,7 @@ class dnaTrace:
                     self.mol_is_circulars.append(mol_is_circular)
                     fitted_trace = self.get_fitted_traces(trace, mol_is_circular)
                     self.fitted_trace_img += coords_2_img(fitted_trace, self.image)
-                    # Propper cleanup needed - ordered trace instead of fitted trace?
+                    # Proper cleanup needed - ordered trace instead of fitted trace?
 
                     splined_trace = self.get_splined_traces(fitted_trace, mol_is_circular)
                     # sometimes traces can get skwiffy
@@ -292,7 +292,7 @@ class dnaTrace:
         """
         Smooth grains based on the lower number of binary pixels added from dilation or gaussian.
 
-        This method ensures gaussian smoothing isn't too agressive and covers / creates gaps in the mask.
+        This method ensures gaussian smoothing isn't too aggressive and covers / creates gaps in the mask.
 
         Parameters
         ----------
@@ -333,7 +333,7 @@ class dnaTrace:
 
         As Gaussian dilation smoothing methods can close holes in the original mask, this function obtains those holes
         (based on the general background being the first due to padding) and adds them back into the smoothed mask. When
-        paired, this essentailly just smooths the outer edge of the grains.
+        paired, this essentially just smooths the outer edge of the grains.
 
         Parameters
         ----------
@@ -378,7 +378,7 @@ class dnaTrace:
         Parameters
         ----------
         ordered_trace : npt.NDArray
-            Array of ordered trace co-ordinates.
+            Array of ordered trace coordinates.
 
         Returns
         -------
@@ -629,7 +629,7 @@ class dnaTrace:
                 y_coords = np.arange(trace_coordinate[1] - index_width, trace_coordinate[1] + index_width)
                 x_coords = np.full(len(y_coords), trace_coordinate[0])
 
-            # Use the perp array to index the guassian filtered image
+            # Use the perp array to index the gaussian filtered image
             perp_array = np.column_stack((x_coords, y_coords))
             try:
                 height_values = self.smoothed_grain[perp_array[:, 0], perp_array[:, 1]]
@@ -1596,7 +1596,7 @@ def trace_grain(
                     "trace_distances": None,
                     "ordered_trace": None,
                     "splined_trace": None,
-                },  # incase no mols could be traced, need empties to attempt to merge on
+                },  # in case no mols could be traced, need empties to attempt to merge on
             },
             "nodeStats": dnatrace.node_dict,
         },

--- a/topostats/tracing/skeletonize.py
+++ b/topostats/tracing/skeletonize.py
@@ -25,7 +25,8 @@ class getSkeleton:  # pylint: disable=too-few-public-methods
     method : str
         Method for skeletonizing. Options 'zhang' (default), 'lee', 'medial_axis', 'thin' and 'topostats'.
     height_bias : float
-        Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+        Ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels
+        smiilar to Zhang.
     """
 
     def __init__(self, image: npt.NDArray, mask: npt.NDArray, method: str = "zhang", height_bias: float = 0.6):
@@ -46,7 +47,8 @@ class getSkeleton:  # pylint: disable=too-few-public-methods
         method : str
             Method for skeletonizing. Options 'zhang' (default), 'lee', 'medial_axis', 'thin' and 'topostats'.
         height_bias : float
-            Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+            Ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all
+            pixels smiilar to Zhang.
         """
         # Q What benefit is there to having a class getSkeleton over the get_skeleton() function? Ostensibly the class
         # is doing only one thing, we don't need to change state/modify anything here. Beyond encapsulating all
@@ -173,7 +175,8 @@ class getSkeleton:  # pylint: disable=too-few-public-methods
         mask : npt.NDArray
             Binary array to skeletonise.
         height_bias : float
-            Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+            Ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all
+            pixels smiilar to Zhang.
 
         Returns
         -------
@@ -187,8 +190,8 @@ class topostatsSkeletonize:  # pylint: disable=too-many-instance-attributes
     """
     Skeletonise a binary array following Zhang's algorithm (Zhang and Suen, 1984).
 
-    Modifications are made to the published algorithm during the removal step to remove a fraction of the smallest pixel values
-    opposed to all of them in the aforementioned algorithm. All operations are performed on the mask entered.
+    Modifications are made to the published algorithm during the removal step to remove a fraction of the smallest pixel
+    values opposed to all of them in the aforementioned algorithm. All operations are performed on the mask entered.
 
     Parameters
     ----------
@@ -197,7 +200,8 @@ class topostatsSkeletonize:  # pylint: disable=too-many-instance-attributes
     mask : npt.NDArray
         Binary image containing the object to be skeletonised. Dimensions should match those of 'image'.
     height_bias : float
-        Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+        Ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels
+        smiilar to Zhang.
     """
 
     def __init__(self, image: npt.NDArray, mask: npt.NDArray, height_bias: float = 0.6):
@@ -211,7 +215,8 @@ class topostatsSkeletonize:  # pylint: disable=too-many-instance-attributes
         mask : npt.NDArray
             Binary image containing the object to be skeletonised. Dimensions should match those of 'image'.
         height_bias : float
-            Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+            Ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all
+            pixels smiilar to Zhang.
         """
         self.image = image
         self.mask = mask.copy()
@@ -253,7 +258,8 @@ class topostatsSkeletonize:  # pylint: disable=too-many-instance-attributes
 
         This determines whether to delete a point according to the Zhang algorithm.
 
-        Then removes Raito of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1 is all pixels smiilar to Zhang.
+        Then removes ratio of lowest intensity (height) pixels to total pixels fitting the skeletonisation criteria. 1
+        is all pixels smiilar to Zhang.
         """
         skel_img = self.mask.copy()
         pixels_to_delete = []


### PR DESCRIPTION
Missed a copy and paste tpyo and have corrected `Raito` > `Ratio`.

Also when trying to make the commit `pylint` (via `pre-commit`) checks informed me there were a number of lines in the added docstrings that were beyond the 120 character limit.

I think this may be because Black and Ruff don't touch docstrings, but most IDEs have support to hard-wrap lines at a given length, although in VSCode this appears to require a [plugin](https://stackoverflow.com/questions/43122175/automatically-hard-wrap-lines-at-column-in-vscode).