### PR TITLE
bug: Addresses importlib.resources.open_text() deprecation

### DIFF
--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,6 @@
 """Tests for the plotting module."""
 
-import importlib.resources as pkg_resources
+from importlib import resources
 from pathlib import Path
 
 import pandas as pd
@@ -92,8 +92,8 @@ def test_var_to_label_config(tmp_path: Path) -> None:
     with var_to_label_config.open("r", encoding="utf-8") as f:
         var_to_label_str = f.read()
     var_to_label = yaml.safe_load(var_to_label_str)
-    plotting_yaml = pkg_resources.open_text(topostats.__package__, "var_to_label.yaml")
-    expected_var_to_label = yaml.safe_load(plotting_yaml.read())
+    plotting_yaml = (resources.files(topostats.__package__) / "var_to_label.yaml").read_text()
+    expected_var_to_label = yaml.safe_load(plotting_yaml)
 
     assert var_to_label == expected_var_to_label
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import importlib.resources as pkg_resources
 import io
 import logging
 import os
 import pickle as pkl
 import struct
 from datetime import datetime
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -126,15 +126,15 @@ def write_config_with_comments(args=None) -> None:
     logger_msg = "A sample configuration has been written to"
     # If no config or default is requested we load the default_config.yaml
     if args.config is None or args.config == "default":
-        config = pkg_resources.open_text(__package__, "default_config.yaml").read()
+        config = (resources.files(__package__) / "default_config.yaml").read_text()
     elif args.config == "topostats.mplstyle":
-        config = pkg_resources.open_text(__package__, "topostats.mplstyle").read()
+        config = (resources.files(__package__) / "topostats.mplstyle").read_text()
         logger_msg = "A sample matplotlibrc parameters file has been written to"
     # Otherwise we have scope for loading different configs based on the argument, add future dictionaries to
     # topostats/<sample_type>_config.yaml
     else:
         try:
-            config = pkg_resources.open_text(__package__, f"{args.config}_config.yaml").read()
+            config = (resources.files(__package__) / f"{args.config}_config.yaml").read_text()
         except FileNotFoundError as e:
             raise UserWarning(f"There is no configuration for samples of type : {args.config}") from e
 

--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 
-import importlib.resources as pkg_resources
+from importlib import resources
 import logging
 from pathlib import Path
 import sys
@@ -427,16 +427,16 @@ def run_toposum(args=None) -> None:
         config = read_yaml(args.config_file)
         LOGGER.info(f"[plotting] Configuration file loaded from : {args.config_file}")
     else:
-        summary_yaml = pkg_resources.open_text(__package__, "summary_config.yaml")
-        config = yaml.safe_load(summary_yaml.read())
+        summary_yaml = (resources.files(__package__) / "summary_config.yaml").read_text()
+        config = yaml.safe_load(summary_yaml)
         LOGGER.info("[plotting] Default configuration file loaded.")
     config = update_config(config, args)
     if args.var_to_label is not None:
         config["var_to_label"] = read_yaml(args.var_to_label)
         LOGGER.info("[plotting] Variable to labels mapping loaded from : {args.var_to_label}")
     else:
-        plotting_yaml = pkg_resources.open_text(__package__, "var_to_label.yaml")
-        config["var_to_label"] = yaml.safe_load(plotting_yaml.read())
+        plotting_yaml = (resources.files(__package__) / "var_to_label.yaml").read_text()
+        config["var_to_label"] = yaml.safe_load(plotting_yaml)
         LOGGER.info("[plotting] Default variable to labels mapping loaded.")
     if args.csv_file is not None:
         config["csv_file"] = args.csv_file

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import importlib.resources as pkg_resources
 import logging
+from importlib import resources
 from pathlib import Path
 
 import matplotlib as mpl
@@ -89,7 +89,7 @@ def load_mplstyle(style: str | Path) -> None:
         Path to a Matplotlib Style file.
     """
     if style == "topostats.mplstyle":
-        plt.style.use(pkg_resources.files(topostats) / style)
+        plt.style.use(resources.files(topostats) / style)
     else:
         plt.style.use(style)
 

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -4,11 +4,11 @@ Run TopoStats.
 This provides an entry point for running TopoStats as a command line programme.
 """
 
-import importlib.resources as pkg_resources
 import logging
 import sys
 from collections import defaultdict
 from functools import partial
+from importlib import resources
 from multiprocessing import Pool
 from pprint import pformat
 
@@ -56,7 +56,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
     if args.config_file is not None:
         config = read_yaml(args.config_file)
     else:
-        default_config = pkg_resources.open_text(__package__, "default_config.yaml").read()
+        default_config = (resources.files(__package__) / "default_config.yaml").read_text()
         config = yaml.safe_load(default_config)
     # Override the config with command line arguments passed in, eg --output_dir ./output/
     config = update_config(config, args)
@@ -77,8 +77,8 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
     config["output_dir"].mkdir(parents=True, exist_ok=True)
 
     # Load plotting_dictionary and validate then update with command line options
-    plotting_dictionary = pkg_resources.open_text(__package__, "plotting_dictionary.yaml")
-    config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary.read())
+    plotting_dictionary = (resources.files(__package__) / "plotting_dictionary.yaml").read_text()
+    config["plotting"]["plot_dict"] = yaml.safe_load(plotting_dictionary)
     validate_config(
         config["plotting"]["plot_dict"], schema=PLOTTING_SCHEMA, config_type="YAML plotting configuration file"
     )
@@ -168,8 +168,8 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         elif config["summary_stats"]["config"] is not None:
             summary_config = read_yaml(config["summary_stats"]["config"])
         else:
-            summary_yaml = pkg_resources.open_text(__package__, "summary_config.yaml")
-            summary_config = yaml.safe_load(summary_yaml.read())
+            summary_yaml = (resources.files(__package__) / "summary_config.yaml").read_text()
+            summary_config = yaml.safe_load(summary_yaml)
 
         # Do not pass command line arguments to toposum as they clash with process command line arguments
         summary_config = update_config(summary_config, config["plotting"])
@@ -179,8 +179,8 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         summary_config.pop("csv_file")
 
         # Load variable to label mapping
-        plotting_yaml = pkg_resources.open_text(__package__, "var_to_label.yaml")
-        summary_config["var_to_label"] = yaml.safe_load(plotting_yaml.read())
+        plotting_yaml = (resources.files(__package__) / "var_to_label.yaml").read_text()
+        summary_config["var_to_label"] = yaml.safe_load(plotting_yaml)
         LOGGER.info("[plotting] Default variable to labels mapping loaded.")
 
         # If we don't have a dataframe or we do and it is all NaN there is nothing to plot


### PR DESCRIPTION
Closes #828

Deprecation of [legacy API](https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy) was now throwing errors. These have been addressed and the new `files()` API is used in place.