### PR TITLE
chore: Update codecov version used in test workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,4 +38,4 @@ jobs:
         run: |
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4


### PR DESCRIPTION
Noticed in #830 that there was the following warning...

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Checked [codecov/codecov-action](https://github.com/codecov/codecov-action) and the latest release if `4.3.0`.

This Pull Request updates the version used to `codecov/codecov-action@v4`