### PR TITLE
ci: Peg sphinx-autoapi-3.1.0b0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -25,7 +25,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
   "myst_parser",
   "numpydoc",
   "pydata_sphinx_theme",
-  "sphinx-autoapi",
+  "sphinx-autoapi==3.1.0b0",
   "sphinx-autodoc-typehints",
   "sphinx-multiversion",
   "sphinx_markdown_tables",


### PR DESCRIPTION
Might close #841

Also noticed the `.readthedocs.yaml` had an a couple of errors in where the version was incorrectly specified in one
location and outdated in another.