### PR TITLE
add orig err msg in broad channel try/except

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1026,6 +1026,7 @@ class LoadScans:
                     self.image, self.pixel_to_nm_scaling = suffix_to_loader[suffix]()
                 except Exception as e:
                     if "Channel" in str(e) and "not found" in str(e):
+                        LOGGER.warning(e) # log the specific error message
                         LOGGER.warning(f"[{self.filename}] Channel {self.channel} not found, skipping image.")
                     else:
                         raise

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1026,7 +1026,7 @@ class LoadScans:
                     self.image, self.pixel_to_nm_scaling = suffix_to_loader[suffix]()
                 except Exception as e:
                     if "Channel" in str(e) and "not found" in str(e):
-                        LOGGER.warning(e) # log the specific error message
+                        LOGGER.warning(e)  # log the specific error message
                         LOGGER.warning(f"[{self.filename}] Channel {self.channel} not found, skipping image.")
                     else:
                         raise


### PR DESCRIPTION
Closes #853 

Adds 1 line reciting the original error message passed to a broad try/except.

For `asd` files, there available channels logging output from `AFMReader` is no longer super-seeded and output. Because the other filetypes don't use `AFMReader` yet, they have duplicate "available channel" outputs.