### PR TITLE
tests(ordered_tracing): Tests and fixes for ordered_trace_mask()

### DIFF
--- a/tests/tracing/test_ordered_tracing.py
+++ b/tests/tracing/test_ordered_tracing.py
@@ -1,0 +1,79 @@
+"""Tests for the ordered_tracing module."""
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+from topostats.tracing import ordered_tracing
+
+
+@pytest.mark.parametrize(
+    ("coordinates", "shape", "target"),
+    [
+        pytest.param([[1, 1]], (3, 3), np.asarray([[0, 0, 0], [0, 1, 0], [0, 0, 0]]), id="single point in 3x3 array"),
+        pytest.param(
+            [[0, 0], [1, 1], [2, 2]],
+            (3, 3),
+            np.asarray([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            id="diagonal line across 3x3 array (top left to bottom right)",
+        ),
+    ],
+)
+def test_ordered_trace_mask(coordinates: list, shape: tuple, target: npt.NDArray) -> None:
+    """Test of ordered_trace_mask()."""
+    np.testing.assert_array_equal(ordered_tracing.ordered_trace_mask(coordinates, shape), target)
+
+
+@pytest.mark.parametrize(
+    ("coordinates", "shape", "target"),
+    [
+        pytest.param(
+            [[1, 1]],
+            (3, 3),
+            np.asarray([[0, 0, 0], [0, 1, 0], [0, 0, 0]]),
+            id="list of coordinates with single point in 3x3 array",
+        ),
+        pytest.param(
+            [[0, 0], [1, 1], [2, 2]],
+            (3, 3),
+            np.asarray([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            id="list of coordinates with diagonal line across 3x3 array (top left to bottom right)",
+        ),
+        pytest.param(
+            np.asarray([[1, 1]]),
+            (3, 3),
+            np.asarray([[0, 0, 0], [0, 1, 0], [0, 0, 0]]),
+            id="Numpy array of coordinates with single point in 3x3 array",
+        ),
+        pytest.param(
+            np.asarray([[0, 0], [1, 1], [2, 2]]),
+            (3, 3),
+            np.asarray([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+            id="Numpy array of coordinates with diagonal line across 3x3 array (top left to bottom right)",
+        ),
+    ],
+)
+def test_trace_mask(coordinates: list, shape: tuple, target: npt.NDArray) -> None:
+    """Test of ordered_trace_mask()."""
+    np.testing.assert_array_equal(ordered_tracing.trace_mask(coordinates, shape), target)
+
+
+@pytest.mark.parametrize(
+    ("coordinates", "shape"),
+    [
+        pytest.param(
+            ((1, 1)),
+            (3, 3),
+            id="tuple of coordinates with single point in 3x3 array",
+        ),
+        pytest.param(
+            ([0, 0], [1, 1], [2, 2]),
+            (3, 3),
+            id="tuple of coordinates with diagonal line across 3x3 array (top left to bottom right)",
+        ),
+    ],
+)
+def test_trace_mask_type_error(coordinates: tuple, shape: tuple) -> None:
+    """Assert type error is raised by trace_mask() when passed neither list or Numpy array."""
+    with pytest.raises(TypeError):
+        ordered_tracing.trace_mask(coordinates, shape)

--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -480,12 +480,22 @@ def run_toposum(args=None) -> None:
 def plot_crossing_linetrace_halfmax(
     branch_stats_dict: dict, mask_cmap: matplotlib.colors.Colormap, title: str
 ) -> tuple:
-    """Plots the heightmap lines traces of the branches found in the 'branch_stats' dictionary, and their meetings.
+    """
+    Plot the heightmap lines traces of the branches found in the 'branch_stats' dictionary, and their meetings.
 
-    Parameters:
-    -----------
-    branch_stats_dict: dict
+    Parameters
+    ----------
+    branch_stats_dict : dict
         Dictionary containing branch height, distance and fwhm info.
+    mask_cmap : matplotlib.colors.Colormap
+        Colormap to plot with.
+    title : str
+        Title for the plot.
+
+    Returns
+    -------
+    tuple
+        Matplotlib figure and axis objects.
     """
     fig, ax = plt.subplots(1, 1, figsize=(7, 4))
     cmp = Colormap(mask_cmap).get_cmap()

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -24,6 +24,7 @@ from topostats.tracing.nodestats import nodestats_image
 from topostats.tracing.ordered_tracing import ordered_tracing_image
 from topostats.utils import create_empty_dataframe
 
+# pylint: disable=too-many-lines
 # pylint: disable=broad-except
 # pylint: disable=line-too-long
 # pylint: disable=too-many-arguments
@@ -430,7 +431,7 @@ def run_disorderedTrace(
         return {}
 
 
-def run_nodestats(
+def run_nodestats(  # noqa: C901
     image: npt.NDArray,
     disordered_tracing_data: dict,
     pixel_to_nm_scaling: float,
@@ -569,7 +570,6 @@ def run_ordered_tracing(
     image: npt.NDArray,
     disordered_tracing_data: dict,
     nodestats_data: dict,
-    pixel_to_nm_scaling: float,
     filename: str,
     core_out_path: Path,
     tracing_out_path: Path,
@@ -588,8 +588,6 @@ def run_ordered_tracing(
         Dictionary of skeletonised and pruned grain masks. Result from "run_disordered_tracing".
     nodestats_data : dict
         Dictionary of images and statistics from the NodeStats analysis. Result from "run_nodestats".
-    pixel_to_nm_scaling : float
-        Scaling factor for converting pixel length scales to nanometers, i.e. the number of pixels per nanometres (nm).
     filename : str
         Name of the image.
     core_out_path : Path
@@ -614,7 +612,6 @@ def run_ordered_tracing(
         ordered_tracing_image_data = defaultdict()
         grainstats_additions_image = pd.DataFrame()
 
-        # try:
         # run image using directional grain masks
         for direction, disordered_tracing_direction_data in disordered_tracing_data.items():
             (
@@ -626,7 +623,6 @@ def run_ordered_tracing(
                 disordered_tracing_direction_data=disordered_tracing_direction_data,
                 nodestats_direction_data=nodestats_data[direction],
                 filename=filename,
-                pixel_to_nm_scaling=pixel_to_nm_scaling,
                 **ordered_tracing_config,
             )
 
@@ -665,11 +661,6 @@ def run_ordered_tracing(
 
         # merge all image dictionaries
         return ordered_tracing_image_data, resultant_grainstats
-        """
-        except Exception as e:
-            LOGGER.info(f"NodeStats failed with {e} - skipping.")
-            return nodestats_image_data, resultant_grainstats
-        """
     return None, None
 
 
@@ -894,6 +885,8 @@ def process_scan(
         Dictionary configuration for obtaining a disordered trace representation of the grains.
     nodestats_config : dict
         Dictionary of configuration options for running the NodeStats stage.
+    ordered_tracing_config : dict
+        Dictionary of configuration options for running the Ordered Tracing stage.
     dnatracing_config : dict
         Dictionary of configuration options for running the DNA Tracing stage.
     plotting_config : dict
@@ -993,7 +986,6 @@ def process_scan(
             image=topostats_object["image_flattened"],
             disordered_tracing_data=disordered_traces,
             nodestats_data=nodestats,
-            pixel_to_nm_scaling=topostats_object["pixel_to_nm_scaling"],
             filename=topostats_object["filename"],
             core_out_path=core_out_path,
             tracing_out_path=tracing_out_path,
@@ -1046,14 +1038,14 @@ def process_scan(
     return topostats_object["img_path"], results_df, image_stats
 
 
-def check_run_steps(
+def check_run_steps(  # noqa: C901
     filter_run: bool,
     grains_run: bool,
     grainstats_run: bool,
     disordered_tracing_run: bool,
     nodestats_run: bool,
     dnatracing_run: bool,
-) -> None:  # noqa: C901
+) -> None:
     """
     Check options for running steps (Filter, Grain, Grainstats and DNA tracing) are logically consistent.
 


### PR DESCRIPTION
The function `ordered_trace_mask()` looked strange on review...

- Docstring said it took `npt.NDArray` as argument but logic only returned mask if `list` was supplied.
- Slicing caused `TypeError: list indices must be integers or slices, not tuple`.
- After correcting that `np.arange(len(mol_coords))` raised a `ValueError: setting an array element with a sequence.`

Test written to demonstrate these problems and alternative `trace_mask()` function offered (along with tests that pass).