### PR TITLE
Seperate out Splining from dnaTracing

### DIFF
--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -336,8 +336,8 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
             grainstats_additions[cropped_image_index] = {
                 "image": filename,
                 "grain_number": cropped_image_index,
-                "grain_endpoints": any(conv_pruned_skeleton[conv_pruned_skeleton == 2]),
-                "grain_crossings": any(conv_pruned_skeleton[conv_pruned_skeleton == 3]),
+                "grain_endpoints": (conv_pruned_skeleton == 2).sum(),
+                "grain_junctions": (conv_pruned_skeleton == 3).sum(),
             }
 
             # remap the cropped images back onto the original

--- a/topostats/tracing/splining.py
+++ b/topostats/tracing/splining.py
@@ -595,7 +595,7 @@ def splining_image(
                 all_splines_data[grain_no] = {}
 
         # average the e2e dists -> mol_no should always be in the grain dict
-        grain_trace_stats["average_end_to_end_distance"] /= int(mol_no.split("_")[-1]) + 1
+        grain_trace_stats["average_end_to_end_distance"] /= len(ordered_grain_data)
 
         # compile metrics
         grainstats_additions[grain_no] = {


### PR DESCRIPTION
This PR splits out the dnatrace smoothing functions into the "splining.py" module to TopoStats which does the sole function of smoothing the disordered traces either as TopoStats normally does (average of splines), or Sylvia's rolling window method.

The fitted traces step has been removed as this could cause issues.
No new diagnostic images are produced - as this only works of the coordinates.
1 new core image is added -> The individual splined coordinates mapped onto the image.
(Currently) 2 new stats are added to grainstats -> total_contour_length and average_end_to_end_distance.
Saves molecule smoothed traces, bbox and contour length and e2e distances to the .topostats file.