### PR TITLE
Add U-Net grain segmentation option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ topostats/_version.py
 
 # default output directory, often common from testing
 output/
+
+# Debugging
+pytest-debug.ini

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import importlib.resources as pkg_resources
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import numpy.typing as npt
@@ -959,3 +960,35 @@ def skeleton_linear3() -> dict:
 # pruned_plot(skeleton_linear1)
 # pruned_plot(skeleton_linear2)
 # pruned_plot(skeleton_linear3)
+
+
+# U-Net fixtures
+@pytest.fixture()
+def mock_model() -> MagicMock:
+    """Create a mock model."""
+    # Create a mock model
+    model_mocker = MagicMock()
+
+    # Define a custom side effect function for the predict method
+    def side_effect_predict(input_array: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+        assert input_array.shape == (1, 5, 5, 1), "Input shape is not as expected"
+        assert input_array.dtype == np.float32, "Input data type is not as expected"
+
+        return (
+            np.array(
+                [
+                    [0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 1, 0, 1, 0],
+                    [0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            )
+            .reshape((1, 5, 5, 1))
+            .astype(np.float32)
+        )
+
+    # Assign the side effect to the mock's predict method
+    model_mocker.predict.side_effect = side_effect_predict
+
+    return model_mocker

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -3,11 +3,14 @@
 import logging
 
 import numpy as np
+import numpy.typing as npt
 import pytest
+
+from topostats.grains import Grains
 
 # Pylint returns this error for from skimage.filters import gaussian
 # pylint: disable=no-name-in-module
-from topostats.grains import Grains
+# pylint: disable=too-many-arguments
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.propagate = True
@@ -208,3 +211,137 @@ def test_remove_edge_intersecting_grains(
     number_of_grains = len(grains.region_properties["above"])
 
     assert number_of_grains == expected_number_of_grains
+
+
+@pytest.mark.parametrize(
+    (
+        "image",
+        "pixel_to_nm_scaling",
+        "threshold_method",
+        "otsu_threshold_multiplier",
+        "threshold_std_dev",
+        "threshold_absolute",
+        "absolute_area_threshold",
+        "direction",
+        "smallest_grain_size_nm2",
+        "remove_edge_intersecting_grains",
+        "expected_grain_mask",
+    ),
+    [
+        pytest.param(
+            np.array(
+                [
+                    [0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+                    [0.2, 1.1, 1.0, 1.2, 0.2, 0.1, 1.5, 1.6, 1.7, 0.1],
+                    [0.1, 1.1, 0.2, 1.0, 0.1, 0.2, 1.6, 0.2, 1.6, 0.2],
+                    [0.2, 1.0, 1.1, 1.1, 0.2, 0.1, 1.6, 1.5, 1.5, 0.1],
+                    [0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+                    [1.5, 1.5, 0.2, 1.5, 1.5, 0.1, 2.0, 1.9, 1.8, 0.1],
+                    [0.1, 0.1, 0.2, 0.0, 0.0, 0.2, 0.1, 0.2, 1.7, 0.2],
+                    [0.2, 1.5, 1.5, 0.1, 0.2, 0.1, 0.2, 0.1, 1.6, 0.1],
+                    [0.1, 0.1, 1.5, 0.1, 1.5, 0.2, 1.3, 1.4, 1.5, 0.2],
+                    [0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1],
+                ]
+            ),
+            1.0,
+            "absolute",
+            None,
+            None,
+            {"above": 0.9, "below": 0.0},
+            {"above": [1, 10000000], "below": [1, 10000000]},
+            "above",
+            1,
+            True,
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 2, 2, 2, 0],
+                    [0, 1, 0, 1, 0, 0, 2, 0, 2, 0],
+                    [0, 1, 1, 1, 0, 0, 2, 2, 2, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 3, 3, 0, 4, 4, 4, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 4, 0],
+                    [0, 5, 5, 0, 0, 0, 0, 0, 4, 0],
+                    [0, 0, 5, 0, 6, 0, 4, 4, 4, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+            id="absolute, above 0.9, remove edge, smallest grain 1",
+        ),
+        pytest.param(
+            np.array(
+                [
+                    [0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+                    [0.2, 1.1, 1.0, 1.2, 0.2, 0.1, 1.5, 1.6, 1.7, 0.1],
+                    [0.1, 1.1, 0.2, 1.0, 0.1, 0.2, 1.6, 0.2, 1.6, 0.2],
+                    [0.2, 1.0, 1.1, 1.1, 0.2, 0.1, 1.6, 1.5, 1.5, 0.1],
+                    [0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2],
+                    [1.5, 1.5, 0.2, 1.5, 1.5, 0.1, 2.0, 1.9, 1.8, 0.1],
+                    [0.1, 0.1, 0.2, 0.0, 0.0, 0.2, 0.1, 0.2, 1.7, 0.2],
+                    [0.2, 1.5, 1.5, 0.1, 0.2, 0.1, 0.2, 0.1, 1.6, 0.1],
+                    [0.1, 0.1, 1.5, 0.1, 1.5, 0.2, 1.3, 1.4, 1.5, 0.2],
+                    [0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1],
+                ]
+            ),
+            1.0,
+            "absolute",
+            None,
+            None,
+            {"above": 0.9, "below": 0.0},
+            {"above": [1, 10000000], "below": [1, 10000000]},
+            "above",
+            2,
+            False,
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 0, 0, 2, 2, 2, 0],
+                    [0, 1, 0, 1, 0, 0, 2, 0, 2, 0],
+                    [0, 1, 1, 1, 0, 0, 2, 2, 2, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [3, 3, 0, 4, 4, 0, 5, 5, 5, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 5, 0],
+                    [0, 6, 6, 0, 0, 0, 0, 0, 5, 0],
+                    [0, 0, 6, 0, 0, 0, 5, 5, 5, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ]
+            ),
+            id="absolute, above 0.9, no remove edge, smallest grain 2",
+        ),
+    ],
+)
+def test_find_grains(
+    image: npt.NDArray[np.float32],
+    pixel_to_nm_scaling: float,
+    threshold_method: str,
+    otsu_threshold_multiplier: float,
+    threshold_std_dev: dict,
+    threshold_absolute: dict,
+    absolute_area_threshold: dict,
+    direction: str,
+    smallest_grain_size_nm2: int,
+    remove_edge_intersecting_grains: bool,
+    expected_grain_mask: npt.NDArray[np.int32],
+) -> None:
+    """Test the find_grains method of the Grains class."""
+    # Initialise the grains object
+    grains_object = Grains(
+        image=image,
+        filename="test_image",
+        pixel_to_nm_scaling=pixel_to_nm_scaling,
+        unet_config=None,
+        threshold_method=threshold_method,
+        otsu_threshold_multiplier=otsu_threshold_multiplier,
+        threshold_std_dev=threshold_std_dev,
+        threshold_absolute=threshold_absolute,
+        absolute_area_threshold=absolute_area_threshold,
+        direction=direction,
+        smallest_grain_size_nm2=smallest_grain_size_nm2,
+        remove_edge_intersecting_grains=remove_edge_intersecting_grains,
+    )
+
+    grains_object.find_grains()
+
+    result_removed_small_objects = grains_object.directions[direction]["removed_small_objects"]
+
+    np.testing.assert_array_equal(result_removed_small_objects, expected_grain_mask)

--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -277,22 +277,6 @@ def test_high_dpi(minicircle_grain_gaussian_filter: Grains, plotting_config: dic
     return fig
 
 
-@pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
-def test_mask_dilation(plotting_config: dict, tmp_path: Path) -> None:
-    """Test the plotting of a mask with a different colourmap (blu)."""
-    plotting_config["mask_cmap"] = "blu"
-    mask = np.zeros((1024, 1024))
-    mask[500, :] = 1
-    fig, _ = Images(
-        data=RNG.random((1024, 1024)),
-        output_dir=tmp_path,
-        filename="mask_dilation",
-        masked_array=mask,
-        **plotting_config,
-    ).plot_and_save()
-    return fig
-
-
 @pytest.mark.parametrize(
     ("n", "expected"),
     [

--- a/tests/test_unet_masking.py
+++ b/tests/test_unet_masking.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from topostats.unet_masking import make_crop_square
+from topostats.unet_masking import make_crop_square, pad_bounding_box
 
 
 @pytest.mark.parametrize(
@@ -23,7 +23,40 @@ from topostats.unet_masking import make_crop_square
         pytest.param(6, 1, 8, 7, (10, 10), (2, 1, 8, 7), id="constrained bottom"),
     ],
 )
-def test_make_crop_square(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape, expected_indices):
+def test_make_crop_square(
+    crop_min_row: int,
+    crop_min_col: int,
+    crop_max_row: int,
+    crop_max_col: int,
+    image_shape: tuple[int, int],
+    expected_indices: tuple[int, int, int, int],
+):
     """Test the crop square method."""
     result = make_crop_square(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape)
+    assert result == expected_indices
+
+
+@pytest.mark.parametrize(
+    ("crop_min_row", "crop_min_col", "crop_max_row", "crop_max_col", "image_shape", "padding", "expected_indices"),
+    [
+        pytest.param(2, 2, 6, 6, (10, 10), 0, (2, 2, 6, 6), id="no padding"),
+        pytest.param(0, 0, 10, 10, (10, 10), 5, (0, 0, 10, 10), id="crop too big to be padded"),
+        pytest.param(2, 2, 6, 6, (10, 10), 2, (0, 0, 8, 8), id="padding 2, no obstruction"),
+        pytest.param(0, 4, 6, 8, (10, 10), 2, (0, 2, 8, 10), id="padding 2, obstruction top"),
+        pytest.param(4, 0, 8, 6, (10, 10), 2, (2, 0, 10, 8), id="padding 2, obstruction left"),
+        pytest.param(4, 4, 10, 6, (10, 10), 2, (2, 2, 10, 8), id="padding 2, obstruction bottom"),
+        pytest.param(4, 4, 6, 10, (10, 10), 2, (2, 2, 8, 10), id="padding 2, obstruction right"),
+    ],
+)
+def test_pad_bounding_box(
+    crop_min_row: int,
+    crop_min_col: int,
+    crop_max_row: int,
+    crop_max_col: int,
+    image_shape: tuple[int, int],
+    padding,
+    expected_indices,
+):
+    """Test the pad bounding box method."""
+    result = pad_bounding_box(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape, padding)
     assert result == expected_indices

--- a/tests/test_unet_masking.py
+++ b/tests/test_unet_masking.py
@@ -89,14 +89,14 @@ def test_iou_loss(
     np.testing.assert_allclose(result, expected_loss, atol=1e-5)
 
 
-def test_predict_unet(mock_model: MagicMock) -> None:
+def test_predict_unet(mock_model_5_by_5: MagicMock) -> None:
     """Test the predict_unet method."""
     image = np.array(
         [
             [0.1, 0.2, 0.1, 0.2, 0.1],
-            [0.1, 1.1, 1.2, 1.0, 0.2],
-            [0.2, 1.2, 0.3, 1.3, 0.2],
-            [0.1, 1.0, 1.2, 1.2, 0.1],
+            [0.1, 1.0, 1.0, 1.0, 0.1],
+            [0.2, 1.0, 1.0, 1.0, 0.2],
+            [0.1, 1.0, 1.0, 1.0, 0.1],
             [0.1, 0.1, 0.2, 0.2, 0.1],
         ]
     )
@@ -107,7 +107,7 @@ def test_predict_unet(mock_model: MagicMock) -> None:
 
     predicted_mask = predict_unet(
         image=image,
-        model=mock_model,
+        model=mock_model_5_by_5,
         confidence=confidence,
         model_input_shape=model_input_shape,
         upper_norm_bound=upper_norm_bound,
@@ -117,6 +117,18 @@ def test_predict_unet(mock_model: MagicMock) -> None:
     assert predicted_mask.shape == (5, 5)
     assert isinstance(predicted_mask, np.ndarray)
     assert predicted_mask.dtype == np.bool_
+    np.testing.assert_array_equal(
+        predicted_mask,
+        np.array(
+            [
+                [0, 0, 0, 0, 0],
+                [0, 1, 1, 1, 0],
+                [0, 1, 0, 1, 0],
+                [0, 1, 1, 1, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        ),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_unet_masking.py
+++ b/tests/test_unet_masking.py
@@ -1,0 +1,29 @@
+"""Test unet masking methods."""
+
+import pytest
+
+from topostats.unet_masking import make_crop_square
+
+
+@pytest.mark.parametrize(
+    ("crop_min_row", "crop_min_col", "crop_max_row", "crop_max_col", "image_shape", "expected_indices"),
+    [
+        pytest.param(0, 0, 100, 100, (100, 100), (0, 0, 100, 100), id="not a crop"),
+        pytest.param(3, 4, 8, 8, (10, 10), (3, 4, 8, 9), id="free space single min col decrease"),
+        pytest.param(4, 3, 8, 8, (10, 10), (4, 3, 9, 8), id="free space single min row decrease"),
+        pytest.param(4, 4, 7, 8, (10, 10), (4, 4, 8, 8), id="free space single max col increase"),
+        pytest.param(4, 4, 8, 7, (10, 10), (4, 4, 8, 8), id="free space single max row increase"),
+        pytest.param(4, 2, 8, 8, (10, 10), (3, 2, 9, 8), id="free space double min col decrease"),
+        pytest.param(2, 4, 8, 8, (10, 10), (2, 3, 8, 9), id="free space double min row decrease"),
+        pytest.param(4, 4, 8, 6, (10, 10), (4, 3, 8, 7), id="free space double max col increase"),
+        pytest.param(4, 4, 6, 8, (10, 10), (3, 4, 7, 8), id="free space double max row increase"),
+        pytest.param(1, 1, 6, 2, (10, 10), (1, 1, 6, 6), id="constrained left"),
+        pytest.param(1, 6, 7, 8, (10, 10), (1, 2, 7, 8), id="constrained right"),
+        pytest.param(1, 1, 2, 6, (10, 10), (1, 1, 6, 6), id="constrained top"),
+        pytest.param(6, 1, 8, 7, (10, 10), (2, 1, 8, 7), id="constrained bottom"),
+    ],
+)
+def test_make_crop_square(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape, expected_indices):
+    """Test the crop square method."""
+    result = make_crop_square(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape)
+    assert result == expected_indices

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -30,7 +30,7 @@ filter:
 grains:
   run: true # Options : true, false
   # Thresholding by height
-  threshold_method: std_dev # Options : std_dev, otsu, absolute
+  threshold_method: std_dev # Options : std_dev, otsu, absolute, unet
   otsu_threshold_multiplier: 1.0
   threshold_std_dev:
     below: 10.0 # Threshold for grains below the image background
@@ -45,6 +45,10 @@ grains:
     above: [300, 3000] # above surface [Low, High] in nm^2 (also takes null)
     below: [null, null] # below surface [Low, High] in nm^2 (also takes null)
   remove_edge_intersecting_grains: true # Whether or not to remove grains that touch the image border
+  unet_config:
+    model_path: null # Path to a trained U-Net model
+    upper_norm_bound: 5.0 # Upper bound for normalisation of input data. This should be slightly higher than the maximum desired / expected height of grains.
+    lower_norm_bound: -1.0 # Lower bound for normalisation of input data. This should be slightly lower than the minimum desired / expected height of the background.
 grainstats:
   run: true # Options : true, false
   edge_detection_method: binary_erosion # Options: canny, binary erosion. Do not change this unless you are sure of what this will do.

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -47,6 +47,7 @@ grains:
   remove_edge_intersecting_grains: true # Whether or not to remove grains that touch the image border
   unet_config:
     model_path: null # Path to a trained U-Net model
+    grain_crop_padding: 0 # Padding to apply to the grain crop bounding box
     upper_norm_bound: 5.0 # Upper bound for normalisation of input data. This should be slightly higher than the maximum desired / expected height of grains.
     lower_norm_bound: -1.0 # Lower bound for normalisation of input data. This should be slightly lower than the minimum desired / expected height of the background.
 grainstats:

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -73,7 +73,7 @@ class Grains:
         image: npt.NDArray,
         filename: str,
         pixel_to_nm_scaling: float,
-        unet_config: dict[str, str | int | float | None] | None = None,
+        unet_config: dict[str, str | int | float | tuple[int | None, int, int, int] | None] | None = None,
         threshold_method: str | None = None,
         otsu_threshold_multiplier: float | None = None,
         threshold_std_dev: dict | None = None,
@@ -532,3 +532,5 @@ class Grains:
                     self.directions[direction]["removed_small_objects"] = unet_mask
                     unet_labelled_regions = self.label_regions(unet_mask)
                     self.directions[direction]["labelled_regions_02"] = unet_labelled_regions
+
+                    LOGGER.info(f"[{self.filename}] : Overridden grains with UNet predictions ({direction})")

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -39,7 +39,7 @@ class Grains:
         File being processed (used in logging).
     pixel_to_nm_scaling : float
         Scaling of pixels to nanometres.
-    unet_config : dict
+    unet_config : dict[str, str | int | float | None]
         Configuration for the UNet model.
         model_path: str
             Path to the UNet model.
@@ -73,14 +73,14 @@ class Grains:
         image: npt.NDArray,
         filename: str,
         pixel_to_nm_scaling: float,
-        unet_config: dict[str, str],
-        threshold_method: str = None,
-        otsu_threshold_multiplier: float = None,
-        threshold_std_dev: dict = None,
-        threshold_absolute: dict = None,
-        absolute_area_threshold: dict = None,
-        direction: str = None,
-        smallest_grain_size_nm2: float = None,
+        unet_config: dict[str, str | int | float | None] | None = None,
+        threshold_method: str | None = None,
+        otsu_threshold_multiplier: float | None = None,
+        threshold_std_dev: dict | None = None,
+        threshold_absolute: dict | None = None,
+        absolute_area_threshold: dict | None = None,
+        direction: str | None = None,
+        smallest_grain_size_nm2: float | None = None,
         remove_edge_intersecting_grains: bool = True,
     ):
         """
@@ -94,7 +94,7 @@ class Grains:
             File being processed (used in logging).
         pixel_to_nm_scaling : float
             Scaling of pixels to nanometres.
-        unet_config : dict
+        unet_config : dict[str, str | int | float | None]
             Configuration for the UNet model.
             model_path: str
                 Path to the UNet model.
@@ -122,6 +122,13 @@ class Grains:
         remove_edge_intersecting_grains : bool
             Direction for which grains are to be detected, valid values are 'above', 'below' and 'both'.
         """
+        if unet_config is None:
+            unet_config = {
+                "model_path": None,
+                "grain_crop_padding": 0,
+                "upper_norm_bound": 1.0,
+                "lower_norm_bound": 0.0,
+            }
         if absolute_area_threshold is None:
             absolute_area_threshold = {"above": [None, None], "below": [None, None]}
         self.image = image

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -334,13 +334,6 @@ class Images:
             )
             if isinstance(self.masked_array, np.ndarray):
                 self.masked_array[self.masked_array != 0] = 1
-                # If the image is too large for singles to be resolved in the mask, then dilate the mask proportionally
-                # to image size to enable clear viewing.
-                if np.max(self.masked_array.shape) > 500:
-                    dilation_strength = int(np.max(self.masked_array.shape) / 256)
-                    self.masked_array = dilate_binary_image(
-                        binary_image=self.masked_array, dilation_iterations=dilation_strength
-                    )
                 mask = np.ma.masked_where(self.masked_array == 0, self.masked_array)
                 ax.imshow(
                     mask,

--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -82,3 +82,42 @@ def make_crop_square(
         new_crop_max_col = crop_max_col
 
     return new_crop_min_row, new_crop_min_col, new_crop_max_row, new_crop_max_col
+
+
+def pad_bounding_box(
+    crop_min_row: int,
+    crop_min_col: int,
+    crop_max_row: int,
+    crop_max_col: int,
+    image_shape: tuple[int, int],
+    padding: int,
+) -> tuple[int, int, int, int]:
+    """
+    Pad a bounding box.
+
+    Parameters
+    ----------
+    crop_min_row : int
+        The minimum row index of the crop.
+    crop_min_col : int
+        The minimum column index of the crop.
+    crop_max_row : int
+        The maximum row index of the crop.
+    crop_max_col : int
+        The maximum column index of the crop.
+    image_shape : tuple[int, int]
+        The shape of the image.
+    padding : int
+        The padding to apply to the bounding box.
+
+    Returns
+    -------
+    tuple[int, int, int, int]
+        The new crop indices.
+    """
+    new_crop_min_row = max(0, crop_min_row - padding)
+    new_crop_min_col = max(0, crop_min_col - padding)
+    new_crop_max_row = min(image_shape[0], crop_max_row + padding)
+    new_crop_max_col = min(image_shape[1], crop_max_col + padding)
+
+    return new_crop_min_row, new_crop_min_col, new_crop_max_row, new_crop_max_col

--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -1,0 +1,84 @@
+"""Segment grains using a U-Net model."""
+
+
+def make_crop_square(
+    crop_min_row: int, crop_min_col: int, crop_max_row: int, crop_max_col: int, image_shape: tuple[int, int]
+) -> tuple[int, int, int, int]:
+    """
+    Make a crop square.
+
+    Parameters
+    ----------
+    crop_min_row : int
+        The minimum row index of the crop.
+    crop_min_col : int
+        The minimum column index of the crop.
+    crop_max_row : int
+        The maximum row index of the crop.
+    crop_max_col : int
+        The maximum column index of the crop.
+    image_shape : tuple[int, int]
+        The shape of the image.
+
+    Returns
+    -------
+    tuple[int, int, int, int]
+        The new crop indices.
+    """
+    crop_height = crop_max_row - crop_min_row
+    crop_width = crop_max_col - crop_min_col
+
+    diff: int
+    new_crop_min_row: int
+    new_crop_min_col: int
+    new_crop_max_row: int
+    new_crop_max_col: int
+
+    if crop_height > crop_width:
+        # The crop is taller than it is wide
+        diff = crop_height - crop_width
+        # Check if we can expand equally in each direction
+        if crop_min_col - diff // 2 >= 0 and crop_max_col + diff - diff // 2 < image_shape[1]:
+            new_crop_min_col = crop_min_col - diff // 2
+            new_crop_max_col = crop_max_col + diff - diff // 2
+        # If we can't expand uniformly, expand in just one direction
+        # Check if we can expand right
+        elif crop_max_col + diff - diff // 2 < image_shape[1]:
+            # We can expand right
+            new_crop_min_col = crop_min_col
+            new_crop_max_col = crop_max_col + diff
+        elif crop_min_col - diff // 2 >= 0:
+            # We can expand left
+            new_crop_min_col = crop_min_col - diff
+            new_crop_max_col = crop_max_col
+        # Set the new crop height to the original crop height since we are just updating the width
+        new_crop_min_row = crop_min_row
+        new_crop_max_row = crop_max_row
+    elif crop_width > crop_height:
+        # The crop is wider than it is tall
+        diff = crop_width - crop_height
+        # Check if we can expand equally in each direction
+        if crop_min_row - diff // 2 >= 0 and crop_max_row + diff - diff // 2 < image_shape[0]:
+            new_crop_min_row = crop_min_row - diff // 2
+            new_crop_max_row = crop_max_row + diff - diff // 2
+        # If we can't expand uniformly, expand in just one direction
+        # Check if we can expand down
+        elif crop_max_row + diff - diff // 2 < image_shape[0]:
+            # We can expand down
+            new_crop_min_row = crop_min_row
+            new_crop_max_row = crop_max_row + diff
+        elif crop_min_row - diff // 2 >= 0:
+            # We can expand up
+            new_crop_min_row = crop_min_row - diff
+            new_crop_max_row = crop_max_row
+        # Set the new crop width to the original crop width since we are just updating the height
+        new_crop_min_col = crop_min_col
+        new_crop_max_col = crop_max_col
+    else:
+        # If the crop is already square, return the original crop
+        new_crop_min_row = crop_min_row
+        new_crop_min_col = crop_min_col
+        new_crop_max_row = crop_max_row
+        new_crop_max_col = crop_max_col
+
+    return new_crop_min_row, new_crop_min_col, new_crop_max_row, new_crop_max_col

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -181,6 +181,7 @@ DEFAULT_CONFIG_SCHEMA = Schema(
             ),
             "unet_config": {
                 "model_path": str,
+                "grain_crop_padding": int,
                 "upper_norm_bound": float,
                 "lower_norm_bound": float,
             },

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -180,7 +180,7 @@ DEFAULT_CONFIG_SCHEMA = Schema(
                 error="Invalid value in config for 'grains.remove_edge_intersecting_grains', valid values are 'True' or 'False'",
             ),
             "unet_config": {
-                "model_path": str,
+                "model_path": Or(None, str),
                 "grain_crop_padding": int,
                 "upper_norm_bound": float,
                 "lower_norm_bound": float,

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -179,6 +179,11 @@ DEFAULT_CONFIG_SCHEMA = Schema(
                 False,
                 error="Invalid value in config for 'grains.remove_edge_intersecting_grains', valid values are 'True' or 'False'",
             ),
+            "unet_config": {
+                "model_path": str,
+                "upper_norm_bound": float,
+                "lower_norm_bound": float,
+            },
         },
         "grainstats": {
             "run": Or(


### PR DESCRIPTION
This PR adds barebones functionality for re-segmenting grains detected in the `find_grains()` function using a pre-trained U-Net provided by the user.