### PR TITLE
test(utils): Fixing broken tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,6 +84,7 @@ def test_update_plotting_config(
                     "extracted_channel": {
                         "filename": "00-raw_heightmap",
                         "image_type": "non-binary",
+                        "core_set": False,
                         "savefig_dpi": 100,
                     }
                 },
@@ -97,6 +98,7 @@ def test_update_plotting_config(
                         "filename": "00-raw_heightmap",
                         "image_type": "non-binary",
                         "savefig_dpi": 100,
+                        "core_set": False,
                         "pixel_interpolation": None,
                     }
                 },
@@ -113,6 +115,7 @@ def test_update_plotting_config(
                         "filename": "00-raw_heightmap",
                         "image_type": "non-binary",
                         "savefig_dpi": 100,
+                        "core_set": False,
                     }
                 },
             },
@@ -125,6 +128,7 @@ def test_update_plotting_config(
                         "filename": "00-raw_heightmap",
                         "image_type": "non-binary",
                         "savefig_dpi": 600,
+                        "core_set": False,
                         "pixel_interpolation": None,
                     }
                 },
@@ -182,8 +186,8 @@ def test_create_empty_dataframe() -> None:
     """Test the empty dataframe is created correctly."""
     empty_df = create_empty_dataframe(ALL_STATISTICS_COLUMNS)
 
-    assert empty_df.index.name == "molecule_number"
-    assert "molecule_number" not in empty_df.columns
+    assert empty_df.index.name == "grain_number"
+    assert "grain_number" not in empty_df.columns
     assert empty_df.shape == (0, 26)
     assert {"image", "basename", "area"}.intersection(empty_df.columns)
 

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -128,7 +128,11 @@ def update_plotting_config(plotting_config: dict) -> dict:
         LOGGER.debug(f"Dictionary for image : {image}")
         LOGGER.debug(f"{pformat(options, indent=4)}")
         # First update options with values that exist in main_config
-        if not plotting_config["plot_dict"][image]["core_set"]:  # avoids updating colourmap for diagnostic images
+        # We must however be careful not to update the colourmap for diagnostic traces
+        if (
+            not plotting_config["plot_dict"][image]["core_set"]
+            and "mask_cmap" in plotting_config["plot_dict"][image].keys()
+        ):
             main_config_temp.pop("mask_cmap")
         plotting_config["plot_dict"][image] = update_config(options, main_config_temp)
         LOGGER.debug(f"Updated values :\n{pformat(plotting_config['plot_dict'][image])}")


### PR DESCRIPTION
+ `test_create_empty_dataframe()` didn't have `molecule_number` reverted to `grain_number`.
+ `topostats.utils.update_plotting_config()` had a clause which only checked if an image was in the `core_set` and failed if it then didn't have a `mask_cmap` entry.