### PR TITLE
tests(plottingfuncs): fixes failing tests

### DIFF
--- a/tests/test_plottingfuncs.py
+++ b/tests/test_plottingfuncs.py
@@ -253,7 +253,7 @@ def test_plot_and_save_non_square_bounding_box(
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_mask_cmap(plotting_config: dict, tmp_path: Path) -> None:
     """Test the plotting of a mask with a different colourmap (blu)."""
-    plotting_config["mask_cmap"] = "blu"
+    plotting_config["mask_cmap"] = "blue"
     fig, _ = Images(
         data=ARRAY,
         output_dir=tmp_path,
@@ -280,7 +280,7 @@ def test_high_dpi(minicircle_grain_gaussian_filter: Grains, plotting_config: dic
 @pytest.mark.mpl_image_compare(baseline_dir="resources/img/")
 def test_mask_dilation(plotting_config: dict, tmp_path: Path) -> None:
     """Test the plotting of a mask with a different colourmap (blu)."""
-    plotting_config["mask_cmap"] = "blu"
+    plotting_config["mask_cmap"] = "blue"
     mask = np.zeros((1024, 1024))
     mask[500, :] = 1
     fig, _ = Images(

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -18,17 +18,12 @@ import topostats
 from topostats.logs.logs import LOGGER_NAME
 from topostats.theme import Colormap
 
+# pylint: disable=dangerous-default-value
+# pylint: disable=too-many-arguments
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-locals
-# pylint: disable=too-many-arguments
-# pylint: disable=dangerous-default-value
 
 LOGGER = logging.getLogger(LOGGER_NAME)
-
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=too-many-arguments
-# pylint: disable=too-many-locals
-# pylint: disable=dangerous-default-value
 
 
 def add_pixel_to_nm_to_plotting_config(plotting_config: dict, pixel_to_nm_scaling: float) -> dict:


### PR DESCRIPTION
First of a series of PRs that will restore the tests that are failing from `tests/test_plottingfuncs.py`.

+ `blu` > `blue` in `test_mask_dilation()` and `test_mask_cmap()` to reflect change in `topostats/theme.py`
+ deduplicate `# pylint: disable` from `topostats/plottingfuncs.py`

I'm looking to adopt the [Stacked PRs workflow](https://www.git-tower.com/blog/stacked-prs/) to help keep the burden of each Pull Request low and speed up the review process so will be making changes on top of these.

