### PR TITLE
tests(plottingfuncs): revert plotting_config fixture in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,7 @@ def plotting_config(default_config: dict) -> dict:
     """Configurations for plotting."""
     config = default_config["plotting"]
     config["image_set"] = "all"
+    config["zrange"] = [None, None]
     config.pop("run")
     config.pop("plot_dict")
     return config


### PR DESCRIPTION
The tests were developed with a value of `zrange: [null, null]` but in this branch the `default_config.yaml` has been modified to `zrange: [-2, 6]` which results in six tests failing. The `plotting_config` fixture (defined in `tests/conftest.py`) therefore reverts this value and the failing tests pass.

This does raise a couple of issues.

1. What should the defaults be in the `main` branch and in releases?

When developing features and testing new code it may be desirable to use custom configurations but what should we be using as defaults for releases? What set of values works best for _most_ use cases?

2. Use `--config <custom_config>.yaml`

Directly related to this is that we should not be changing values in `default_config.yaml` when undertaking development. Rather we should use the `--config` flag with a custom configuration 
file. When new options need adding that isn't a problem to add them to `default_config.yaml` but when modifying values it is _important to ensure all tests pass_.

It can take some time to track down and work out the root cause of these test failures!