### PR TITLE
tests: Remove restriction on pytest<8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "AFMReader",
   "h5py",
   "igor2",
+  "keras",
   "matplotlib",
   "numpy",
   "numpyencoder",
@@ -54,16 +55,14 @@ dependencies = [
   "snoop",
   "tifffile",
   "tqdm",
-  "keras",
   "tensorflow",
 ]
 
 [project.optional-dependencies]
 tests = [
-  "pytest<8.0.0",
+  "pytest",
   "pytest-cov",
   "pytest-github-actions-annotate-failures",
-  "pytest-lazy-fixture",
   "pytest-mpl",
   "pytest-regtest",
   "filetype",


### PR DESCRIPTION
Closes #915

Switches to using `request.getfixturevalue()` and removes dependency on `pytest-lazy-fixture`.

Other things addressed...

+ Adds `pytest.param()` to each test in `tests/tracing/test_dnatracing_single_grain.py` along with `id` argument.
+ Orders dependencies alphabetically in `pyproject.toml` for ease of reading/searching.