### PR TITLE
tests: Remove restriction on pytest<8.0.0 (cherry pick)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ requires-python = ">=3.9"
 dependencies = [
   "h5py",
   "igor2",
+  "keras",
   "matplotlib",
   "numpy",
   "pandas",
@@ -54,14 +55,14 @@ dependencies = [
   "tifffile",
   "AFMReader",
   "tqdm",
+  "tensorflow",
 ]
 
 [project.optional-dependencies]
 tests = [
-  "pytest<8.0.0",
+  "pytest",
   "pytest-cov",
   "pytest-github-actions-annotate-failures",
-  "pytest-lazy-fixture",
   "pytest-mpl",
   "pytest-regtest",
   "filetype",


### PR DESCRIPTION
Cherry pick cecf60fbabe17b12927284b2b5099e5c4c092c4d which removes the restriction of `pytest<8.0.0` and switches to usine `request.getfixturevalue()` for parameterised tests that use fixtures

This is a prelude to fixing these failing tests.