### PR TITLE
ci: restrict supported python version to <3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
   "afm",
   "image processing"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.12"
 dependencies = [
   "h5py",
   "igor2",


### PR DESCRIPTION
Closes #930

Once Topoly performance regression has been resolved we should unpin this upper bound and ideally support upto Python 3.13.