### PR TITLE
ci: Explicit types of pull requests and paths to run CI tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,21 @@
 name: Tests (pytest)
 
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    paths:
+      - "**.csv"
+      - "**.npy"
+      - "**.out"
+      - "**.pkl"
+      - "**.png"
+      - "**.py"
+      - "**.toml"
+      - "**.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Further to #925 it seems that not all pull requests are triggering the `tests.yaml` workflow.

| PR   | Triggered | Workflow            |
|:-----|:----------|:--------------------|
| #925 | :white_check_mark: | [CI Run](https://github.com/AFM-SPM/TopoStats/actions/runs/11123369831?pr=925) |
| #926 | :white_check_mark: | [CI Run](https://github.com/AFM-SPM/TopoStats/actions/runs/11126129773?pr=926) |
| #932 | :x:       | N/A                 |

Not clear why #932 didn't trigger the `tests.yaml` workflow so this PR makes explicit the `type` of activity on `pull_request` that should trigger the event as well as explicitly stating the types of files that should trigger the tests via the `paths` option (as changes to e.g. `*.md` (Markdown) files are never going to affect the outcome of tests.