### PR TITLE
Add topostats file helper class

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1291,3 +1291,45 @@ class TopoFileHelper:
         self.topofile: Path = Path(topofile)
         with h5py.File(self.topofile, "r") as f:
             self.data: dict = hdf5_to_dict(open_hdf5_file=f, group_path="/")
+    def find_data(self, search_keys: list) -> None:
+        """
+        Find the data in the dictionary that matches the list of keys.
+
+        Parameters
+        ----------
+        search_keys : list
+            The list of keys to search for.
+
+        Returns
+        -------
+        None
+        """
+        # Find the best match for the list of keys
+        # First check if there is a direct match
+        LOGGER.info(f"[ Searching for {search_keys} in {self.topofile} ]")
+
+        try:
+            current_data = self.data
+            for key in search_keys:
+                current_data = current_data[key]
+
+            LOGGER.info("| [search] Direct match found")
+        except KeyError:
+            LOGGER.info("| [search] No direct match found.")
+
+        # If no direct match is found, try to find a partial match
+        LOGGER.info("| [search] Searching for partial matches.")
+        partial_matches = self.search_partial_matches(data=self.data, keys=search_keys)
+        if partial_matches:
+            LOGGER.info(f"| [search] !! [ {len(partial_matches)} Partial matches found] !!")
+            for index, match in enumerate(partial_matches):
+                match_str = "/".join(match)
+                if index == len(partial_matches) - 1:
+                    prefix = "| [search] └"
+                else:
+                    prefix = "| [search] ├"
+                LOGGER.info(f"{prefix} {match_str}")
+        else:
+            LOGGER.info("| [search] No partial matches found.")
+        LOGGER.info("└ [End of search]")
+        return

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1333,3 +1333,44 @@ class TopoFileHelper:
             LOGGER.info("| [search] No partial matches found.")
         LOGGER.info("└ [End of search]")
         return
+    def data_info(self, location: str, verbose: bool = False) -> None:
+        """Get information about the data at a location.
+
+        Parameters
+        ----------
+        location : str
+            The location of the data in the dictionary, separated by '/'.
+        """
+        # If there's a trailing '/', remove it
+        if location[-1] == "/":
+            location = location[:-1]
+        keys = location.split("/")
+
+        try:
+            current_data = self.data
+            for key in keys:
+                current_data = current_data[key]
+        except KeyError as e:
+            LOGGER.error(f"[ Info ] Key not found: {e}, please check the location string.")
+            return
+
+        if isinstance(current_data, dict):
+            key_types = {type(k) for k in current_data.keys()}
+            value_types = {type(v) for v in current_data.values()}
+            LOGGER.info(
+                f"[ Info ] Data at {location} is a dictionary with {len(current_data)} "
+                f"keys of types {key_types} and values "
+                f"of types {value_types}"
+            )
+            if verbose:
+                for k, v in current_data.items():
+                    LOGGER.info(f"  {k}: {type(v)}")
+        elif isinstance(current_data, np.ndarray):
+            LOGGER.info(
+                f"[ Info ] Data at {location} is a numpy array with shape: {current_data.shape}, "
+                f"dtype: {current_data.dtype}"
+            )
+        else:
+            LOGGER.info(f"[ Info ] Data at {location} is {type(current_data)}")
+
+        return

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1284,3 +1284,10 @@ def dict_to_json(data: dict, output_dir: str | Path, filename: str | Path, inden
     output_file = output_dir / filename
     with output_file.open("w") as f:
         json.dump(data, f, indent=indent, cls=NumpyEncoder)
+
+
+class TopoFileHelper:
+    def __init__(self, topofile: Path | str):
+        self.topofile: Path = Path(topofile)
+        with h5py.File(self.topofile, "r") as f:
+            self.data: dict = hdf5_to_dict(open_hdf5_file=f, group_path="/")

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1333,6 +1333,34 @@ class TopoFileHelper:
             LOGGER.info("| [search] No partial matches found.")
         LOGGER.info("└ [End of search]")
         return
+    def get_data(self, location: str) -> int | float | str | np.ndarray | dict | None:
+        """
+        Retrieve data from the dictionary using a '/' separated string.
+
+        Parameters
+        ----------
+        location : str
+            The location of the data in the dictionary, separated by '/'.
+
+        Returns
+        -------
+        int | float | str | np.ndarray | dict
+            The data at the location.
+        """
+        # If there's a trailing '/', remove it
+        if location[-1] == "/":
+            location = location[:-1]
+        keys = location.split("/")
+
+        try:
+            current_data = self.data
+            for key in keys:
+                current_data = current_data[key]
+            LOGGER.info(f"[ Get data ] Data found at {location}, type: {type(current_data)}")
+            return current_data
+        except KeyError as e:
+            LOGGER.error(f"[ Get data ] Key not found: {e}, please check the location string.")
+            return None
     def data_info(self, location: str, verbose: bool = False) -> None:
         """Get information about the data at a location.
 


### PR DESCRIPTION
This PR would add a small helper class in `topostats.io` to assist users that want to explore & retrieve data contained in `.topostats` files, as we have had feedback from the experimentalists that navigating the `.hdf5` file structure is prohibitively complex / difficult to do manually.

Previously, to load the file in a notebook, one had to:
```python
from pathlib import Path

import h5py

from topostats.io import hdf5_to_dict


file = Path("./path/to/file.topostats")
with h5py.File(file, "r") as f:
    data_dict = hdf5_to_dict(f, "/")

# Then try to manually navigate the dictionary to find the specific item wanted
data = data_dict["ordered_trace_heights"]["0"]
# get the keys wrong
>>> ValueError
# manually print keys at each level, akin to doing lots of ls, cd
print(data_dict.keys())
data = data_dict["grain_trace_data"]
print(data.keys())
.
.
.
```

The TopoFileHelper class adds some methods to help with this:
- `pretty_print_structure()` will print the entire structure (but not messy dictionaries of arrays!):
```
[./tests/resources/file.topostats]
├ filename
│   └ minicircle
├ grain_masks
│   └ above
│       └ Numpy array, shape: (1024, 1024), dtype: int64
├ grain_trace_data
│   └ above
│       ├ cropped_images
│       │   └ 21 keys with numpy arrays as values
│       ├ ordered_trace_cumulative_distances
│       │   └ 21 keys with numpy arrays as values
│       ├ ordered_trace_heights
│       │   └ 21 keys with numpy arrays as values
│       ├ ordered_traces
│       │   └ 21 keys with numpy arrays as values
│       └ splined_traces
│           └ 21 keys with numpy arrays as values
├ image
│   └ Numpy array, shape: (1024, 1024), dtype: float64
├ image_original
│   └ Numpy array, shape: (1024, 1024), dtype: float64
├ img_path
│   └ /Users/sylvi/Documents/TopoStats/tests/resources/minicircle
├ pixel_to_nm_scaling
│   └ 0.4940029296875
└ topostats_file_version
    └ 0.2
```
- `find_data()` will perform a strict search for the keys (given in a list) and if no match is found, perform a partial search to find possible matches that the user intended. Eg:
```python
topofilehelper.find_data(["ordered_trace_heights", "0"])
```
```
 [ Searching for ['ordered_trace_heights', '0'] in ./tests/resources/file.topostats ]
 | [search] No direct match found.
 | [search] Searching for partial matches.
 | [search] !! [ 1 Partial matches found] !!
 | [search] └ grain_trace_data/above/ordered_trace_heights/0
 └ [End of search]
```
- `get_data()` Simply retries data when provided with a key string separated by "/"s:
```python
ordered_trace_heights = topofilehelper.get_data("grain_trace_data/above/ordered_trace_heights/0")
```
- `data_info()` Prints a little information about the value at a specific key:
```python
topofilehelper.data_info("grain_trace_data/above/ordered_trace_heights/0")
topofilehelper.data_info("grain_trace_data/above/ordered_trace_heights")
```
```
Data at grain_trace_data/above/ordered_trace_heights/0 is a numpy array with shape: (95,), dtype: float64
Data at grain_trace_data/above/ordered_trace_heights is a dictionary with 21 keys of types {<class 'str'>} and values of types {<class 'numpy.ndarray'>}
```

No tests yet, would want feedback first

