### PR TITLE
ci: Adds tmate to tests.yaml workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,3 +51,8 @@ jobs:
           coverage xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 5


### PR DESCRIPTION
Resolves #896

Adds [debugging with tmate](https://github.com/marketplace/actions/debugging-with-tmate) action to `tests.yaml` which
allows SSHing into GitHub Runners _if_ tests have failed.