### PR TITLE
fix: docutils<0.21; unpin sphinx-autoapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,11 @@ tests = [
 ]
 docs = [
   "Sphinx",
+  "docutils<0.21",
   "myst_parser",
   "numpydoc",
   "pydata_sphinx_theme",
-  "sphinx-autoapi==3.1.0b0",
+  "sphinx-autoapi",
   "sphinx-autodoc-typehints",
   "sphinx-multiversion",
   "sphinx_markdown_tables",


### PR DESCRIPTION
Questing to solve the issues with pages failing to build I'm trying removing the `sphinx-autoapi` pinned version and at the same time ensuring `docutils<0.21` are installed as part of the docs dependencies. :crossed_fingers: