### PR TITLE
Fixes `pd.concat` error halting processing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,10 +254,16 @@ The output from running TopoStats is saved in the location defined in the config
 default is the directory `output` within the directory from which `topostats process`. This may differ if you have
 used your own customised configuration file (specifically if you have modified the `output_dir:` option).
 
-At the top level of the output directory are two files `config.yaml` and `all_statistics.csv`
+At the top level of the output directory are a few files produced:
 
 - `config.yaml` : a copy of the configuration used to process the images.
-- `all_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the grain and DNA tracing statistics.
+- `all_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the grain statistics.
+- `all_disordered_segment_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the branched skeleton
+  statistics.
+- `all_mol_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the molecule statistics.
+
+**Note:** - If all grains / branch segments of a column have a `None` or `NaN` value, the column will not be present in
+the output `.csv` file.
 
 The remaining directories of results is contingent on the structure of files within the `base_dir` that is specified in
 the configuration. If all files are in the top-level directory (i.e. no nesting) then you will have just a `Processed`
@@ -281,7 +287,10 @@ one under `level1/a`...
 ```bash
 [4.0K Nov 15 14:06]  output
 |-- [ 381 Nov 15 14:06]  output/all_statistics.csv
+|-- [ 733 Nov 15 14:06]  output/all_disordered_tracing_statistics.csv
+|-- [ 254 Nov 15 14:06]  output/all_mol_statistics.csv
 |-- [7.4K Nov 15 14:06]  output/config.yaml
+|-- [ 222 Nov 15 14:06]  output/image_stats.csv
 |-- [4.0K Nov 15 14:06]  output/level1
 |   |-- [4.0K Nov 15 14:06]  output/level1/a
 |   |   |-- [4.0K Nov 15 14:06]  output/level1/a/Processed

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -461,7 +461,7 @@ def test_save_folder_grainstats(tmp_path: Path) -> None:
     test_df["basename"] = input_path
     out_path = tmp_path / "subfolder"
     Path.mkdir(out_path, parents=True)
-    save_folder_grainstats(out_path, input_path, test_df)
+    save_folder_grainstats(out_path, input_path, test_df, "grainstats")
     assert Path(out_path / "processed" / "folder_grainstats.csv").exists()
 
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -323,7 +323,9 @@ def find_files(base_dir: str | Path = None, file_ext: str = ".spm") -> list:
     return list(base_dir.glob("**/*" + file_ext))
 
 
-def save_folder_grainstats(output_dir: str | Path, base_dir: str | Path, all_stats_df: pd.DataFrame) -> None:
+def save_folder_grainstats(
+    output_dir: str | Path, base_dir: str | Path, all_stats_df: pd.DataFrame, stats_filename: str
+) -> None:
     """
     Save a data frame of grain and tracing statistics at the folder level.
 
@@ -335,6 +337,8 @@ def save_folder_grainstats(output_dir: str | Path, base_dir: str | Path, all_sta
         Path of the base directory where files were found.
     all_stats_df : pd.DataFrame
         The dataframe containing all sample statistics run.
+    stats_filename : str
+        The name of the type of statistics dataframe to be saved.
 
     Returns
     -------
@@ -352,9 +356,9 @@ def save_folder_grainstats(output_dir: str | Path, base_dir: str | Path, all_sta
                 out_path_processed = out_path / "processed"
                 out_path_processed.mkdir(parents=True, exist_ok=True)
             all_stats_df[all_stats_df["basename"] == _dir].to_csv(
-                out_path / "processed" / "folder_grainstats.csv", index=True
+                out_path / "processed" / f"folder_{stats_filename}.csv", index=True
             )
-            LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/folder_grainstats.csv")
+            LOGGER.info(f"Folder-wise statistics saved to: {str(out_path)}/folder_{stats_filename}.csv")
         except TypeError:
             LOGGER.info(f"No folder-wise statistics for directory {_dir}, no grains detected in any images.")
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -32,7 +32,6 @@ from topostats.utils import create_empty_dataframe
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-statements
 # pylint: disable=too-many-nested-blocks
-# pylint: disable=too-many-positional-arguments
 # pylint: disable=unnecessary-dict-index-lookup
 # pylint: disable=too-many-lines
 
@@ -493,11 +492,12 @@ def run_disordered_trace(
                 f"[{filename}] : Disordered tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
+            # add the columns which should have been added
+            grainstats_df.reindex(columns=["grain_endpoints", "grain_junctions", "total_branch_length"])
             return {}, grainstats_df, None
 
-    else:
-        LOGGER.info(f"[{filename}] Calculation of Disordered Tracing disabled, returning empty dictionary.")
-        return {}, grainstats_df, None
+    LOGGER.info(f"[{filename}] Calculation of Disordered Tracing disabled, returning empty dictionary.")
+    return None, grainstats_df, None
 
 
 def run_nodestats(  # noqa: C901
@@ -631,11 +631,12 @@ def run_nodestats(  # noqa: C901
             LOGGER.info(
                 f"[{filename}] : NodeStats failed - skipping. Consider raising an issue on GitHub. Error: ", exc_info=e
             )
-            return nodestats_whole_data, nodestats_grainstats
+            # add the columns which should have been added
+            grainstats_df.reindex(columns=["num_crossings", "avg_crossing_confidence", "min_crossing_confidence"])
+            return nodestats_whole_data, grainstats_df
 
-    else:
-        LOGGER.info(f"[{filename}] : Calculation of nodestats disabled, returning empty dataframe.")
-        return None, grainstats_df
+    LOGGER.info(f"[{filename}] : Calculation of nodestats disabled, returning empty dataframe.")
+    return None, grainstats_df
 
 
 # need to add in the molstats here
@@ -759,8 +760,11 @@ def run_ordered_tracing(
                 f"[{filename}] : Ordered Tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
+            # add the columns which should have been added
+            grainstats_df.reindex(columns=["num_molecules", "circular", "writhe_string"])
             return ordered_tracing_image_data, grainstats_df, None
 
+    LOGGER.info(f"[{filename}] : Calculation of ordered_tracing disabled, returning empty dataframe.")
     return None, grainstats_df, None
 
 
@@ -878,9 +882,12 @@ def run_splining(
             LOGGER.error(
                 f"[{filename}] : Splining failed - skipping. Consider raising an issue on GitHub. Error: ", exc_info=e
             )
-            return splined_image_data, splining_grainstats, splining_molstats
+            # add the columns which should have been added
+            grainstats_df.reindex(columns=["total_contour_length", "average_end_to_end_distance"])
+            return splined_image_data, grainstats_df, splining_molstats
 
-    return None, grainstats_df, molstats_df
+    LOGGER.info(f"[{filename}] : Calculation of Splining disabled, returning empty dataframe.")
+    return None, grainstats_df, None
 
 
 def get_out_paths(image_path: Path, base_dir: Path, output_dir: Path, filename: str, plotting_config: dict):

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -492,8 +492,6 @@ def run_disordered_trace(
                 f"[{filename}] : Disordered tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
-            # add the columns which should have been added
-            grainstats_df.reindex(columns=["grain_endpoints", "grain_junctions", "total_branch_length"])
             return {}, grainstats_df, None
 
     LOGGER.info(f"[{filename}] Calculation of Disordered Tracing disabled, returning empty dictionary.")
@@ -631,8 +629,6 @@ def run_nodestats(  # noqa: C901
             LOGGER.info(
                 f"[{filename}] : NodeStats failed - skipping. Consider raising an issue on GitHub. Error: ", exc_info=e
             )
-            # add the columns which should have been added
-            grainstats_df.reindex(columns=["num_crossings", "avg_crossing_confidence", "min_crossing_confidence"])
             return nodestats_whole_data, grainstats_df
 
     LOGGER.info(f"[{filename}] : Calculation of nodestats disabled, returning empty dataframe.")
@@ -760,11 +756,8 @@ def run_ordered_tracing(
                 f"[{filename}] : Ordered Tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
-            # add the columns which should have been added
-            grainstats_df.reindex(columns=["num_molecules", "circular", "writhe_string"])
             return ordered_tracing_image_data, grainstats_df, None
 
-    LOGGER.info(f"[{filename}] : Calculation of ordered_tracing disabled, returning empty dataframe.")
     return None, grainstats_df, None
 
 
@@ -882,11 +875,8 @@ def run_splining(
             LOGGER.error(
                 f"[{filename}] : Splining failed - skipping. Consider raising an issue on GitHub. Error: ", exc_info=e
             )
-            # add the columns which should have been added
-            grainstats_df.reindex(columns=["total_contour_length", "average_end_to_end_distance"])
             return splined_image_data, grainstats_df, splining_molstats
 
-    LOGGER.info(f"[{filename}] : Calculation of Splining disabled, returning empty dataframe.")
     return None, grainstats_df, None
 
 

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -148,13 +148,13 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
                 processing_function,
                 scan_data_dict.values(),
             ):
-                results[str(img)] = result
-                disordered_trace_results[str(img)] = disordered_trace_result
-                mols_results[str(img)] = mols_result
+                results[str(img)] = result.dropna(axis=1, how="all")
+                disordered_trace_results[str(img)] = disordered_trace_result.dropna(axis=1, how="all")
+                mols_results[str(img)] = mols_result.dropna(axis=1, how="all")
                 pbar.update()
 
                 # Add the dataframe to the results dict
-                image_stats_all[str(img)] = individual_image_stats_df
+                image_stats_all[str(img)] = individual_image_stats_df.dropna(axis=1, how="all")
 
                 # Combine all height profiles
                 height_profile_all[str(img)] = height_profiles

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -177,7 +177,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
     try:
         disordered_trace_results = pd.concat(disordered_trace_results.values())
     except ValueError as error:
-        LOGGER.error("No disordered traces found in any images, consider adjusting disordered tracing parameters.")
+        LOGGER.error("No skeletons found in any images, consider adjusting disordered tracing parameters.")
         LOGGER.error(error)
 
     try:
@@ -254,7 +254,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         images_processed = len(results["image"].unique())
     else:
         images_processed = 0
-        LOGGER.warning("There are no grainstats or dnatracing statistics to write to CSV.")
+        LOGGER.warning("There are no grainstats statistics to write to CSV.")
 
     if isinstance(disordered_trace_results, pd.DataFrame) and not disordered_trace_results.isna().values.all():
         disordered_trace_results.reset_index(inplace=True)
@@ -265,7 +265,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         )
         disordered_trace_results.reset_index(inplace=True)  # So we can access unique image names
     else:
-        LOGGER.warning("There are no grainstats or disordered tracing statistics to write to CSV.")
+        LOGGER.warning("There are no disordered tracing statistics to write to CSV.")
 
     if isinstance(mols_results, pd.DataFrame) and not mols_results.isna().values.all():
         mols_results.reset_index(drop=True, inplace=True)
@@ -274,7 +274,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         save_folder_grainstats(config["output_dir"], config["base_dir"], mols_results, "mol_stats")
         mols_results.reset_index(inplace=True)  # So we can access unique image names
     else:
-        LOGGER.warning("There are no grainstats or molecule tracing statistics to write to CSV.")
+        LOGGER.warning("There are no molecule tracing statistics to write to CSV.")
     # Write config to file
     config["plotting"].pop("plot_dict")
     write_yaml(config, output_dir=config["output_dir"])

--- a/topostats/run_topostats.py
+++ b/topostats/run_topostats.py
@@ -249,7 +249,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         results.reset_index(inplace=True)
         results.set_index(["image", "threshold", "grain_number"], inplace=True)
         results.to_csv(config["output_dir"] / "all_statistics.csv", index=True)
-        save_folder_grainstats(config["output_dir"], config["base_dir"], results)
+        save_folder_grainstats(config["output_dir"], config["base_dir"], results, "grain_stats")
         results.reset_index(inplace=True)  # So we can access unique image names
         images_processed = len(results["image"].unique())
     else:
@@ -260,7 +260,9 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         disordered_trace_results.reset_index(inplace=True)
         disordered_trace_results.set_index(["image", "threshold", "grain_number"], inplace=True)
         disordered_trace_results.to_csv(config["output_dir"] / "all_disordered_segment_statistics.csv", index=True)
-        save_folder_grainstats(config["output_dir"], config["base_dir"], mols_results)
+        save_folder_grainstats(
+            config["output_dir"], config["base_dir"], disordered_trace_results, "disordered_trace_stats"
+        )
         disordered_trace_results.reset_index(inplace=True)  # So we can access unique image names
     else:
         LOGGER.warning("There are no grainstats or disordered tracing statistics to write to CSV.")
@@ -269,7 +271,7 @@ def run_topostats(args: None = None) -> None:  # noqa: C901
         mols_results.reset_index(drop=True, inplace=True)
         mols_results.set_index(["image", "threshold", "grain_number"], inplace=True)
         mols_results.to_csv(config["output_dir"] / "all_mol_statistics.csv", index=True)
-        save_folder_grainstats(config["output_dir"], config["base_dir"], mols_results)
+        save_folder_grainstats(config["output_dir"], config["base_dir"], mols_results, "mol_stats")
         mols_results.reset_index(inplace=True)  # So we can access unique image names
     else:
         LOGGER.warning("There are no grainstats or molecule tracing statistics to write to CSV.")


### PR DESCRIPTION
closes #969

TLDR:
PR adds the following:
- Rejigging tracing stats outputs so base grainstats / molstats / None is returned.
- Enables folder stats to be output properly.
- drops empty stats columns causing concat warning.

Think I got it. The cause according to the docs is that pandas doesn't like concatenating objects with whole columns (or rows) as NaN's or None's (we had a mix which is why it was hard to find).

Not only that, but for some reason the "warning" also halts processing.

The initial fix I tried was to stop the warning using the below code which seemed to work, so maybe a 🔥hotfix🔥 idea for something in the future:
```
import warnings
...
warnings.filterwarnings("ignore")
```

Then I thought... WWND (what would @ns-rse do) 👼, and so I solved the root issue and stopped the message from popping up in the first place by dropping all columns with all values as None or NaN's, and applied this across:
- grainstats
- disordered_tracing_stats
- molstats
- image_stats
so this shouldn't happen again **and** we will still be told of depreciation warnings.

Now I've tested this slightly to ensure that if a column is present in `df1` but not `df2`, it will be added, but filled with NaNs for the values in the `resultant_df` for `df2`.