### PR TITLE
Fixes None tracing outputs attempted to be concatenated

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -254,10 +254,16 @@ The output from running TopoStats is saved in the location defined in the config
 default is the directory `output` within the directory from which `topostats process`. This may differ if you have
 used your own customised configuration file (specifically if you have modified the `output_dir:` option).
 
-At the top level of the output directory are two files `config.yaml` and `all_statistics.csv`
+At the top level of the output directory are a few files produced:
 
 - `config.yaml` : a copy of the configuration used to process the images.
-- `all_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the grain and DNA tracing statistics.
+- `all_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the grain statistics.
+- `all_disordered_segment_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the branched skeleton
+  statistics.
+- `all_mol_statistics.csv` : a Comma Separated Variable ASCII plain-text file of the molecule statistics.
+
+**Note:** - If all grains / branch segments of a column have a `None` or `NaN` value, the column will not be present in
+the output `.csv` file.
 
 The remaining directories of results is contingent on the structure of files within the `base_dir` that is specified in
 the configuration. If all files are in the top-level directory (i.e. no nesting) then you will have just a `Processed`
@@ -281,7 +287,10 @@ one under `level1/a`...
 ```bash
 [4.0K Nov 15 14:06]  output
 |-- [ 381 Nov 15 14:06]  output/all_statistics.csv
+|-- [ 733 Nov 15 14:06]  output/all_disordered_tracing_statistics.csv
+|-- [ 254 Nov 15 14:06]  output/all_mol_statistics.csv
 |-- [7.4K Nov 15 14:06]  output/config.yaml
+|-- [ 222 Nov 15 14:06]  output/image_stats.csv
 |-- [4.0K Nov 15 14:06]  output/level1
 |   |-- [4.0K Nov 15 14:06]  output/level1/a
 |   |   |-- [4.0K Nov 15 14:06]  output/level1/a/Processed

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ import numpy.typing as npt
 import pytest
 
 from topostats.utils import (
-    ALL_STATISTICS_COLUMNS,
     bound_padded_coordinates_to_image,
     convert_path,
     convolve_skeleton,
@@ -184,7 +183,7 @@ def test_get_thresholds_value_error(image_random: np.ndarray) -> None:
 
 def test_create_empty_dataframe() -> None:
     """Test the empty dataframe is created correctly."""
-    empty_df = create_empty_dataframe(ALL_STATISTICS_COLUMNS)
+    empty_df = create_empty_dataframe()
 
     assert empty_df.index.name == "grain_number"
     assert "grain_number" not in empty_df.columns

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -629,6 +629,9 @@ def run_nodestats(  # noqa: C901
             # merge all image dictionaries
             return nodestats_whole_data, resultant_grainstats
 
+        except KeyError as e:
+            LOGGER.info(f"[{filename}] : NodeStats failed {e} - no skeletons found from the Disordered Tracing step.")
+
         except Exception as e:
             LOGGER.info(
                 f"[{filename}] : NodeStats failed - skipping. Consider raising an issue on GitHub. Error: ", exc_info=e
@@ -754,6 +757,16 @@ def run_ordered_tracing(
 
             # merge all image dictionaries
             return ordered_tracing_image_data, resultant_grainstats, ordered_tracing_molstats
+
+        except KeyError as e:
+            LOGGER.info(
+                f"[{filename}] : Ordered Tracing failed {e} - no skeletons found from the Disordered Tracing step."
+            )
+            return (
+                ordered_tracing_image_data,
+                grainstats_df,
+                create_empty_dataframe(column_set="mol_statistics", index="molecule_number"),
+            )
 
         except Exception as e:
             LOGGER.info(

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -492,10 +492,14 @@ def run_disordered_trace(
                 f"[{filename}] : Disordered tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
-            return {}, grainstats_df, None
+            return (
+                disordered_traces,
+                grainstats_df,
+                create_empty_dataframe(column_set="disordered_tracing_statistics", index="index"),
+            )
 
     LOGGER.info(f"[{filename}] Calculation of Disordered Tracing disabled, returning empty dictionary.")
-    return None, grainstats_df, None
+    return None, grainstats_df, create_empty_dataframe(column_set="disordered_tracing_statistics", index="index")
 
 
 def run_nodestats(  # noqa: C901
@@ -756,9 +760,13 @@ def run_ordered_tracing(
                 f"[{filename}] : Ordered Tracing failed - skipping. Consider raising an issue on GitHub. Error: ",
                 exc_info=e,
             )
-            return ordered_tracing_image_data, grainstats_df, None
+            return (
+                ordered_tracing_image_data,
+                grainstats_df,
+                create_empty_dataframe(column_set="mol_statistics", index="molecule_number"),
+            )
 
-    return None, grainstats_df, None
+    return None, grainstats_df, create_empty_dataframe(column_set="mol_statistics", index="molecule_number")
 
 
 def run_splining(
@@ -816,7 +824,7 @@ def run_splining(
                         f"[{filename}] : No grains exist for the {direction} direction. Skipping disordered_tracing for {direction}."
                     )
                     splining_grainstats = create_empty_dataframe()
-                    splining_molstats = create_empty_dataframe(columns=["image", "basename", "threshold"])
+                    splining_molstats = create_empty_dataframe(column_set="mol_statistics", index="molecule_number")
                     raise ValueError(f"No grains exist for the {direction} direction")
 
                 # if grains are found
@@ -877,7 +885,7 @@ def run_splining(
             )
             return splined_image_data, grainstats_df, splining_molstats
 
-    return None, grainstats_df, None
+    return None, grainstats_df, molstats_df
 
 
 def get_out_paths(image_path: Path, base_dir: Path, output_dir: Path, filename: str, plotting_config: dict):

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -416,7 +416,7 @@ def run_disordered_trace(
     plotting_config : dict
         Dictionary configuration for plotting images.
     grainstats_df : pd.DataFrame, optional
-        The grain statistics dataframe to be added to. by default None.
+        The grain statistics dataframe to be added to. by default an empty grainstats dataframe.
 
     Returns
     -------
@@ -426,6 +426,10 @@ def run_disordered_trace(
     if disordered_tracing_config["run"]:
         disordered_tracing_config.pop("run")
         LOGGER.info(f"[{filename}] : *** Disordered Tracing ***")
+
+        if grainstats_df is None:
+            grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+
         disordered_traces = defaultdict()
         disordered_trace_grainstats = pd.DataFrame()
         disordered_tracing_stats_image = pd.DataFrame()
@@ -537,7 +541,7 @@ def run_nodestats(  # noqa: C901
     plotting_config : dict
         Dictionary configuration for plotting images.
     grainstats_df : pd.DataFrame, optional
-        The grain statistics dataframe to bee added to. by default None.
+        The grain statistics dataframe to bee added to. by default an empty grainstats dataframe.
 
     Returns
     -------
@@ -547,6 +551,10 @@ def run_nodestats(  # noqa: C901
     if nodestats_config["run"]:
         nodestats_config.pop("run")
         LOGGER.info(f"[{filename}] : *** Nodestats ***")
+
+        if grainstats_df is None:
+            grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+
         nodestats_whole_data = defaultdict()
         nodestats_grainstats = pd.DataFrame()
         try:
@@ -681,7 +689,7 @@ def run_ordered_tracing(
     plotting_config : dict
         Dictionary configuration for plotting images.
     grainstats_df : pd.DataFrame, optional
-        The grain statistics dataframe to be added to. by default None.
+        The grain statistics dataframe to be added to. by default empty grainstats dataframe.
 
     Returns
     -------
@@ -691,6 +699,10 @@ def run_ordered_tracing(
     if ordered_tracing_config["run"]:
         ordered_tracing_config.pop("run")
         LOGGER.info(f"[{filename}] : *** Ordered Tracing ***")
+
+        if grainstats_df is None:
+            grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+
         ordered_tracing_image_data = defaultdict()
         ordered_tracing_molstats = pd.DataFrame()
         ordered_tracing_grainstats = pd.DataFrame()
@@ -815,9 +827,9 @@ def run_splining(
     plotting_config : dict
         Dictionary configuration for plotting images.
     grainstats_df : pd.DataFrame, optional
-        The grain statistics dataframe to be added to. by default None.
+        The grain statistics dataframe to be added to. by default an empty grainstats dataframe.
     molstats_df : pd.DataFrame, optional
-        The molecule statistics dataframe to be added to. by default None.
+        The molecule statistics dataframe to be added to. by default an empty molstats dataframe.
 
     Returns
     -------
@@ -827,6 +839,12 @@ def run_splining(
     if splining_config["run"]:
         splining_config.pop("run")
         LOGGER.info(f"[{filename}] : *** Splining ***")
+
+        if grainstats_df is None:
+            grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+        if molstats_df is None:
+            molstats_df = create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number")
+
         splined_image_data = defaultdict()
         splining_grainstats = pd.DataFrame()
         splining_molstats = pd.DataFrame()

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -19,35 +19,62 @@ from topostats.thresholds import threshold
 LOGGER = logging.getLogger(LOGGER_NAME)
 
 
-ALL_STATISTICS_COLUMNS = (
-    "image",
-    "basename",
-    "grain_number",
-    "area",
-    "area_cartesian_bbox",
-    "aspect_ratio",
-    "bending_angle",
-    "centre_x",
-    "centre_y",
-    "circular",
-    "contour_length",
-    "end_to_end_distance",
-    "height_max",
-    "height_mean",
-    "height_median",
-    "height_min",
-    "max_feret",
-    "min_feret",
-    "radius_max",
-    "radius_mean",
-    "radius_median",
-    "radius_min",
-    "smallest_bounding_area",
-    "smallest_bounding_length",
-    "smallest_bounding_width",
-    "threshold",
-    "volume",
-)
+COLUMN_SETS = {
+    "grainstats": (
+        "image",
+        "basename",
+        "grain_number",
+        "area",
+        "area_cartesian_bbox",
+        "aspect_ratio",
+        "bending_angle",
+        "centre_x",
+        "centre_y",
+        "circular",
+        "contour_length",
+        "end_to_end_distance",
+        "height_max",
+        "height_mean",
+        "height_median",
+        "height_min",
+        "max_feret",
+        "min_feret",
+        "radius_max",
+        "radius_mean",
+        "radius_median",
+        "radius_min",
+        "smallest_bounding_area",
+        "smallest_bounding_length",
+        "smallest_bounding_width",
+        "threshold",
+        "volume",
+    ),
+    "disordered_tracing_statistics": (
+        "image",
+        "basename",
+        "threshold",
+        "grain_number",
+        "index",
+        "branch_distance",
+        "branch_type",
+        "connected_segments",
+        "mean_pixel_value",
+        "stdev_pixel_value",
+        "min_value",
+        "median_value",
+        "middle_value",
+    ),
+    "mol_statistics": (
+        "image",
+        "threshold",
+        "basename",
+        "grain_number",
+        "molecule_number",
+        "circular",
+        "topology",
+        "processing",
+    ),
+}
 
 
 def convert_path(path: str | Path) -> Path:
@@ -269,14 +296,14 @@ def get_thresholds(  # noqa: C901
     return thresholds
 
 
-def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: str = "grain_number") -> pd.DataFrame:
+def create_empty_dataframe(column_set: str = "grainstats", index: str = "grain_number") -> pd.DataFrame:
     """
     Create an empty data frame for returning when no results are found.
 
     Parameters
     ----------
-    columns : list
-        Columns of the empty dataframe.
+    column_set : str
+        The name of the set of columns for the empty dataframe.
     index : str
         Column to set as index of empty dataframe.
 
@@ -285,7 +312,7 @@ def create_empty_dataframe(columns: set = ALL_STATISTICS_COLUMNS, index: str = "
     pd.DataFrame
         Empty Pandas DataFrame.
     """
-    empty_df = pd.DataFrame(columns=columns)
+    empty_df = pd.DataFrame(columns=COLUMN_SETS[column_set])
     return empty_df.set_index(index)
 
 


### PR DESCRIPTION
Apologies, the previous PR was a tad early, I thought the "merge when ready" would wait for until tests finished...

This should provide a hotfix to the errors and similar like them:
```
disordered_trace_results[str(img)] = disordered_trace_result.dropna(axis=1, how="all")
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'dropna'
```

This occurred because the disabled modules would return `None` instead of an empty dataframe and we expected to have the dataframe function `DataFrame.dropna()` which obvs didn't exist.

This fix should ensure that dataframes are returned by disabled modules.

It also adds another exception I found when forcing the disordered traces step to fail causing KeyErrors in NodeStats and Ordered Tracing as they couldn't find the image name keys of a skeleton to grab.