### PR TITLE
tests(utils): parameterise test_create_empty_dataframe()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -181,14 +181,30 @@ def test_get_thresholds_value_error(image_random: np.ndarray) -> None:
         get_thresholds(image=image_random, threshold_method="mean", **THRESHOLD_OPTIONS)
 
 
-def test_create_empty_dataframe() -> None:
-    """Test the empty dataframe is created correctly."""
-    empty_df = create_empty_dataframe()
+@pytest.mark.parametrize(
+    ("column_set", "index_col", "n_columns", "columns_check"),
+    [
+        pytest.param("grainstats", "grain_number", 26, {"image", "basename", "area"}, id="Empty grainstats dataframe"),
+        pytest.param(
+            "disordered_tracing_statistics",
+            "index",
+            12,
+            {"connected_segments", "mean_pixel_value", "stdev_pixel_value"},
+            id="Empty disordered_tracing_statistics dataframe",
+        ),
+        pytest.param(
+            "mol_statistics", "molecule_number", 7, {"image", "basename", "area"}, id="Empty mol_statistics dataframe"
+        ),
+    ],
+)
+def test_create_empty_dataframe(column_set: str, index_col: str, n_columns: int, columns_check: set) -> None:
+    """Test the empty dataframes are created correctly."""
+    empty_df = create_empty_dataframe(column_set, index_col)
 
-    assert empty_df.index.name == "grain_number"
-    assert "grain_number" not in empty_df.columns
-    assert empty_df.shape == (0, 26)
-    assert {"image", "basename", "area"}.intersection(empty_df.columns)
+    assert empty_df.index.name == index_col
+    assert index_col not in empty_df.columns
+    assert empty_df.shape == (0, n_columns)
+    assert columns_check.intersection(empty_df.columns)
 
 
 @pytest.mark.parametrize(

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -317,7 +317,9 @@ def run_grainstats(
                     LOGGER.warning(
                         f"[{filename}] : No grains exist for the {direction} direction. Skipping grainstats for {direction}."
                     )
-                    grainstats_dict[direction] = create_empty_dataframe()
+                    grainstats_dict[direction] = create_empty_dataframe(
+                        column_set="grainstats", index_col="grain_number"
+                    )
                 else:
                     grainstats_calculator = GrainStats(
                         data=image,
@@ -350,7 +352,7 @@ def run_grainstats(
 
             # Create results dataframe from above and below results
             # Appease pylint and ensure that grainstats_df is always created
-            grainstats_df = create_empty_dataframe()
+            grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
             if "above" in grainstats_dict and "below" in grainstats_dict:
                 grainstats_df = pd.concat([grainstats_dict["below"], grainstats_dict["above"]])
             elif "above" in grainstats_dict:
@@ -369,12 +371,12 @@ def run_grainstats(
             LOGGER.info(
                 f"[{filename}] : Errors occurred whilst calculating grain statistics. Returning empty dataframe."
             )
-            return create_empty_dataframe(), height_profiles_dict
+            return create_empty_dataframe(column_set="grainstats", index_col="grain_number"), height_profiles_dict
     else:
         LOGGER.info(
             f"[{filename}] : Calculation of grainstats disabled, returning empty dataframe and empty height_profiles."
         )
-        return create_empty_dataframe(), {}
+        return create_empty_dataframe(column_set="grainstats", index_col="grain_number"), {}
 
 
 def run_disordered_trace(
@@ -495,11 +497,11 @@ def run_disordered_trace(
             return (
                 disordered_traces,
                 grainstats_df,
-                create_empty_dataframe(column_set="disordered_tracing_statistics", index="index"),
+                create_empty_dataframe(column_set="disordered_tracing_statistics", index_col="index"),
             )
 
     LOGGER.info(f"[{filename}] Calculation of Disordered Tracing disabled, returning empty dictionary.")
-    return None, grainstats_df, create_empty_dataframe(column_set="disordered_tracing_statistics", index="index")
+    return None, grainstats_df, create_empty_dataframe(column_set="disordered_tracing_statistics", index_col="index")
 
 
 def run_nodestats(  # noqa: C901
@@ -765,7 +767,7 @@ def run_ordered_tracing(
             return (
                 ordered_tracing_image_data,
                 grainstats_df,
-                create_empty_dataframe(column_set="mol_statistics", index="molecule_number"),
+                create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number"),
             )
 
         except Exception as e:
@@ -776,10 +778,10 @@ def run_ordered_tracing(
             return (
                 ordered_tracing_image_data,
                 grainstats_df,
-                create_empty_dataframe(column_set="mol_statistics", index="molecule_number"),
+                create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number"),
             )
 
-    return None, grainstats_df, create_empty_dataframe(column_set="mol_statistics", index="molecule_number")
+    return None, grainstats_df, create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number")
 
 
 def run_splining(
@@ -836,8 +838,8 @@ def run_splining(
                     LOGGER.warning(
                         f"[{filename}] : No grains exist for the {direction} direction. Skipping disordered_tracing for {direction}."
                     )
-                    splining_grainstats = create_empty_dataframe()
-                    splining_molstats = create_empty_dataframe(column_set="mol_statistics", index="molecule_number")
+                    splining_grainstats = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+                    splining_molstats = create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number")
                     raise ValueError(f"No grains exist for the {direction} direction")
 
                 # if grains are found
@@ -1101,14 +1103,13 @@ def process_scan(
             grainstats_df=grainstats_df,
             molstats_df=molstats_df,
         )
-
         # Add grain trace data to topostats object
         topostats_object["splining"] = splined_data
 
     else:
-        grainstats_df = create_empty_dataframe()
-        molstats_df = create_empty_dataframe()
-        disordered_tracing_stats = create_empty_dataframe()
+        grainstats_df = create_empty_dataframe(column_set="grainstats", index_col="grain_number")
+        molstats_df = create_empty_dataframe(column_set="mol_statistics", index_col="molecule_number")
+        disordered_tracing_stats = create_empty_dataframe(column_set="disordered_tracing_statistics", index_col="index")
         height_profiles = {}
 
     # Get image statistics

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -296,7 +296,7 @@ def get_thresholds(  # noqa: C901
     return thresholds
 
 
-def create_empty_dataframe(column_set: str = "grainstats", index: str = "grain_number") -> pd.DataFrame:
+def create_empty_dataframe(column_set: str = "grainstats", index_col: str = "grain_number") -> pd.DataFrame:
     """
     Create an empty data frame for returning when no results are found.
 
@@ -304,7 +304,7 @@ def create_empty_dataframe(column_set: str = "grainstats", index: str = "grain_n
     ----------
     column_set : str
         The name of the set of columns for the empty dataframe.
-    index : str
+    index_col : str
         Column to set as index of empty dataframe.
 
     Returns
@@ -313,7 +313,7 @@ def create_empty_dataframe(column_set: str = "grainstats", index: str = "grain_n
         Empty Pandas DataFrame.
     """
     empty_df = pd.DataFrame(columns=COLUMN_SETS[column_set])
-    return empty_df.set_index(index)
+    return empty_df.set_index(index_col)
 
 
 def bound_padded_coordinates_to_image(coordinates: npt.NDArray, padding: int, image_shape: tuple) -> tuple:


### PR DESCRIPTION
- Parameterises `test_utils.py::test_create_empty_dataframe()` so that all three possible empty dataframes are now tested.
- Renames `create_empty_dataframe()` parameter `index` > `index_col` to avoid confusion with Python and Pandas `index` methods.
- Explicitly calls `create_empty_dataframe()` with the `column_set` and `index_col` in each instance rather than relying on defaults when an empty `grainstats_df` is required.
- Further at the end of `process_scan()` empty dataframes of all types were incorrectly generated as no types were specified for any, these now generate the correct type for each required data frame.