### PR TITLE
update readme.md with new swiss army knife processing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ topostats process
 ```
 
 If you have your own YAML configuration file (see [Usage : Configuring
-TopoStats](https://afm-spm.github.io/TopoStats/main/usage.html#configuring_topostats)) then invoke `topostats process`
-and use the argument for `--config <config_file>.yaml` that points to your file.
+TopoStats](https://afm-spm.github.io/TopoStats/main/usage.html#configuring_topostats)) then invoke `topostats`
+and use the argument for `--config <config_file>.yaml` that points to your file with an associated module of
+TopoStats i.e. `process`.
 
 ```bash
 # Edit and save my_config.yaml then run TopoStats with this configuration file
-topostats process --config my_config.yaml
+topostats --config my_config.yaml process
 ```
 
 The configuration file is validated before analysis begins and if there are problems you will see errors messages that
@@ -80,7 +81,7 @@ configuration to the file `./config.yaml` (i.e. in the current directory). This 
 version > 2.0.0 and <= 2.1.2 you can use the older `run_topostats --create-config` option.
 
 ```bash
-run_topostats --create-config-file config.yaml
+run_topostats --create-config -f config.yaml
 ```
 
 ### Notebooks

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ topostats process
 If you have your own YAML configuration file (see [Usage : Configuring
 TopoStats](https://afm-spm.github.io/TopoStats/main/usage.html#configuring_topostats)) then invoke `topostats`
 and use the argument for `--config <config_file>.yaml` that points to your file with an associated module of
-TopoStats i.e. `process`.
+TopoStats e.g. `process`.
 
 ```bash
 # Edit and save my_config.yaml then run TopoStats with this configuration file

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ If you have generated a configuration file you can modify and edit a configurati
 fields below). Once these changes have been saved, you can run TopoStats with this configuration file as shown below.
 
 ```bash
-topostats process --config my_config.yaml
+topostats --config my_config.yaml process
 ```
 
 On completion a copy of the configuration that was used is written to the output directory so you have a record of the
@@ -199,7 +199,7 @@ this custom file using the following command (substituting `my_custom_topostats.
 your file as).
 
 ```bash
-topostats process --matplotlibrc my_custom_topostats.mplstyle
+topostats --matplotlibrc my_custom_topostats.mplstyle process
 ```
 
 **NB** Plotting with Matplotlib is highly configurable and there are a plethora of options that you may wish to

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -130,31 +130,18 @@ using the `-h` or `--help` flag.
 
 ```bash
  ❱ topostats process --help
-usage: topostats process [-h] [-c CONFIG_FILE] [-s SUMMARY_CONFIG] [--matplotlibrc MATPLOTLIBRC] [-b BASE_DIR] [-j CORES] [-l LOG_LEVEL] [-f FILE_EXT] [--channel CHANNEL] [-o OUTPUT_DIR] [--save-plots SAVE_PLOTS] [-m MASK] [-w WARNINGS]
+usage: topostats process [-h] [-s SUMMARY_CONFIG] [--matplotlibrc MATPLOTLIBRC] [-b BASE_DIR] [-j CORES] [-l LOG_LEVEL] [-f FILE_EXT] [--channel CHANNEL] [-o OUTPUT_DIR] [--save-plots SAVE_PLOTS] [-m MASK] [-w WARNINGS]
 
 Process AFM images. Additional arguments over-ride those in the configuration file.
 
 options:
-  -h, --help            show this help message and exit
-  -c CONFIG_FILE, --config-file CONFIG_FILE
-                        Path to a YAML configuration file.
-  -s SUMMARY_CONFIG, --summary-config SUMMARY_CONFIG
-                        Path to a YAML configuration file for summary plots and statistics.
-  --matplotlibrc MATPLOTLIBRC
-                        Path to a matplotlibrc file.
-  -b BASE_DIR, --base-dir BASE_DIR
-                        Base directory to scan for images.
-  -j CORES, --cores CORES
-                        Number of CPU cores to use when processing.
-  -l LOG_LEVEL, --log-level LOG_LEVEL
-                        Logging level to use, default is 'info' for verbose output use 'debug'.
-  -f FILE_EXT, --file-ext FILE_EXT
-                        File extension to scan for.
-  --channel CHANNEL     Channel to extract.
-  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
-                        Output directory to write results to.
   --save-plots SAVE_PLOTS
                         Whether to save plots.
+  --savefig-format SAVEFIG_FORMAT
+                        Format for saving figures to, options are 'png', 'svg', or other valid Matplotlib supported formats.
+  --savefig-dpi SAVEFIG_DPI
+                        Dots Per Inch for plots, should be integer for dots per inch.
+  --cmap CMAP           Colormap to use, options include 'nanoscope', 'afmhot' or any valid Matplotlib colormap.
   -m MASK, --mask MASK  Mask the image.
   -w WARNINGS, --warnings WARNINGS
                         Whether to ignore warnings.
@@ -233,7 +220,7 @@ you edited. That doesn't _have_ to be the case but it makes life easier for if y
 and relative paths.
 
 ```bash
-topostats process --config my_config.yaml
+topostats --config my_config.yaml process
 [Tue, 15 Nov 2022 12:39:48] [INFO    ] [topostats] Configuration is valid.
 [Tue, 15 Nov 2022 12:39:48] [INFO    ] [topostats] Plotting configuration is valid.
 [Tue, 15 Nov 2022 12:39:48] [INFO    ] [topostats] Configuration file loaded from      : None


### PR DESCRIPTION
Amends the docs in `readme.md`, `docs/configuration.md`, and `docs/usage.md` in light of the entry-point changes.

Mainly just adjusts to use: `topostats -c <config>.yaml process