### PR TITLE
ci: Adds a Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,8 @@ description of why a particular item is not relevant.
 Before submitting a Pull Request please check the following.
 
 - [ ] Existing tests pass.
-- [ ] Documentation has been updated and builds.
+- [ ] Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant
+      processing sections under `advanced.md`.
 - [ ] Pre-commit checks pass.
 - [ ] New functions/methods have typehints and docstrings.
 - [ ] New functions/methods have tests which check the intended behaviour is correct.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# TopoStats Pull Requests
+
+Please provide a descriptive summary of the changes your Pull Request introduces.
+
+The [Software Development](https://afm-spm.github.io/TopoStats/main/contributing.html#software-development) section of
+the Contributing Guidelines may be useful if you are unfamiliar with linting, pre-commit, docstrings and testing.
+
+**NB** - This header should be replaced with the description but please complete the below checklist or a short
+description of why a particular item is not relevant.
+
+---
+
+Before submitting a Pull Request please check the following.
+
+- [ ] Existing tests pass.
+- [ ] Documentation has been updated and builds.
+- [ ] Pre-commit checks pass.
+- [ ] New functions/methods have typehints and docstrings.
+- [ ] New functions/methods have tests which check the intended behaviour is correct.
+
+## Optional
+
+### `topostats/default_config.yaml`
+
+If adding options to `topostats/default_config.yaml` please ensure.
+
+- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
+- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
+- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.


### PR DESCRIPTION
As [suggested](https://github.com/AFM-SPM/TopoStats/pull/996#issuecomment-2476147390) by @SylviaWhittle we could all do with an _aide memoire_ when making Pull Requests that we have covered everything we should.

This Pull Request therefore introduces just such a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to aid contributors in making sure we have covered everything.

---

- [ ] Existing tests pass. **N/A** no changes to code base introduced.
- [ ] Documentation has been updated and builds. **N/A** no changes to code base introduced.
- [x] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings. **N/A** no changes to code base introduced.
- [ ] New functions/methods have tests which check the intended behaviour is correct. **N/A** no changes to code base introduced.