### PR TITLE
doc: Reduce Python version to 3.11 in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Closes #719 

Sets Python version for building on ReadTheDocs to align with those required by Python (`>=3.9 & < 3.12`)

---

Before submitting a Pull Request please check the following.

**NA** - Change is concerned with Continuous Integration building of documentation

- [ ] ~~Existing tests pass.~~
- [ ] ~~Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant processing sections under `advanced.md`.~~
- [ ] ~~Pre-commit checks pass.~~
- [ ] ~~New functions/methods have typehints and docstrings.~~
- [ ] ~~New functions/methods have tests which check the intended behaviour is correct.~~

