### PR TITLE
style: Changes prettier mirror used by pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,8 +58,8 @@ repos:
     hooks:
       - id: codespell
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
 


### PR DESCRIPTION
Closes #1006 

As per [PC180](https://learn.scientific-python.org/development/guides/style#PC180) uses [rbubley/mirrors-prettier](https://github.com/rbubley/mirrors-prettier/) over [pre-commit/mirrors-prettier](https://github.com/pre-commit/mirrors-prettier/).

# TopoStats Pull Requests

Please provide a descriptive summary of the changes your Pull Request introduces.

The [Software Development](https://afm-spm.github.io/TopoStats/main/contributing.html#software-development) section of
the Contributing Guidelines may be useful if you are unfamiliar with linting, pre-commit, docstrings and testing.

**NB** - This header should be replaced with the description but please complete the below checklist or a short
description of why a particular item is not relevant.

---

Before submitting a Pull Request please check the following.

- [x] ~~Existing tests pass.~~
- [x] ~~Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant processing sections under `advanced.md`.~~
- [x] Pre-commit checks pass.
- [x] ~~New functions/methods have typehints and docstrings.~~
- [x] ~~New functions/methods have tests which check the intended behaviour is correct.~~

## Optional

**N/A**