### PR TITLE
dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,11 @@ description of why a particular item is not relevant.
 Before submitting a Pull Request please check the following.
 
 - [ ] Existing tests pass.
-- [ ] Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant
-      processing sections under `advanced.md`.
+- [ ] Documentation has been updated and builds. Remember to update as required...
+  - [ ] `docs/configuration.md`
+  - [ ] `docs/usage.md`
+  - [ ] `docs/data_dictionary.md`
+  - [ ] `docs/advanced.md` and new pages it should link to.
 - [ ] Pre-commit checks pass.
 - [ ] New functions/methods have typehints and docstrings.
 - [ ] New functions/methods have tests which check the intended behaviour is correct.


### PR DESCRIPTION
Closes #733 

As per [GH200](https://learn.scientific-python.org/development/guides/gha-basic/#GH200) enables dependabot to check for
updates to GitHub Actions and updates automatically with Pull Requests.

Also tweaks the `.github/pull_request_template.md` to be more explicit about updating documentation.

**NB** This is a Stacked Pull Request and Should be merged after #1011 (as it was branched from
`ns-rse/1006-prettier-update`).

---

Before submitting a Pull Request please check the following.

- [x] ~~Existing tests pass.~~
- [ ] ~~Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant processing sections under `advanced.md`.~~
- [x] Pre-commit checks pass.
- [x] ~~New functions/methods have typehints and docstrings.~~
- [x] ~~New functions/methods have tests which check the intended behaviour is correct.~~

## Optional

### `topostats/default_config.yaml`

**N/A**