### PR TITLE
config: Removes target-version from ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,6 @@ exclude = [
 ]
 # per-file-ignores = []
 line-length = 120
-target-version = "py310"
 lint.select = [
   "A", # flake8-builtins
   "B", # flake8-bugbear


### PR DESCRIPTION
Closes #1007

As per [RF002](https://learn.scientific-python.org/development/guides/style#RF002): Target version must be set
We had both Ruff's `target-version` and `project.requires-python`. We only need the latter.

**NB** This is a stacked pull request and should be merged after #1012

---

Before submitting a Pull Request please check the following.

- [x] ~~Existing tests pass.~~
- [x] ~~Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant processing sections under `advanced.md`.~~
- [x] ~~Pre-commit checks pass.~~
- [x] ~~New functions/methods have typehints and docstrings.~~
- [x] ~~New functions/methods have tests which check the intended behaviour is correct.~~

## Optional

### `topostats/default_config.yaml`

**N/A**