### PR TITLE
ci: Adds pygrep-hooks and fixes errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,17 @@ repos:
     hooks:
       - id: numpydoc-validation
 
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: python-no-eval
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-check-mock-methods
+
   - repo: local
     hooks:
       - id: pylint

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -147,7 +147,7 @@ def _log_setup(config: dict, args: argparse.Namespace | None, img_files: dict) -
         sys.exit()
     LOGGER.info(f"Thresholding method (Filtering)     : {config['filter']['threshold_method']}")
     LOGGER.info(f"Thresholding method (Grains)        : {config['grains']['threshold_method']}")
-    LOGGER.debug(f"Configuration after update         : \n{pformat(config, indent=4)}")  # noqa : T203
+    LOGGER.debug(f"Configuration after update         : \n{pformat(config, indent=4)}")  # noqa: T203
 
 
 def _parse_configuration(args: argparse.Namespace | None = None) -> tuple[dict, dict]:


### PR DESCRIPTION
Closes #1005

As per [PC170](https://learn.scientific-python.org/development/guides/style#PC170): Uses PyGrep hooks (only needed if
rST present) adds [pygrep-hooks](https://github.com/pre-commit/pygrep-hooks) to `.pre-commit-config.yaml`.

Opted to enable more than just the `rst-` hooks.

**NB** This is a stacked commit and should be merged after #1013 from which it was branched.

---

Before submitting a Pull Request please check the following.

- [x] ~~Existing tests pass.~~
- [x] ~~Documentation has been updated and builds. Remember to update `configuration.md`, `usage.md`, and relevant processing sections under `advanced.md`.~~
- [x] Pre-commit checks pass.
- [x] ~~New functions/methods have typehints and docstrings.~~
- [x] ~~New functions/methods have tests which check the intended behaviour is correct.~~

## Optional

### `topostats/default_config.yaml`

**N/A**