### PR TITLE
tests(unet_masking): Correct ids and add expected fail

### DIFF
--- a/tests/test_unet_masking.py
+++ b/tests/test_unet_masking.py
@@ -151,19 +151,29 @@ def test_predict_unet(mock_model_5_by_5_single_class: MagicMock) -> None:
     ("crop_min_row", "crop_min_col", "crop_max_row", "crop_max_col", "image_shape", "expected_indices"),
     [
         pytest.param(0, 0, 100, 100, (100, 100), (0, 0, 100, 100), id="not a crop"),
-        pytest.param(3, 4, 8, 8, (10, 10), (3, 4, 8, 9), id="free space single min col decrease"),
-        pytest.param(4, 3, 8, 8, (10, 10), (4, 3, 9, 8), id="free space single min row decrease"),
-        pytest.param(4, 4, 7, 8, (10, 10), (4, 4, 8, 8), id="free space single max col increase"),
-        pytest.param(4, 4, 8, 7, (10, 10), (4, 4, 8, 8), id="free space single max row increase"),
-        pytest.param(4, 2, 8, 8, (10, 10), (3, 2, 9, 8), id="free space double min col decrease"),
-        pytest.param(2, 4, 8, 8, (10, 10), (2, 3, 8, 9), id="free space double min row decrease"),
-        pytest.param(4, 4, 8, 6, (10, 10), (4, 3, 8, 7), id="free space double max col increase"),
-        pytest.param(4, 4, 6, 8, (10, 10), (3, 4, 7, 8), id="free space double max row increase"),
+        pytest.param(3, 4, 8, 8, (10, 10), (3, 4, 8, 9), id="free space single max col increase"),
+        pytest.param(4, 3, 8, 8, (10, 10), (4, 3, 9, 8), id="free space single max row increase"),
+        pytest.param(4, 4, 7, 8, (10, 10), (4, 4, 8, 8), id="free space single max row increase"),
+        pytest.param(4, 4, 8, 7, (10, 10), (4, 4, 8, 8), id="free space single max col increase"),
+        pytest.param(4, 2, 8, 8, (10, 10), (3, 2, 9, 8), id="free space double min row decrease, max row increase"),
+        pytest.param(2, 4, 8, 8, (10, 10), (2, 3, 8, 9), id="free space double min col decrease, max col increase"),
+        pytest.param(4, 4, 8, 6, (10, 10), (4, 3, 8, 7), id="free space double min col decrease, max col increase"),
+        pytest.param(4, 4, 6, 8, (10, 10), (3, 4, 7, 8), id="free space double min row decrease, max row increase"),
         pytest.param(1, 1, 6, 2, (10, 10), (1, 0, 6, 5), id="constrained left"),
         pytest.param(1, 6, 7, 8, (10, 10), (1, 3, 7, 9), id="constrained right"),
         pytest.param(1, 1, 2, 6, (10, 10), (0, 1, 5, 6), id="constrained top"),
         pytest.param(6, 1, 8, 7, (10, 10), (3, 1, 9, 7), id="constrained bottom"),
         pytest.param(117, 20, 521, 603, (608, 608), (24, 20, 607, 603), id="constrained top and bottom"),
+        pytest.param(
+            1,
+            1,
+            2,
+            4,
+            (2, 4),
+            (0, 1, 2, 4),
+            id="rectangular image with large rectangular box",
+            marks=pytest.mark.xfail(reason="square bounding box not possible"),
+        ),
     ],
 )
 def test_make_bounding_box_square(
@@ -174,7 +184,7 @@ def test_make_bounding_box_square(
     image_shape: tuple[int, int],
     expected_indices: tuple[int, int, int, int],
 ) -> None:
-    """Test the make_bounding_box_square method."""
+    """Test the make_bounding_box_square method returns square objects within image shape with known coordinates."""
     result = make_bounding_box_square(crop_min_row, crop_min_col, crop_max_row, crop_max_col, image_shape)
     # check bbox within image bounds
     assert result[0] >= 0


### PR DESCRIPTION
- Corrects the `id` of the parameterised tests for `test_make_bounding_box_square()` to reflect the `row`/`col`
  and whether they `increase`/`decrease`.
- Adds a rectangular image with a large rectangular `bbox` that can not be squared and marks the test as a fail.

I recall, but can't find, that we added functionality to handle non-square scans (I think @SylviaWhittle wrote the code
to handle it) and so its possible that instances may arise where the `bbox` can't be squared.

Ideally we should add a `try: ... except:` to handle such cases but for now adding a test which is marked as expected to
fail should serve as an _aide memoire_ that sometimes things won't work.