### PR TITLE
chore: Remove unused method, test and package dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,11 @@ dependencies = [
   "art",
   "AFMReader",
   "h5py",
-  "igor2",
   "keras",
   "matplotlib",
   "numpy",
   "numpyencoder",
   "pandas",
-  "pySPM",
   "pyyaml",
   "ruamel.yaml",
   "schema",
@@ -54,7 +52,6 @@ dependencies = [
   "skan~=0.11.0",
   "snoop",
   "tensorflow",
-  "tifffile",
   "topoly",
   "tqdm",
 ]
@@ -66,7 +63,6 @@ tests = [
   "pytest-github-actions-annotate-failures",
   "pytest-mpl",
   "pytest-regtest==2.3.1",
-  "pytest-testmon",
   "filetype",
 ]
 docs = [
@@ -89,6 +85,7 @@ dev = [
   "pyupgrade",
   "pytest-durations",
   "pytest-icdiff",
+  "pytest-testmon",
   "pytest-xdist",
 ]
 pypi = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-import pySPM
 import pytest
 import yaml
 from skimage import draw, filters
@@ -371,13 +370,6 @@ def load_scan_data() -> LoadScans:
 def load_scan_spm() -> LoadScans:
     """Instantiate a LoadScans object from a .spm file."""
     return LoadScans([RESOURCES / "minicircle.spm"], channel="Height")
-
-
-@pytest.fixture()
-def spm_channel_data() -> pySPM.SPM.SPM_image:
-    """Instantiate channel data from a LoadScans object."""
-    scan = pySPM.Bruker(RESOURCES / "minicircle.spm")
-    return scan.get_channel("Height")
 
 
 @pytest.fixture()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -5,12 +5,10 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import patch
 
 import h5py
 import numpy as np
 import pandas as pd
-import pySPM
 import pytest
 
 from topostats.io import (
@@ -601,33 +599,6 @@ def test_load_scan_topostats(load_scan_topostats: LoadScans) -> None:
     assert above_grain_mask.sum() == 633746
     assert isinstance(grain_trace_data, dict)
     assert grain_trace_data.keys() == {"above"}
-
-
-@patch("pySPM.SPM.SPM_image.pxs")
-@pytest.mark.parametrize(
-    ("unit", "x", "y", "expected_px2nm"),
-    [
-        pytest.param("mm", 0.01, 0.01, 10000, id="mm units; square"),
-        pytest.param("um", 1.5, 1.5, 1500, id="um units; square"),
-        pytest.param("nm", 50, 50, 50, id="nm units; square"),
-        pytest.param("pm", 233, 233, 0.233, id="pm units; square"),
-        pytest.param("pm", 1, 512, 0.001, id="pm units; rectangular (thin)"),
-        pytest.param("pm", 512, 1, 0.512, id="pm units; rectangular (tall)"),
-    ],
-)
-def test__spm_pixel_to_nm_scaling(
-    mock_pxs,
-    load_scan_spm: LoadScans,
-    spm_channel_data: pySPM.SPM.SPM_image,
-    unit: str,
-    x: int,
-    y: int,
-    expected_px2nm: float,
-) -> None:
-    """Test extraction of pixels to nanometer scaling."""
-    mock_pxs.return_value = [(x, unit), (y, unit)]  # issue is that pxs is a func that returns the data
-    result = load_scan_spm._spm_pixel_to_nm_scaling(spm_channel_data)
-    assert result == expected_px2nm
 
 
 @pytest.mark.parametrize(

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -18,7 +18,6 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-import pySPM
 from AFMReader import asd, gwy, ibw, jpk, spm, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
@@ -641,38 +640,6 @@ class LoadScans:
         except FileNotFoundError:
             LOGGER.error(f"File Not Found : {self.img_path}")
             raise
-
-    def _spm_pixel_to_nm_scaling(self, channel_data: pySPM.SPM.SPM_image) -> float:
-        """
-        Extract pixel to nm scaling from the SPM image metadata.
-
-        Parameters
-        ----------
-        channel_data : pySPM.SPM.SPM_image
-            Channel data from PySPM.
-
-        Returns
-        -------
-        float
-            Pixel to nm scaling factor.
-        """
-        unit_dict = {
-            "pm": 1e-3,
-            "nm": 1,
-            "um": 1e3,
-            "mm": 1e6,
-        }
-        px_to_real = channel_data.pxs()
-        # Has potential for non-square pixels but not yet implemented
-        pixel_to_nm_scaling = (
-            px_to_real[0][0] * unit_dict[px_to_real[0][1]],
-            px_to_real[1][0] * unit_dict[px_to_real[1][1]],
-        )[0]
-        if px_to_real[0][0] == 0 and px_to_real[1][0] == 0:
-            pixel_to_nm_scaling = 1
-            LOGGER.warning(f"[{self.filename}] : Pixel size not found in metadata, defaulting to 1nm")
-        LOGGER.debug(f"[{self.filename}] : Pixel to nm scaling : {pixel_to_nm_scaling}")
-        return pixel_to_nm_scaling
 
     def load_topostats(self) -> tuple[npt.NDArray, float]:
         """


### PR DESCRIPTION
Closes #1036

With the delegation of much I/O (Input/Output) functionality to @SylviaWhittle `AFMReader` (see #1031) we have removed most of the methods to the `io.LoadScan()` class. One that slipped through was `_spm_pixel_to_nm_scaling()` and this commit removes it along with its associated test.

Further the delegation of reading AFM files using `AFMReader` means `TopoStats` no longer has explicit dependencies on the `igor2`, `pySPM` or `tifffile` packages and so these have been removed from the `dependencies` section of `pyproject.toml`. These are dependencies of `AFMReader` and will still be installed in virtual environments.

Moved `pytest-testmon` from `tests` to `dev` under optional dependencies as its not used when running the test suite, only when making commits locally.


---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.