### PR TITLE
refactor(disordered_tracing): Work with skan-0.12.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "scikit-image",
   "scipy",
   "seaborn",
-  "skan~=0.11.0",
+  "skan",
   "snoop",
   "tensorflow",
   "topoly",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "AFMReader",
   "h5py",
   "keras",
-  "matplotlib",
+  "matplotlib~=3.9.4",
   "numpy",
   "numpyencoder",
   "pandas",

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -387,7 +387,7 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
                         np.where(disordered_trace_images["pruned_skeleton"] == 1, cropped_image, 0),
                         spacing=pixel_to_nm_scaling,
                     )
-                    skan_df = skan.summarize(skan_skeleton)
+                    skan_df = skan.summarize(skan_skeleton, separator="_")
                     skan_df = compile_skan_stats(skan_df, skan_skeleton, cropped_image, filename, cropped_image_index)
                     total_branch_length = skan_df["branch_distance"].sum() * 1e-9
                 except ValueError:
@@ -463,17 +463,12 @@ def compile_skan_stats(
         mean-pixel-value, stdev-pixel-value, min-value, median-value, and mid-value.
     """
     skan_df["image"] = filename
-    skan_df["branch-type"] = np.int64(skan_df["branch-type"])
+    skan_df["branch-type"] = np.int64(skan_df["branch_type"])
     skan_df["grain_number"] = grain_number
     skan_df["connected_segments"] = skan_df.apply(find_connections, axis=1, skan_df=skan_df)
     skan_df["min_value"] = skan_df.apply(lambda x: segment_heights(x, skan_skeleton, image).min(), axis=1)
     skan_df["median_value"] = skan_df.apply(lambda x: np.median(segment_heights(x, skan_skeleton, image)), axis=1)
     skan_df["middle_value"] = skan_df.apply(segment_middles, skan_skeleton=skan_skeleton, image=image, axis=1)
-
-    # Skan-0.11.1 uses dashes in variables names which prevents dot-notation being used to refer to variable names
-    # this has been addressed (see https://github.com/jni/skan/pull/215) for now manually convert.
-    skan_df.columns = skan_df.columns.str.replace("-", "_")
-
     # remove unused skan columns
     return skan_df[
         [
@@ -555,10 +550,10 @@ def find_connections(row: pd.Series, skan_df: pd.DataFrame) -> str:
         String is needed for csv compatibility since csvs can't hold lists.
     """
     connections = skan_df[
-        (skan_df["node-id-src"] == row["node-id-src"])
-        | (skan_df["node-id-dst"] == row["node-id-dst"])
-        | (skan_df["node-id-src"] == row["node-id-dst"])
-        | (skan_df["node-id-dst"] == row["node-id-src"])
+        (skan_df["node_id_src"] == row["node_id_src"])
+        | (skan_df["node_id_dst"] == row["node_id_dst"])
+        | (skan_df["node_id_src"] == row["node_id_dst"])
+        | (skan_df["node_id_dst"] == row["node_id_src"])
     ].index.tolist()
 
     # Remove the index of the current row itself from the list of connections
@@ -707,12 +702,8 @@ def disordered_trace_grain(  # pylint: disable=too-many-arguments
         "smoothed_grain": disorderedtrace.smoothed_mask,
         "skeleton": disorderedtrace.skeleton,
         "pruned_skeleton": disorderedtrace.pruned_skeleton,
-        "branch_types": get_skan_image(
-            cropped_image, disorderedtrace.pruned_skeleton, "branch-type"
-        ),  # change with Skan new release
-        "branch_indexes": get_skan_image(
-            cropped_image, disorderedtrace.pruned_skeleton, "node-id-src"
-        ),  # change with Skan new release
+        "branch_types": get_skan_image(cropped_image, disorderedtrace.pruned_skeleton, "branch_type"),
+        "branch_indexes": get_skan_image(cropped_image, disorderedtrace.pruned_skeleton, "node_id_src"),
     }
 
 
@@ -742,13 +733,12 @@ def get_skan_image(original_image: npt.NDArray, pruned_skeleton: npt.NDArray, sk
     """
     branch_field_image = np.zeros_like(original_image)
     skeleton_image = np.where(pruned_skeleton == 1, original_image, 0)
-
     try:
         skan_skeleton = skan.Skeleton(skeleton_image, spacing=1e-9, value_is_height=True)
-        res = skan.summarize(skan_skeleton)
+        res = skan.summarize(skan_skeleton, separator="_")
         for i, branch_field in enumerate(res[skan_column]):
             path_coords = skan_skeleton.path_coordinates(i)
-            if skan_column == "node-id-src":
+            if skan_column == "node_id_src":
                 branch_field = i
             branch_field_image[path_coords[:, 0], path_coords[:, 1]] = branch_field + 1
     except ValueError:  # when no skeleton to skan


### PR DESCRIPTION
Closes #986

With the release of `skan-0.12.2` we can remove the code which converts `-` in the variable names of Pandas DataFrames to instead use `_` which allows the use of "dot-notation" when referring to the variables of data frames.

We therefore unpin the `skan` version in `pyproject.toml`, explicitly state the `separator="_"` argument to `skan.summarize()` and adapt the hard-coded variable names appropriately. As noted in the [release notes](https://github.com/jni/skan/releases/tag/v0.12.2) the default will be `_` from `v0.13.0` and the flag allows backwards compatibility but since we have gone with the use of `_` in variable names it will do no harm leaving these in place (although they could be removed when `skan-v0.13.0` is released).


In addressing #986 I tested in a fresh virtual environment. This pulled in [matplotlib-3.10.0](https://github.com/matplotlib/matplotlib/releases/tag/v3.10.0) which was released 2024-12-14 (two days ago!). Our dependency on [topoly](topoly.cent.uw.edu.pl/documentation.html) doesn't work with this new version because of the removal of `inset_location.InsetPosition` in favour of `inset_axes`.

This has been reported to the Topoly developers, see [ImportError: cannot import name 'InsetPosition' from
'mpl_toolkits.axes_grid1.inset_locator' · Issue #5 · ilbsm/topoly_tutorial](https://github.com/ilbsm/topoly_tutorial/issues/5) and hopefully won't take long to resolve. For now though we pin our dependency `matplotlib~=3.9.4` and all tests pass.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.