### PR TITLE
style(notebooks): Ignore Flake8 complaints on Notebooks

### DIFF
--- a/notebooks/OUTDATED-02-Summary-statistics-and-plots.ipynb
+++ b/notebooks/OUTDATED-02-Summary-statistics-and-plots.ipynb
@@ -82,7 +82,7 @@
    "outputs": [],
    "source": [
     "df = pd.read_csv(\"../tests/resources/minicircle_default_all_statistics.csv\")\n",
-    "df.set_index([\"image\", \"threshold\", \"molecule_number\"], inplace=True)"
+    "df.set_index([\"image\", \"threshold\", \"grain_number\"], inplace=True)"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[df[\"circular\"] == False][\"end_to_end_distance\"].plot.hist(\n",
+    "df[df[\"circular\"] == False][\"end_to_end_distance\"].plot.hist(  # noqa: E712\n",
     "    figsize=(16, 9), bins=20, title=\"End to End Distance\", alpha=0.5\n",
     ")"
    ]

--- a/notebooks/OUTDATED-03-Plotting-scans.ipynb
+++ b/notebooks/OUTDATED-03-Plotting-scans.ipynb
@@ -70,11 +70,11 @@
     "    print(f\"filename               : {filename}\")\n",
     "    print(f\"uploaded_file[filename]['metadata'] : {uploaded_file[filename]['metadata']}\")\n",
     "    # print(f\"uploaded_file          : {str(uploaded_file.keys()[0])}\")\n",
-    "    content = uploaded_file[filename][\"content\"]\n",
+    "    content = uploaded_file[filename][\"content\"]  # noqa: F841\n",
     "\n",
     "\n",
     "upload_button = widgets.FileUpload(accept=\".npy\", multiple=False)\n",
-    "display(upload_button)\n",
+    "display(upload_button)  # noqa: F821\n",
     "# select_file_upload.observe(on_file_upload, names=\"value\")"
    ]
   },


### PR DESCRIPTION
One (E712) is a false positive as its used to subset a Pandas DataFrame.

The other two I've no current alternative plan as they involve creating buttons for users to upload files. Not sure
whether these will persist past the notebook refactor (#943) so have disabled the checks for the time being.

---

Before submitting a Pull Request please check the following.

- [x] Pre-commit checks pass.