### PR TITLE
feature: Adds --image-set as option to topostats

### DIFF
--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -106,6 +106,13 @@ def create_parser() -> arg.ArgumentParser:
         required=False,
         help="Channel to extract.",
     )
+    parser.add_argument(
+        "--image-set",
+        dest="image_set",
+        type=str,
+        required=False,
+        help="Image set to generate, default is 'core' other option is 'all'.",
+    )
 
     subparsers = parser.add_subparsers(title="program", description="Available programs, listed below:", dest="program")
 


### PR DESCRIPTION
Closes #1057

In reviewing #1056 I wanted to look at the individual grain curvature plots that were generated and realised that there
was no command-line option to modify the configuration value loaded from the YAML (`topostats/default_config.yaml` or
user specified with `--config-file/-c`).

This means that currently if people want the `all` image set then they have to use `topostats create-config` to create a
configuration file, modify the value of `image_set` and run the analysis with `topostats -c new_config.yaml`.

It was very quick and easy to add this option so I could check the output and as its been done I felt it should be
incorporated into TopoStats.

-------

- [x] Existing tests pass.
- [x] Pre-commit checks pass.