### PR TITLE
feature: expand objects returned by LoadScan.load_topostats()

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -25,6 +25,8 @@ from topostats.utils import update_plotting_config
 BASE_DIR = Path.cwd()
 RESOURCES = BASE_DIR / "tests/resources"
 
+# pylint: disable=too-many-positional-arguments
+
 
 # Can't see a way of parameterising with pytest-regtest as it writes to a file based on the file/function
 # so instead we run three regression tests.
@@ -202,7 +204,7 @@ def test_process_scan_both(regtest, tmp_path, process_scan_config: dict, load_sc
     # Check the keys, this will flag all new keys when adding output stats
     assert expected_topostats.keys() == saved_topostats.keys()
     # Check the data
-    assert dict_almost_equal(expected_topostats, saved_topostats)
+    assert dict_almost_equal(expected_topostats, saved_topostats, abs_tol=1e-6)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1067

Modifies `LoadScan.load_topostats()` to take an argument `extract: str = "all"` so that by default the cleaned
image (post filter) that is stored at `image`, `px_to_nm_scaling` and `data` that are stored in `.topostats` HDF5 are
returned.

To assist with #517 though it is also possible to specify other data to extract such as `raw` to get the original
image array and `pixel_to_nm_scaling` should the user want to re-run the `Filter` stage and `filter` should the user
wish to re-run the grain detection on the cleaned (post-Filter) array

The user options are mapped to the keys used in the HDF5 structure by means of a dictionary (which is local to the
`.load_topostats()` function) and will be extended as required in subsequent work.

Tests are expanded.

-------

# TopoStats Pull Requests

Please provide a descriptive summary of the changes your Pull Request introduces.

The [Software Development](https://afm-spm.github.io/TopoStats/main/contributing.html#software-development) section of
the Contributing Guidelines may be useful if you are unfamiliar with linting, pre-commit, docstrings and testing.

- [X] Existing tests pass.
- [X] Pre-commit checks pass.
- [X] New functions/methods have typehints and docstrings.
- [X] New functions/methods have tests which check the intended behaviour is correct.