### PR TITLE
Combine grain crops rather than overwriting them

### DIFF
--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -1334,8 +1334,15 @@ class Grains:
             grain_mask_tensor[
                 min_row + padding : max_row - padding,
                 min_col + padding : max_col - padding,
-                :,
-            ] = cropped_grain
+                :
+            ] = np.maximum(
+                grain_mask_tensor[
+                    min_row + padding : max_row - padding,
+                    min_col + padding : max_col - padding,
+                    :
+                ], 
+                cropped_grain
+            )
 
         # Update the background class
         grain_mask_tensor = Grains.update_background_class(grain_mask_tensor)

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -1331,17 +1331,11 @@ class Grains:
             ]
 
             # Update the grain mask tensor
-            grain_mask_tensor[
-                min_row + padding : max_row - padding,
-                min_col + padding : max_col - padding,
-                :
-            ] = np.maximum(
-                grain_mask_tensor[
-                    min_row + padding : max_row - padding,
-                    min_col + padding : max_col - padding,
-                    :
-                ], 
-                cropped_grain
+            grain_mask_tensor[min_row + padding : max_row - padding, min_col + padding : max_col - padding, :] = (
+                np.maximum(
+                    grain_mask_tensor[min_row + padding : max_row - padding, min_col + padding : max_col - padding, :],
+                    cropped_grain,
+                )
             )
 
         # Update the background class


### PR DESCRIPTION
Resolves #1066 

This PR resolves the bug found by @tcatley in issue #1066 by combining grain crops rather than overwriting them to avoid issues when multiple bounding boxes overlap one another. 

The image below shows how grain crops are now correctly combined to assemble full image masks.

![20240802_GMP_RTdryup_KCl2 0_00014_above_masked](https://github.com/user-attachments/assets/d7faa4db-80bc-44a5-b4bc-7e01512b0570)
