### PR TITLE
docs|style: line wrapping in adding_modules.md

### DIFF
--- a/docs/contributing/adding_modules.md
+++ b/docs/contributing/adding_modules.md
@@ -321,7 +321,8 @@ before a completion message is run.
 
 ## Conclusion
 
-Adding functionality is useful but it has to integrate into the workflow and ideally be accessible as a stand alone step in the process. Hopefully the above helps demystify the steps required to achieve this.
+Adding functionality is useful but it has to integrate into the workflow and ideally be accessible as a stand alone step
+in the process. Hopefully the above helps demystify the steps required to achieve this.
 
 [python_argparse]: https://docs.python.org/3/library/argparse.html
 [python_kwargs]: https://realpython.com/python-kwargs-and-args/


### PR DESCRIPTION
Also adds a link to the `contributing.md` page so that the `adding_modules.md` page is findable and can be read on the
website!

This will need tweaking when we switch to mkdocs (see #1079)