### PR TITLE
Replace deprecated Image.NEAREST with Image.Resampling.NEAREST

### DIFF
--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -201,7 +201,7 @@ def predict_unet(
         # Resize the channel mask to the original image size, but we want boolean so use nearest neighbour
         # Sylvia: Pylint incorrectly thinks that Image.NEAREST is not a member of Image. IDK why.
         # pylint: disable=no-member
-        channel_mask_PIL = channel_mask_PIL.resize((original_image.shape[1], original_image.shape[0]), Image.NEAREST)
+        channel_mask_PIL = channel_mask_PIL.resize((original_image.shape[1], original_image.shape[0]), Image.Resampling.NEAREST)
         resized_predicted_mask[:, :, channel_index] = np.array(channel_mask_PIL).astype(bool)
 
     return resized_predicted_mask

--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -201,7 +201,9 @@ def predict_unet(
         # Resize the channel mask to the original image size, but we want boolean so use nearest neighbour
         # Sylvia: Pylint incorrectly thinks that Image.NEAREST is not a member of Image. IDK why.
         # pylint: disable=no-member
-        channel_mask_PIL = channel_mask_PIL.resize((original_image.shape[1], original_image.shape[0]), Image.Resampling.NEAREST)
+        channel_mask_PIL = channel_mask_PIL.resize(
+            (original_image.shape[1], original_image.shape[0]), Image.Resampling.NEAREST
+        )
         resized_predicted_mask[:, :, channel_index] = np.array(channel_mask_PIL).astype(bool)
 
     return resized_predicted_mask


### PR DESCRIPTION
Really tiny change but Image.NEAREST is now deprecated and needs to be replaced with Image.Resampling.NEAREST to run without error. This is already corrected in the upcoming grains refactor but thought it was worth correcting in main in the meantime!

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Documentation has been updated and builds. Remember to update as required...
  - [ ] ~~`docs/configuration.md`~~
  - [ ] ~~`docs/usage.md`~~
  - [ ] ~~`docs/data_dictionary.md`~~
  - [ ] ~~`docs/advanced.md` and new pages it should link to.~~
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
