### PR TITLE
fix: Updates io to work with AFMReader only returning data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 requires-python = ">=3.9, <3.12"
 dependencies = [
   "art",
-  "AFMReader",
+  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@main",
   "h5py",
   "keras",
   "matplotlib~=3.9.4",

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -33,7 +33,6 @@ def test_median_flatten_no_mask(
     median_flattened = test_filters_random.median_flatten(
         image, mask=None, row_alignment_quantile=row_alignment_quantile
     )
-
     assert isinstance(median_flattened, np.ndarray)
     assert median_flattened.shape == (20, 20)
     np.testing.assert_allclose(median_flattened, expected, **TOLERANCE)
@@ -42,7 +41,6 @@ def test_median_flatten_no_mask(
 def test_remove_tilt_no_mask(test_filters_random: Filters, image_random_remove_x_y_tilt: np.array) -> None:
     """Test removal of x/y tilt."""
     tilt_removed = test_filters_random.remove_tilt(test_filters_random.images["pixels"], mask=None)
-
     assert isinstance(tilt_removed, np.ndarray)
     assert tilt_removed.shape == (1024, 1024)
     np.testing.assert_allclose(tilt_removed, image_random_remove_x_y_tilt, **TOLERANCE)

--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -174,7 +174,7 @@ def test_filters(caplog) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Filtering completed." in caplog.text
     # Load the output and check the keys
-    _, _, data = topostats.load_topostats("output/processed/minicircle_small.topostats")
+    data = topostats.load_topostats("output/processed/minicircle_small.topostats")
     assert list(data.keys()) == [
         "filename",
         "image",
@@ -205,7 +205,7 @@ def test_grains(caplog) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Grain detection completed (NB - Filtering was *not* re-run)." in caplog.text
     # Load the output and check the keys
-    _, _, data = topostats.load_topostats("output/processed/minicircle_small.topostats")
+    data = topostats.load_topostats("output/processed/minicircle_small.topostats")
     assert list(data.keys()) == [
         "filename",
         "grain_masks",


### PR DESCRIPTION
Closes #1086

Updates the `LoadScans.load_topostats()` and `LoadScans.get_data()` to work with the new version of AFMReader.

~~This means the CI tests _will_ fail because we haven't released AFMReader yet (and I'm wary of doing so until we are ready to make another TopoStats release).~~

EDIT : Updated `pyproject.toml` to install AFMReader from GitHub so tests should pass on CI :crossed_fingers: 

But...tests all pass for me locally(!) with AFMReader installed from `HEAD` of `main` branch.

If you want to check locally you'll need a fresh Python3.11 environment (because `topoly`!) and to install AFMReader from your local git clone (you can install from git using `pip` but I can't remember the command and am not going to look it up now!).

-------

# TopoStats Pull Requests


Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [ ] ~~Documentation has been updated and builds. Remember to update as required...~~
  - [ ] ~~`docs/configuration.md`~~
  - [ ] ~~`docs/usage.md`~~
  - [ ] ~~`docs/data_dictionary.md`~~
  - [ ] ~~`docs/advanced.md` and new pages it should link to.~~
- [x] ~~Pre-commit checks pass.
- [ ] ~~New functions/methods have typehints and docstrings.~~
- [ ] ~~New functions/methods have tests which check the intended behaviour is correct.~~