### PR TITLE
feature(grainstats): Adds entry point for grainstats

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -724,7 +724,7 @@ def test_process_scan_no_grains(process_scan_config: dict, load_scan_data: LoadS
 
 
 def test_run_filters(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path) -> None:
-    """Test the filter_wrapper function of processing.py."""
+    """Test the filter wrapper function of processing.py."""
     img_dict = load_scan_data.img_dict
     unprocessed_image = img_dict["minicircle_small"]["image_original"]
     pixel_to_nm_scaling = img_dict["minicircle_small"]["pixel_to_nm_scaling"]
@@ -745,7 +745,7 @@ def test_run_filters(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
 
 
 def test_run_grains(process_scan_config: dict, tmp_path: Path) -> None:
-    """Test the grains_wrapper function of processing.py."""
+    """Test the grains wrapper function of processing.py."""
     flattened_image = np.load("./tests/resources/minicircle_cropped_flattened.npy")
 
     grains_config = process_scan_config["grains"]

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -815,8 +815,8 @@ def create_parser() -> arg.ArgumentParser:
 
     grainstats_parser = subparsers.add_parser(
         "grainstats",
-        description="WIP DO NOT USE - Load images with grains from '.topostats' files and calculate statistics.",
-        help="WIP DO NOT USE - Load images with grains from '.topostats' files and calculate statistics.",
+        description="Load images with grains from '.topostats' files and calculate statistics.",
+        help="Load images with grains from '.topostats' files and calculate statistics.",
     )
     grainstats_parser.add_argument(
         "--edge-detection-method",

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -779,6 +779,9 @@ class LoadScans:
                         data = self.load_topostats(extract=self.extract)
                         self.image = data["image"]
                         self.pixel_to_nm_scaling = data["pixel_to_nm_scaling"]
+                        # If we need the grain masks for processing we extract them
+                        if self.extract in ("grainstats"):
+                            self.grain_masks = data["grain_masks"]
                     elif suffix == ".topostats" and self.extract in ("filter", "raw"):
                         self.image, self.pixel_to_nm_scaling = self.load_topostats(extract=self.extract)
                     else:
@@ -869,10 +872,21 @@ class LoadScans:
         dict[str, Any]
             Returns the image dictionary with keys/values removed appropriate to the extraction stage.
         """
-        if self.extract in ["grains", "grainstats"]:
+        # Reverse order so we remove things in reverse order, splining removes what it doesn't need then ordered
+        # tracing removes what it doesn't need, then nodestats, then disordered, then grainstats then grains, should be
+        # more succinct code with less popping
+        if self.extract in ["grains"]:
             img_dict.pop("disordered_traces")
             img_dict.pop("grain_curvature_stats")
             img_dict.pop("grain_masks")
+            img_dict.pop("height_profiles")
+            img_dict.pop("nodestats")
+            img_dict.pop("ordered_traces")
+            img_dict.pop("splining")
+            return img_dict
+        if self.extract in ["grainstats"]:
+            img_dict.pop("disordered_traces")
+            img_dict.pop("grain_curvature_stats")
             img_dict.pop("height_profiles")
             img_dict.pop("nodestats")
             img_dict.pop("ordered_traces")

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -260,7 +260,7 @@ def run_grainstats(
     grainstats_config: dict,
     plotting_config: dict,
     grain_out_path: Path,
-):
+) -> pd.DataFrame:
     """
     Calculate grain statistics for an image and optionally plots the results.
 
@@ -1334,10 +1334,10 @@ def process_grains(
     output_dir: str | Path = "output",
 ) -> tuple[str, bool]:
     """
-    Detect grains in an image return the flattened images and save to ''.topostats''.
+    Detect grains in flattened images and save to ''.topostats''.
 
-    Runs just the first key step of flattening images to remove noise, tilt and optionally scars saving to
-    ''.topostats'' for subsequent processing and analyses.
+    Runs grain detection on flattened images to identify grains and save data to  ''.topostats'' for subsequent
+    processing and analyses.
 
     Parameters
     ----------
@@ -1359,7 +1359,7 @@ def process_grains(
     tuple[str, bool]
         A tuple of the image and a boolean indicating if the image was successfully processed.
     """
-    core_out_path, filter_out_path, _, _ = get_out_paths(
+    core_out_path, _, grain_out_path, _ = get_out_paths(
         image_path=topostats_object["img_path"],
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1374,7 +1374,7 @@ def process_grains(
             image=topostats_object["image"],
             pixel_to_nm_scaling=topostats_object["pixel_to_nm_scaling"],
             filename=topostats_object["filename"],
-            grain_out_path=filter_out_path,
+            grain_out_path=grain_out_path,
             core_out_path=core_out_path,
             plotting_config=plotting_config,
             grains_config=grains_config,
@@ -1389,6 +1389,78 @@ def process_grains(
     except:  # noqa: E722  # pylint: disable=bare-except
         LOGGER.info(f"Grain detection failed for image : {topostats_object['filename']}")
         return (topostats_object["filename"], False)
+
+
+def process_grainstats(
+    topostats_object: dict,
+    base_dir: str | Path,
+    grainstats_config: dict,
+    plotting_config: dict,
+    output_dir: str | Path = "output",
+) -> tuple[str, bool]:
+    """
+    Calculate grain statistics in an image where grains have already been detected.
+
+    Runs just the first key step of flattening images to remove noise, tilt and optionally scars saving to
+    ''.topostats'' for subsequent processing and analyses.
+
+    Parameters
+    ----------
+    topostats_object : dict[str, Union[npt.NDArray, Path, float]]
+        A dictionary with keys 'image', 'img_path' and 'pixel_to_nm_scaling' containing a file or frames' image, it's
+        path and it's pixel to namometre scaling value.
+    base_dir : str | Path
+        Directory to recursively search for files, if not specified the current directory is scanned.
+    grainstats_config : dict
+        Dictionary of configuration options for running the Filter stage.
+    plotting_config : dict
+        Dictionary of configuration options for plotting figures.
+    output_dir : str | Path
+        Directory to save output to, it will be created if it does not exist. If it already exists then it is possible
+        that output will be over-written.
+
+    Returns
+    -------
+    tuple[str, bool]
+        A tuple of the image and a boolean indicating if the image was successfully processed.
+    """
+    core_out_path, _, grainstats_out_path, _ = get_out_paths(
+        image_path=topostats_object["img_path"],
+        base_dir=base_dir,
+        output_dir=output_dir,
+        filename=topostats_object["filename"],
+        plotting_config=plotting_config,
+    )
+    plotting_config = add_pixel_to_nm_to_plotting_config(plotting_config, topostats_object["pixel_to_nm_scaling"])
+
+    # Calculate grainstats if there are any to be detected
+    # try:
+    print(f"\n{topostats_object.keys()=}\n")
+    if "above" in topostats_object["grain_masks"].keys() or "below" in topostats_object["grain_masks"].keys():
+        grainstats_df, height_profiles = run_grainstats(
+            image=topostats_object["image"],
+            pixel_to_nm_scaling=topostats_object["pixel_to_nm_scaling"],
+            grain_masks=topostats_object["grain_masks"],
+            filename=topostats_object["filename"],
+            basename=topostats_object["img_path"],
+            grainstats_config=grainstats_config,
+            plotting_config=plotting_config,
+            grain_out_path=grainstats_out_path,
+        )
+        # Save the topostats dictionary object to .topostats file.
+        topostats_object["height_profiles"] = height_profiles
+        save_topostats_file(
+            output_dir=core_out_path, filename=str(topostats_object["filename"]), topostats_object=topostats_object
+        )
+        return (topostats_object["filename"], grainstats_df, height_profiles)
+    return (
+        topostats_object["filename"],
+        create_empty_dataframe(column_set="grainstats", index_col="grain_number"),
+        None,
+    )
+    # except:  # noqa: E722  # pylint: disable=bare-except
+    #     LOGGER.info(f"Grain detection failed for image : {topostats_object['filename']}")
+    #     return (create_empty_dataframe(column_set="grainstats", index_col="grain_number"), False)
 
 
 def check_run_steps(  # noqa: C901


### PR DESCRIPTION
Closes #743

Adds an entry point for running GrainStats `process grainstats --help`.

You can test it with...

```
❱ topostats -b tests/resources/test_image -f .topostats grainstats
❱ tree output
[4.0K Feb 24 14:53]  output
├── [2.7K Feb 24 14:53]  output/config.yaml
├── [2.7K Feb 24 14:53]  output/height_profiles.json
├── [1.7K Feb 24 14:53]  output/image_stats.csv
└── [4.0K Feb 24 14:53]  output/processed
    └── [109K Feb 24 14:53]  output/processed/minicircle_small.topostats

2 directories, 4 files
```

Unlike with #1076 only the required directory structure is created.

-------


Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Documentation has been updated and builds. Remember to update as required...
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.