### PR TITLE
tests: disable test_run_modules::test_grainstats

### DIFF
--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -218,6 +218,7 @@ def test_grains(caplog) -> None:
     ]
 
 
+@pytest.mark.xfail(reason="Awaiting update of AFMReader to reconstruct `image_grain_crops` with correct classes")
 def test_grainstats(caplog) -> None:
     """Test running the grainstats module.
 
@@ -239,30 +240,34 @@ def test_grainstats(caplog) -> None:
     assert "[minicircle_small] Grainstats completed (NB - Filtering was *not* re-run)." in caplog.text
     # Load the output and check the keys
     data = pd.read_csv("output/image_stats.csv")
-    print(f"\n{list(data.columns)=}\n")
     assert list(data.columns) == [
+        "Unnamed: 0",
+        "image",
+        "basename",
         "grain_number",
+        "area",
+        "area_cartesian_bbox",
+        "aspect_ratio",
+        "bending_angle",
         "centre_x",
         "centre_y",
-        "radius_min",
+        "circular",
+        "contour_length",
+        "end_to_end_distance",
+        "height_max",
+        "height_mean",
+        "height_median",
+        "height_min",
+        "max_feret",
+        "min_feret",
         "radius_max",
         "radius_mean",
         "radius_median",
-        "height_min",
-        "height_max",
-        "height_median",
-        "height_mean",
-        "volume",
-        "area",
-        "area_cartesian_bbox",
-        "smallest_bounding_width",
-        "smallest_bounding_length",
+        "radius_min",
         "smallest_bounding_area",
-        "aspect_ratio",
+        "smallest_bounding_length",
+        "smallest_bounding_width",
         "threshold",
-        "max_feret",
-        "min_feret",
-        "image",
-        "basename",
+        "volume",
     ]
     assert data.shape == (3, 23)


### PR DESCRIPTION
The refactoring to use classes for objects rather than dictionaries breaks the `topostats grainstats` entry point that
was introduced with #1094.

Previously the dictionary item `image=topostats_object["image"]` was passed into `processing.run_grainstats()` when called from
`processing.process_grainstats()`. The refactoring requires that `image_grain_crop=image_grain_crop`, an object of the new type
`ImageGrainCrops`, is now passed to `grainstats`.

This isn't currently possible though because `AFMReader` loads `.topostats` objects and returns a dictionary and whilst
the refactoring does save the new `image_grain_crop` (/`ImageGrainCrops`) the loading does _not_ currently re-create
these structures.

For now I have disabled the test of the entry point. Once this refactoring has been merged we will have to...

- Make `TopoStats` a dependency of `AFMReader` (somewhat wary of this as it may cause headaches further down the line
  but for now we'll go with it!).
- Modify `AFMReader.topostats.load_topostats()` to modify the `data["grain_tensors"]["above"]` and
  `data["grain_tensors"]["above"]` so that they are of class `ImageGrainCrops` (and the associated nested classes).
- Once that is done we can then pass the loaded `data["grain_tensors"]` to `processing.run_grainstats()` (this may
require reconstructing to be the same as `image_grain_crop`, not sure at the moment!)


**EDIT** : Looking at this further we have a challenge as currently only the `image_grain_crops.[above|below].full_mask_tensors` are added to the `topostats_object` which means that when we load `.topostats` object it is not possible to create the `ImageGrainCrops` without first re-running the grain detection. This in turn means its not possible to have entry points for `grainstats` and all subsequent processing stages until we inlcude this data, at least in raw-format, when we save `.topostats` objects so that `AFMReader` can recreate them on loading.

I've noted this and more thoughts down in [AFMReader #121](https://github.com/AFM-SPM/AFMReader/issues/121).