### PR TITLE
feature(grains|io): Method to convert GrainCrop to dictionary

### DIFF
--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -68,6 +68,19 @@ grain_array4 = np.array(
 )
 
 
+def test_grain_crop_to_dict(dummy_graincrop: GrainCrop):
+    """Test the GrainCrop.grain_crop_to_dict() method."""
+    expected = {
+        "image": dummy_graincrop.image,
+        "mask": dummy_graincrop.mask,
+        "padding": dummy_graincrop.padding,
+        "bbox": dummy_graincrop.bbox,
+        "pixel_to_nm_scaling": dummy_graincrop.pixel_to_nm_scaling,
+        "filename": dummy_graincrop.filename,
+    }
+    np.testing.assert_array_equal(dummy_graincrop.grain_crop_to_dict(), expected)
+
+
 @pytest.mark.parametrize(
     ("area_thresh_nm", "expected"),
     [([None, None], grain_array), ([None, 32], grain_array2), ([12, 24], grain_array3), ([32, 44], grain_array4)],
@@ -279,7 +292,6 @@ def test_remove_edge_intersecting_grains(
     assert number_of_grains == expected_number_of_grains
 
 
-# Find grains without unet
 @pytest.mark.parametrize(
     (
         "image",
@@ -621,7 +633,7 @@ def test_find_grains(
     expected_labelled_regions: npt.NDArray[np.int32],
     expected_imagegraincrops: ImageGrainCrops,
 ) -> None:
-    """Test the find_grains method of the Grains class."""
+    """Test the find_grains method of the Grains class without unet."""
     # Initialise the grains object
     grains_object = Grains(
         image=image,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -960,22 +960,23 @@ def test_dict_to_hdf5_list(tmp_path: Path) -> None:
         np.testing.assert_array_equal(f["list"][()], expected["list"])
 
 
-def test_dict_to_hdf5_graincrop(dummy_graincrop: grains.GrainCrop, tmp_path: Path) -> None:
+def test_dict_to_hdf5_graincrop(dummy_graincrops_dict: grains.GrainCrop, tmp_path: Path) -> None:
     """Test loading a GrainGrop object and writing to file."""
     # Make a dictionary from dummy_graincrop
+    print(f"{dummy_graincrops_dict=}")
     expected = {
         "0": {
-            "image": dummy_graincrop.image,
-            "mask": dummy_graincrop.mask,
-            "padding": dummy_graincrop.padding,
-            "bbox": dummy_graincrop.bbox,
-            "pixel_to_nm_scaling": dummy_graincrop.pixel_to_nm_scaling,
-            "filename": dummy_graincrop.filename,
+            "image": dummy_graincrops_dict[0].image,
+            "mask": dummy_graincrops_dict[0].mask,
+            "padding": dummy_graincrops_dict[0].padding,
+            "bbox": dummy_graincrops_dict[0].bbox,
+            "pixel_to_nm_scaling": dummy_graincrops_dict[0].pixel_to_nm_scaling,
+            "filename": dummy_graincrops_dict[0].filename,
         }
     }
 
     with h5py.File(tmp_path / "hdf5_grain_crop.hdf5", "w") as f:
-        dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary={0: dummy_graincrop})
+        dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary=dummy_graincrops_dict)
     # Load it back in and check if the dictionary is the same
     with h5py.File(tmp_path / "hdf5_grain_crop.hdf5", "r") as f:
         # Check keys are the same

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -963,7 +963,6 @@ def test_dict_to_hdf5_list(tmp_path: Path) -> None:
 def test_dict_to_hdf5_graincrop(dummy_graincrops_dict: grains.GrainCrop, tmp_path: Path) -> None:
     """Test loading a GrainGrop object and writing to file."""
     # Make a dictionary from dummy_graincrop
-    print(f"{dummy_graincrops_dict=}")
     expected = {
         "0": {
             "image": dummy_graincrops_dict[0].image,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from topostats import grains
 from topostats.io import (
     LoadScans,
     convert_basename_to_relative_paths,
@@ -957,6 +958,34 @@ def test_dict_to_hdf5_list(tmp_path: Path) -> None:
         # Check keys are the same
         assert sorted(f.keys()) == sorted(expected.keys())
         np.testing.assert_array_equal(f["list"][()], expected["list"])
+
+
+def test_dict_to_hdf5_graincrop(dummy_graincrop: grains.GrainCrop, tmp_path: Path) -> None:
+    """Test loading a GrainGrop object and writing to file."""
+    # Make a dictionary from dummy_graincrop
+    expected = {
+        "0": {
+            "image": dummy_graincrop.image,
+            "mask": dummy_graincrop.mask,
+            "padding": dummy_graincrop.padding,
+            "bbox": dummy_graincrop.bbox,
+            "pixel_to_nm_scaling": dummy_graincrop.pixel_to_nm_scaling,
+            "filename": dummy_graincrop.filename,
+        }
+    }
+
+    with h5py.File(tmp_path / "hdf5_grain_crop.hdf5", "w") as f:
+        dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary={0: dummy_graincrop})
+    # Load it back in and check if the dictionary is the same
+    with h5py.File(tmp_path / "hdf5_grain_crop.hdf5", "r") as f:
+        # Check keys are the same
+        assert sorted(f.keys()) == sorted(expected.keys())
+        np.testing.assert_array_equal(f["0"]["image"], expected["0"]["image"])
+        np.testing.assert_array_equal(f["0"]["mask"], expected["0"]["mask"])
+        assert f["0"]["padding"], expected["0"]["padding"]
+        assert f["0"]["bbox"], expected["0"]["bbox"]
+        assert f["0"]["pixel_to_nm_scaling"], expected["0"]["pixel_to_nm_scaling"]
+        assert f["0"]["filename"], expected["0"]["filename"]
 
 
 def test_hdf5_to_dict_all_together_group_path_default(tmp_path: Path) -> None:

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -7,6 +7,7 @@ import logging
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import Any
 
 import keras
 import numpy as np
@@ -32,12 +33,13 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 
 # pylint: disable=fixme
 # pylint: disable=line-too-long
-# pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-public-methods
 # pylint: disable=bare-except
 # pylint: disable=dangerous-default-value
-# pylint: disable=too-many-lines
-# pylint: disable=too-many-public-methods
 
 
 class GrainCrop:
@@ -321,6 +323,24 @@ class GrainCrop:
             and self.pixel_to_nm_scaling == other.pixel_to_nm_scaling
             and self.filename == other.filename
         )
+
+    def grain_crop_to_dict(self) -> dict[str, Any]:
+        """
+        Convert grain crop to dictionary indexed by attributes.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary indexed by attribute of the grain attributes.
+        """
+        return {
+            "image": self.image,
+            "mask": self.mask,
+            "bbox": self.bbox,
+            "pixel_to_nm_scaling": self.pixel_to_nm_scaling,
+            "padding": self.padding,
+            "filename": self.filename,
+        }
 
     def debug_locate_difference(self, other: object) -> None:
         """
@@ -1938,7 +1958,6 @@ class Grains:
 
         # Iterate over the grain crops
         for grain_number, graincrop in graincrops.items():
-
             single_grain_mask_tensor = graincrop.mask
             pixel_to_nm_scaling = graincrop.pixel_to_nm_scaling
 

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
@@ -333,14 +334,7 @@ class GrainCrop:
         dict[str, Any]
             Dictionary indexed by attribute of the grain attributes.
         """
-        return {
-            "image": self.image,
-            "mask": self.mask,
-            "bbox": self.bbox,
-            "pixel_to_nm_scaling": self.pixel_to_nm_scaling,
-            "padding": self.padding,
-            "filename": self.filename,
-        }
+        return {re.sub(r"^_", "", key): value for key, value in self.__dict__.items()}
 
     def debug_locate_difference(self, other: object) -> None:
         """
@@ -843,7 +837,7 @@ class Grains:
             )
             LOGGER.debug(
                 f"[{self.filename}] : Removed small objects (< \
-{self.minimum_grain_size} px^2 / {self.minimum_grain_size / (self.pixel_to_nm_scaling)**2} nm^2)"
+{self.minimum_grain_size} px^2 / {self.minimum_grain_size / (self.pixel_to_nm_scaling) ** 2} nm^2)"
             )
             return small_objects_removed > 0.0
         return image

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -975,11 +975,7 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
                 dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.full_mask_tensor)
             elif isinstance(item, grains.GrainCrop):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.image)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.mask)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.bbox)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.pixel_to_nm_scaling)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.padding)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crop_to_dict())
             # Dictionaries need to be recursively saved
             elif isinstance(item, dict):  # a sub-dictionary, so we need to recurse
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
@@ -1050,7 +1046,7 @@ def save_topostats_file(output_dir: Path, filename: str, topostats_object: dict)
         # It may be possible for topostats_object["image"] to be None.
         # Make sure that this is not the case.
         if topostats_object["image"] is not None:
-            topostats_object["topostats_file_version"] = 0.3
+            topostats_object["topostats_file_version"] = 0.2
             # Recursively save the topostats object dictionary to the .topostats file
             dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary=topostats_object)
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -22,6 +22,7 @@ from AFMReader import asd, gwy, ibw, jpk, spm, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
+from topostats import grains
 from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
@@ -32,6 +33,7 @@ CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and 
 
 # pylint: disable=broad-except
 # pylint: disable=too-many-lines
+# pylint: disable=too-many-branches
 
 MutableMappingType = TypeVar("MutableMappingType", bound="MutableMapping")
 
@@ -906,7 +908,7 @@ class LoadScans:
         return img_dict
 
 
-def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -> None:
+def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -> None:  # noqa: C901
     """
     Recursively save a dictionary to an open hdf5 file.
 
@@ -929,23 +931,58 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
 
         # Check if the item is a known datatype
         # Ruff wants us to use the pipe operator here but it isn't supported by python 3.9
-        if isinstance(item, (list, str, int, float, np.ndarray, Path, dict)):  # noqa: UP038
+        if isinstance(
+            item,
+            (
+                list,
+                str,
+                int,
+                float,
+                np.ndarray,
+                Path,
+                dict,
+                grains.GrainCrop,
+                grains.GrainCropsDirection,
+                grains.ImageGrainCrops,
+            ),
+        ):  # noqa: UP038
             # Lists need to be converted to numpy arrays
             if isinstance(item, list):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 item = np.array(item)
                 open_hdf5_file[group_path + key] = item
             # Strings need to be encoded to bytes
             elif isinstance(item, str):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 open_hdf5_file[group_path + key] = item.encode("utf8")
             # Integers, floats and numpy arrays can be added directly to the hdf5 file
             # Ruff wants us to use the pipe operator here but it isn't supported by python 3.9
             elif isinstance(item, (int, float, np.ndarray)):  # noqa: UP038
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 open_hdf5_file[group_path + key] = item
             # Path objects need to be encoded to bytes
             elif isinstance(item, Path):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 open_hdf5_file[group_path + key] = str(item).encode("utf8")
+            # Extract ImageGrainCrops
+            elif isinstance(item, grains.ImageGrainCrops):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.above)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.below)
+            elif isinstance(item, grains.GrainCropsDirection):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.crops)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.full_mask_tensor)
+            elif isinstance(item, grains.GrainCrop):
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.image)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.mask)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.bbox)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.pixel_to_nm_scaling)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.padding)
             # Dictionaries need to be recursively saved
             elif isinstance(item, dict):  # a sub-dictionary, so we need to recurse
+                LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 dict_to_hdf5(open_hdf5_file, group_path + key + "/", item)
         else:  # attempt to save an item that is not a numpy array or a dictionary
             try:
@@ -1013,7 +1050,7 @@ def save_topostats_file(output_dir: Path, filename: str, topostats_object: dict)
         # It may be possible for topostats_object["image"] to be None.
         # Make sure that this is not the case.
         if topostats_object["image"] is not None:
-            topostats_object["topostats_file_version"] = 0.2
+            topostats_object["topostats_file_version"] = 0.3
             # Recursively save the topostats object dictionary to the .topostats file
             dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary=topostats_object)
 


### PR DESCRIPTION
Adds a method to convert a `grains.GrainCrop` object to a dictionary (`grains.GrainCrop.grain_crop_to_dict()`) which is
indexed by the attribute names with the attributes as the values. Includes a simple test using the `dummy_graincrop`
fixture.

As this will be needed to convert the nested dictionaries of `ImageGrainCrops` (which hold `GrainCrop` objects within
`GrainCropsDirection`) objects we include a check to see if the `item` (value) of a dictionary is of type `GrainCrop`
and if so recursively call `dict_to_hdf5` on the result of `item.grain_crop_to_dict()`. Again a simple test to ensure
this functions as expected is included.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [x] New functions/methods have tests which check the intended behaviour is correct.