### PR TITLE
feature(grains|io): GrainCropsDirection to dictionary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 requires-python = ">=3.9, <3.12"
 dependencies = [
   "art",
-  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@main",
+  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@1f03159edae2e906cb709ad9949d7b6d460cd1a9",
   "h5py",
   "keras",
   "matplotlib~=3.9.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from skimage.morphology import skeletonize
 
 import topostats
 from topostats.filters import Filters
-from topostats.grains import GrainCrop, Grains
+from topostats.grains import GrainCrop, GrainCropsDirection, Grains
 from topostats.grainstats import GrainStats
 from topostats.io import LoadScans, read_yaml
 from topostats.plotting import TopoSum
@@ -379,6 +379,45 @@ def dummy_graincrop() -> GrainCrop:
 def dummy_graincrops_dict(dummy_graincrop: GrainCrop) -> dict[int, GrainCrop]:
     """Dummy dictionary of GrainCrop objects for testing."""
     return {0: dummy_graincrop}
+
+
+@pytest.fixture()
+def dummy_graincropsdirection(dummy_graincrops_dict: dict[int, GrainCrop]) -> GrainCropsDirection:
+    """Dummy GrainCropsDirection object for testing."""
+    full_mask_tensor = np.stack(
+        [
+            np.array(
+                [
+                    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 0, 0, 0, 0, 0, 0, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                ]
+            ),
+            np.array(
+                [
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                ],
+            ),
+        ],
+        axis=-1,
+    ).astype(np.bool_)
+    return GrainCropsDirection(full_mask_tensor=full_mask_tensor, crops=dummy_graincrops_dict)
 
 
 @pytest.fixture()

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -81,6 +81,15 @@ def test_grain_crop_to_dict(dummy_graincrop: GrainCrop):
     np.testing.assert_array_equal(dummy_graincrop.grain_crop_to_dict(), expected)
 
 
+def test_grain_crop_direction_to_dict(dummy_graincropsdirection: GrainCropsDirection):
+    """Test the GrainCropDirection.grain_crop_direction_to_dict() method."""
+    expected = {
+        "crops": dummy_graincropsdirection.crops,
+        "full_mask_tensor": dummy_graincropsdirection.full_mask_tensor,
+    }
+    assert dict_almost_equal(dummy_graincropsdirection.grain_crops_direction_to_dict(), expected)
+
+
 @pytest.mark.parametrize(
     ("area_thresh_nm", "expected"),
     [([None, None], grain_array), ([None, 32], grain_array2), ([12, 24], grain_array3), ([32, 44], grain_array4)],
@@ -94,7 +103,7 @@ def test_known_array_threshold(area_thresh_nm, expected) -> None:
 # def test_random_grains(random_grains: Grains, caplog) -> None:
 #     """Test errors raised when processing images without grains."""
 #     # FIXME : I can see for myself that the error message is logged but the assert fails as caplog.text is empty?
-#     # assert "No gains found." in caplog.text
+#     # assert "No grains found." in caplog.text
 #     assert True
 
 

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -327,7 +327,7 @@ class GrainCrop:
 
     def grain_crop_to_dict(self) -> dict[str, Any]:
         """
-        Convert grain crop to dictionary indexed by attributes.
+        Convert GrainCrop to dictionary indexed by attributes.
 
         Returns
         -------
@@ -454,6 +454,17 @@ class GrainCropsDirection:
         if not isinstance(other, GrainCropsDirection):
             return False
         return self.crops == other.crops and np.array_equal(self.full_mask_tensor, other.full_mask_tensor)
+
+    def grain_crops_direction_to_dict(self) -> dict[str, npt.NDArray[np.bool_] | dict[str:Any]]:
+        """
+        Convert GrainCropsDirection to dictionary indexed by attributes.
+
+        Returns
+        -------
+        dict[str, Any]
+            Dictionary indexed by attribute of the grain attributes.
+        """
+        return {re.sub(r"^_", "", key): value for key, value in self.__dict__.items()}
 
     def debug_locate_difference(self, other: object) -> None:
         """

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -967,12 +967,10 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
             # Extract ImageGrainCrops
             elif isinstance(item, grains.ImageGrainCrops):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.above)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.below)
+                # dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.image_grain_crops_to_dict())
             elif isinstance(item, grains.GrainCropsDirection):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.crops)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.full_mask_tensor)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crops_direction_to_dict())
             elif isinstance(item, grains.GrainCrop):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crop_to_dict())


### PR DESCRIPTION
**NB** This is a stacked pull request and should be merged _after_ #1104

Adds a method, based on the `__dict__` "magic dunder" method to convert the `GrainCropsDirection` to a dictionary. Tests
are included not just for the method itself but because this is required in `io.dict_to_hdf5` there are also tests that
it works with that (these are contingent on changes introduced in #1104 because `GrainCrop` are nested within the
`GrainCropsDirection` object).


- [X] Existing tests pass.
- [X] Pre-commit checks pass.
- [X] New functions/methods have typehints and docstrings.
- [X] New functions/methods have tests which check the intended behaviour is correct.