### PR TITLE
tests(jpk): Updates sum of images loaded from JPK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 requires-python = ">=3.9, <3.12"
 dependencies = [
   "art",
-  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@1f03159edae2e906cb709ad9949d7b6d460cd1a9",
+  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@main",
   "h5py",
   "keras",
   "matplotlib~=3.9.4",

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -529,7 +529,7 @@ def test_load_scan_jpk(load_scan_jpk: LoadScans) -> None:
     image, px_to_nm_scaling = load_scan_jpk.load_jpk()
     assert isinstance(image, np.ndarray)
     assert image.shape == (256, 256)
-    assert image.sum() == 286598232.9308627
+    assert image.sum() == 219242202.8256843
     assert isinstance(px_to_nm_scaling, float)
     assert px_to_nm_scaling == 1.2770176335964876
 
@@ -648,7 +648,7 @@ def test_load_scan_topostats_components_flattened(
     [
         pytest.param("load_scan_spm", 1, (1024, 1024), 30695369.188316286, "minicircle", 0.4940029296875, id="spm"),
         pytest.param("load_scan_ibw", 1, (512, 512), -218091520.0, "minicircle2", 1.5625, id="ibw"),
-        pytest.param("load_scan_jpk", 1, (256, 256), 286598232.9308627, "file", 1.2770176335964876, id="jpk"),
+        pytest.param("load_scan_jpk", 1, (256, 256), 219242202.8256843, "file", 1.2770176335964876, id="jpk"),
         pytest.param("load_scan_gwy", 1, (512, 512), 33836850.232917726, "file", 0.8468632812499975, id="gwy"),
         pytest.param(
             "load_scan_topostats",


### PR DESCRIPTION
Closes #1110

In light of the changes to AFMReader which modified the scaling the sum of the arrays of the `.jpk` test files needed
updating here too.


Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.