### PR TITLE
Add code for loading .stp and .top files

### DIFF
--- a/topostats/io.py
+++ b/topostats/io.py
@@ -18,7 +18,7 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from AFMReader import asd, gwy, ibw, jpk, spm, topostats, stp, top
+from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
@@ -771,7 +771,7 @@ class LoadScans:
         except FileNotFoundError:
             LOGGER.error(f"File not found : {self.img_path}")
             raise
-     
+
     def load_stp(self) -> tuple[npt.NDArray, float]:
         """
         Extract image and pixel to nm scaling from the WsXM .stp file.
@@ -1001,12 +1001,10 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
             # Extract ImageGrainCrops
             elif isinstance(item, grains.ImageGrainCrops):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.above)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.below)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.image_grain_crops_to_dict())
             elif isinstance(item, grains.GrainCropsDirection):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.crops)
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.full_mask_tensor)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crops_direction_to_dict())
             elif isinstance(item, grains.GrainCrop):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crop_to_dict())

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -18,7 +18,7 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from AFMReader import asd, gwy, ibw, jpk, spm, topostats
+from AFMReader import asd, gwy, ibw, jpk, spm, topostats, stp, top
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
@@ -756,6 +756,38 @@ class LoadScans:
             LOGGER.error(f"File not found : {self.img_path}")
             raise
 
+    def load_top(self) -> tuple[npt.NDArray, float]:
+        """
+        Extract image and pixel to nm scaling from the WsXM .top file.
+
+        Returns
+        -------
+        tuple[npt.NDArray, float]
+            A tuple containing the image and its pixel to nanometre scaling value.
+        """
+        LOGGER.debug(f"Loading image from : {self.img_path}")
+        try:
+            return top.load_top(file_path=self.img_path)
+        except FileNotFoundError:
+            LOGGER.error(f"File not found : {self.img_path}")
+            raise
+     
+    def load_stp(self) -> tuple[npt.NDArray, float]:
+        """
+        Extract image and pixel to nm scaling from the WsXM .stp file.
+
+        Returns
+        -------
+        tuple[npt.NDArray, float]
+            A tuple containing the image and its pixel to nanometre scaling value.
+        """
+        LOGGER.debug(f"Loading image from : {self.img_path}")
+        try:
+            return stp.load_stp(file_path=self.img_path)
+        except FileNotFoundError:
+            LOGGER.error(f"File not found : {self.img_path}")
+            raise
+
     def get_data(self) -> None:  # noqa: C901  # pylint: disable=too-many-branches
         """Extract image, filepath and pixel to nm scaling value, and append these to the img_dic object."""
         suffix_to_loader = {
@@ -765,6 +797,8 @@ class LoadScans:
             ".gwy": self.load_gwy,
             ".topostats": self.load_topostats,
             ".asd": self.load_asd,
+            ".stp": self.load_stp,
+            ".top": self.load_top,
         }
         for img_path in self.img_paths:
             self.img_path = img_path
@@ -967,10 +1001,12 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
             # Extract ImageGrainCrops
             elif isinstance(item, grains.ImageGrainCrops):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.image_grain_crops_to_dict())
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.above)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.below)
             elif isinstance(item, grains.GrainCropsDirection):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
-                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crops_direction_to_dict())
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.crops)
+                dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.full_mask_tensor)
             elif isinstance(item, grains.GrainCrop):
                 LOGGER.debug(f"[dict_to_hdf5] {key} is of type : {type(item)}")
                 dict_to_hdf5(open_hdf5_file, group_path + key + "/", item.grain_crop_to_dict())

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -56,6 +56,8 @@ DEFAULT_CONFIG_SCHEMA = Schema(
             ".ibw",
             ".gwy",
             ".topostats",
+            ".stp",
+            ".top",
             error="Invalid value in config for 'file_ext', valid values are '.spm', '.jpk', '.ibw', '.gwy', '.topostats', or '.asd'.",
         ),
         "loading": {


### PR DESCRIPTION
# TopoStats Pull Requests

>Please provide a descriptive summary of the changes your Pull Request introduces.

Added load_stp and load_top funtions to process .top and .stp file extension. These formats are used in Nanotec AFMs. 
I have attached and example of these images and config files below:
[test_images.zip](https://github.com/user-attachments/files/19778259/test_images.zip)

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass. - waiting for https://github.com/AFM-SPM/AFMReader/tree/SylviaWhittle/132-file-format-top
- [x] Documentation has been updated and builds. Remember to update as required...
  - [x] `docs/configuration.md` - not necessary
  - [x] `docs/usage.md` - not necessary
  - [x] `docs/data_dictionary.md` - not necessary
  - [x] `docs/advanced.md` and new pages it should link to. - not necessary
- [x] Pre-commit checks pass.
- [x] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [x] There is a comment adjacent to the option explaining what it is and the valid values. - not necessary
- [x] A check is made in `topostats/validation.py`
to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`. - not necessary

-------

1. Once Sylvias AFMReader branch is merged we could run the tests. `pytest .\tests\`
2. Possibly add a new test for these functions 
3. Turn off draft PR