### PR TITLE
feature: Introduce TopoStats class and saving to HDF5 .topostats

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -472,6 +472,20 @@ def imagegraincrops_catenanes(graincrops_above_catenanes: GrainCropsDirection) -
 
 
 @pytest.fixture()
+def topostats_catenanes_2_4_0(imagegraincrops_catenanes) -> topostats.TopoStats:
+    """TopoStats object of example catenanes."""
+    return topostats.TopoStats(
+        image_grain_crops=imagegraincrops_catenanes,
+        filename="example_catenanes.spm",
+        pixel_to_nm_scaling=0.488,
+        topostats_version="2.4.0",
+        img_path=str(GRAINCROP_DIR),
+        image=None,
+        image_original=None,
+    )
+
+
+@pytest.fixture()
 def graincrop_rep_int_0() -> GrainCrop:
     """Rep_Int GrainCrop object."""
     image: npt.NDArray[float] = np.load(GRAINCROP_DIR / "example_rep_int_image_0.npy")
@@ -497,6 +511,20 @@ def graincrops_above_rep_int(graincrop_rep_int_0: GrainCrop) -> GrainCropsDirect
 def imagegraincrops_rep_int(graincrops_above_rep_int: GrainCropsDirection) -> ImageGrainCrops:
     """ImageGrainCrops object of example rep_int."""
     return ImageGrainCrops(above=graincrops_above_rep_int, below=None)
+
+
+@pytest.fixture()
+def topostats_rep_int_2_4_0(imagegraincrops_rep_int) -> topostats.TopoStats:
+    """TopoStats object of example rep_int."""
+    return topostats.TopoStats(
+        image_grain_crops=imagegraincrops_rep_int,
+        filename="example_rep_int.spm",
+        pixel_to_nm_scaling=0.488,
+        topostats_version="2.4.0",
+        img_path=str(GRAINCROP_DIR),
+        image=None,
+        image_original=None,
+    )
 
 
 @pytest.fixture()

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -1,0 +1,81 @@
+"""Tests for the main module components defined in ''__init__.py''."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+import topostats
+from topostats.grains import ImageGrainCrops
+
+BASE_DIR = Path.cwd()
+RESOURCES = BASE_DIR / "tests" / "resources"
+GRAINCROP_DIR = RESOURCES / "graincrop"
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+
+
+@pytest.mark.parametrize(
+    (
+        "topostats_object",
+        "image_grain_crops",
+        "filename",
+        "pixel_to_nm_scaling",
+        "topostats_version",
+        "img_path",
+        "image",
+        "image_original",
+    ),
+    [
+        pytest.param(
+            "topostats_catenanes_2_4_0",
+            "imagegraincrops_catenanes",
+            "example_catenanes.spm",
+            0.488,
+            "2.4.0",
+            str(GRAINCROP_DIR),
+            None,
+            None,
+            id="catenane v2.4.0",
+        ),
+        pytest.param(
+            "topostats_rep_int_2_4_0",
+            "imagegraincrops_rep_int",
+            "example_rep_int.spm",
+            0.488,
+            "2.4.0",
+            str(GRAINCROP_DIR),
+            None,
+            None,
+            id="catenanes v2.4.0",
+        ),
+    ],
+)
+def test_topostats_to_dict(
+    topostats_object: topostats.TopoStats,
+    image_grain_crops: ImageGrainCrops,
+    filename: str,
+    pixel_to_nm_scaling: float,
+    topostats_version: str,
+    img_path: str,
+    image: npt.NDArray | None,
+    image_original: npt.NDArray | None,
+    request,
+) -> None:
+    """Test conversion of TopoStats object to dictionary."""
+    topostats_object = request.getfixturevalue(topostats_object)
+    image_grain_crops = request.getfixturevalue(image_grain_crops)
+    expected = {
+        "image_grain_crops": image_grain_crops,
+        "filename": filename,
+        "pixel_to_nm_scaling": pixel_to_nm_scaling,
+        "topostats_version": topostats_version,
+        "img_path": Path(img_path),
+        "image": image,
+        "image_original": image_original,
+    }
+    np.testing.assert_array_equal(topostats_object.topostats_to_dict(), expected)

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -18,6 +18,9 @@ GRAINCROP_DIR = RESOURCES / "graincrop"
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-positional-arguments
 
+SEED = 4092024
+rng = np.random.default_rng(SEED)
+
 
 @pytest.mark.parametrize(
     (
@@ -51,7 +54,7 @@ GRAINCROP_DIR = RESOURCES / "graincrop"
             str(GRAINCROP_DIR),
             None,
             None,
-            id="catenanes v2.4.0",
+            id="rep_int v2.4.0",
         ),
     ],
 )
@@ -79,3 +82,61 @@ def test_topostats_to_dict(
         "image_original": image_original,
     }
     np.testing.assert_array_equal(topostats_object.topostats_to_dict(), expected)
+
+
+@pytest.mark.parametrize(
+    (
+        "topostats_object",
+        "image_grain_crops",
+        "filename",
+        "pixel_to_nm_scaling",
+        "topostats_version",
+        "img_path",
+        "image",
+        "image_original",
+    ),
+    [
+        pytest.param(
+            "topostats_catenanes_2_4_0",
+            "imagegraincrops_catenanes",
+            "example_catenanes.spm",
+            0.488,
+            "2.4.0",
+            str(GRAINCROP_DIR),
+            rng.random((10, 10)),
+            rng.random((10, 10)),
+            id="catenane v2.4.0",
+        ),
+        pytest.param(
+            "topostats_rep_int_2_4_0",
+            "imagegraincrops_rep_int",
+            "example_rep_int.spm",
+            0.488,
+            "2.4.0",
+            str(GRAINCROP_DIR),
+            rng.random((10, 10)),
+            rng.random((10, 10)),
+            id="tep_int v2.4.0",
+        ),
+    ],
+)
+def test_topostats_eq(
+    topostats_object: topostats.TopoStats,
+    image_grain_crops: ImageGrainCrops,
+    filename: str,
+    pixel_to_nm_scaling: float,
+    topostats_version: str,
+    img_path: str,
+    image: npt.NDArray | None,
+    image_original: npt.NDArray | None,
+    request,
+) -> None:
+    """Test the TopoStats.__eq__ method."""
+    topostats_object = request.getfixturevalue(topostats_object)
+    topostats_object.image = image
+    topostats_object.image_original = image_original
+    image_grain_crops = request.getfixturevalue(image_grain_crops)
+    expected = topostats.TopoStats(
+        image_grain_crops, filename, pixel_to_nm_scaling, img_path, image, image_original, topostats_version
+    )
+    assert topostats_object == expected

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -1,11 +1,17 @@
 """Topostats."""
 
-import os
-from importlib.metadata import version
+from __future__ import annotations
 
+import os
+import re
+from importlib.metadata import version
+from pathlib import Path
+
+import numpy.typing as npt
 import snoop
 from matplotlib import colormaps
 
+from .grains import ImageGrainCrops
 from .logs.logs import setup_logger
 from .theme import Colormap
 
@@ -22,3 +28,266 @@ colormaps.register(cmap=Colormap("gwyddion").get_cmap())
 
 # Disable snoop
 snoop.install(enabled=False)
+
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+
+
+class TopoStats:
+    """
+    Class for storing TopoStats objects.
+
+    Parameters
+    ----------
+    image_grain_crops : ImageGrainCrops | None
+        ImageGrainCrops of processed image.
+    filename : str | None
+        Filename.
+    pixel_to_nm_scaling : str | None
+        Pixel to nanometre scaling.
+    img_path : str | None
+        Original path to image.
+    image : npt.NDArray | None
+        Flattened image (post ''Filter()'').
+    image_original : npt.NDArray | None
+        Original image.
+    topostats_version : str | None
+        TopoStats version.
+    """
+
+    def __init__(
+        self,
+        image_grain_crops: ImageGrainCrops | None = None,
+        filename: str | None = None,
+        pixel_to_nm_scaling: str | None = None,
+        img_path: Path | str | None = None,
+        image: npt.NDArray | None = None,
+        image_original: npt.NDArray | None = None,
+        topostats_version: str | None = None,
+    ) -> None:
+        """
+        Initialise the class.
+
+        Parameters
+        ----------
+        image_grain_crops : ImageGrainCrops | None
+            ImageGrainCrops of processed image.
+        filename : str | None
+            Filename.
+        pixel_to_nm_scaling : str | None
+            Pixel to nanometre scaling.
+        img_path : str | None
+            Original path to image.
+        image : npt.NDArray | None
+            Flattened image (post ''Filter()'').
+        image_original : npt.NDArray | None
+            Original image.
+        topostats_version : str | None
+            TopoStats version.
+        """
+        self.image_grain_crops = image_grain_crops
+        self.filename = filename
+        self.pixel_to_nm_scaling = pixel_to_nm_scaling
+        self.img_path = None if img_path is None else Path(img_path)
+        self.topostats_version = topostats_version
+        self.image = image
+        self.image_original = image_original
+
+    def __eq__(self, other: object) -> bool:
+        """
+        Check if two TopoStats objects are equal.
+
+        Parameters
+        ----------
+        other : object
+          Object to compare to.
+
+        Returns
+        -------
+        bool
+          True if the objects are equal, False otherwise.
+        """
+        if not isinstance(other, TopoStats):
+            return False
+        return (
+            self.image_grain_crops == other.image_grain_crops
+            and self.filename == other.filename
+            and self.pixel_to_nm_scaling == other.pixel_to_nm_scaling
+            and self.topostats_version == other.topostats_version
+            and self.img_path == other.image_path
+            and self.image == other.image
+            and self.image_original == other.image_original
+        )
+
+    @property
+    def image_grain_crops(self) -> ImageGrainCrops:
+        """
+        Getter for the Image Grain Crops.
+
+        Returns
+        -------
+        ImageGrainCrops
+            Image Grain Crops.
+        """
+
+    @image_grain_crops.setter
+    def image_grain_crops(self, value: ImageGrainCrops):
+        """
+        Setter for the ''image_grain_crops'' attribute.
+
+        Parameters
+        ----------
+        value : ImageGrainCrops
+            Image Grain Crops for the image.
+        """
+        self._image_grain_crops = value
+
+    @property
+    def filename(self) -> str:
+        """
+        Getter for the ''filename'' attribute.
+
+        Returns
+        -------
+        str
+            Image filename.
+        """
+
+    @filename.setter
+    def filename(self, value: str):
+        """
+        Setter for the ''filename'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Filename for the image.
+        """
+        self._filename = value
+
+    @property
+    def pixel_to_nm_scaling(self) -> str:
+        """
+        Getter for the ''pixel_to_nm_scaling'' attribute.
+
+        Returns
+        -------
+        str
+            Image ''pixel_to_nm_scaling''.
+        """
+
+    @pixel_to_nm_scaling.setter
+    def pixel_to_nm_scaling(self, value: str):
+        """
+        Setter for the ''pixel_to_nm_scaling'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Pixel to nanometre scaling for the image.
+        """
+        self._pixel_to_nm_scaling = value
+
+    @property
+    def img_path(self) -> str:
+        """
+        Getter for the ''img_path'' attribute.
+
+        Returns
+        -------
+        str
+            Image img_path.
+        """
+
+    @img_path.setter
+    def img_path(self, value: str):
+        """
+        Setter for the ''img_path'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Image Path for the image.
+        """
+        self._img_path = value
+
+    @property
+    def image(self) -> str:
+        """
+        Getter for the ''image'' attribute, post filtering.
+
+        Returns
+        -------
+        str
+            Image image.
+        """
+
+    @image.setter
+    def image(self, value: str):
+        """
+        Setter for the ''image'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Filtered image.
+        """
+        self._image = value
+
+    @property
+    def image_original(self) -> str:
+        """
+        Getter for the ''image_original'' attribute.
+
+        Returns
+        -------
+        str
+            Original image.
+        """
+
+    @image_original.setter
+    def image_original(self, value: str):
+        """
+        Setter for the ''image_original'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Original image.
+        """
+        self._image_original = value
+
+    @property
+    def topostats_version(self) -> str:
+        """
+        Getter for the ''topostats_version'' attribute, post filtering.
+
+        Returns
+        -------
+        str
+            Version of TopoStats the class was created with.
+        """
+
+    @topostats_version.setter
+    def topostats_version(self, value: str):
+        """
+        Setter for the ''topostats_version'' attribute.
+
+        Parameters
+        ----------
+        value : str
+            Topostats version.
+        """
+        self._topostats_version = value
+
+    def topostats_to_dict(self) -> dict[str, str | ImageGrainCrops | npt.NDArray]:
+        """
+        Convert ''TopoStats'' object to dictionary.
+
+        Returns
+        -------
+        dict[str, str | ImageGrainCrops | npt.NDArray]
+            Dictionary of ''TopoStats'' object.
+        """
+        return {re.sub(r"^_", "", key): value for key, value in self.__dict__.items()}

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from dataclasses import dataclass
 from importlib.metadata import version
 from pathlib import Path
 
@@ -34,11 +35,12 @@ snoop.install(enabled=False)
 # pylint: disable=too-many-positional-arguments
 
 
+@dataclass
 class TopoStats:
     """
     Class for storing TopoStats objects.
 
-    Parameters
+    Attributes
     ----------
     image_grain_crops : ImageGrainCrops | None
         ImageGrainCrops of processed image.
@@ -56,43 +58,13 @@ class TopoStats:
         TopoStats version.
     """
 
-    def __init__(
-        self,
-        image_grain_crops: ImageGrainCrops | None = None,
-        filename: str | None = None,
-        pixel_to_nm_scaling: str | None = None,
-        img_path: Path | str | None = None,
-        image: npt.NDArray | None = None,
-        image_original: npt.NDArray | None = None,
-        topostats_version: str | None = None,
-    ) -> None:
-        """
-        Initialise the class.
-
-        Parameters
-        ----------
-        image_grain_crops : ImageGrainCrops | None
-            ImageGrainCrops of processed image.
-        filename : str | None
-            Filename.
-        pixel_to_nm_scaling : str | None
-            Pixel to nanometre scaling.
-        img_path : str | None
-            Original path to image.
-        image : npt.NDArray | None
-            Flattened image (post ''Filter()'').
-        image_original : npt.NDArray | None
-            Original image.
-        topostats_version : str | None
-            TopoStats version.
-        """
-        self.image_grain_crops = image_grain_crops
-        self.filename = filename
-        self.pixel_to_nm_scaling = pixel_to_nm_scaling
-        self.img_path = None if img_path is None else Path(img_path)
-        self.topostats_version = topostats_version
-        self.image = image
-        self.image_original = image_original
+    image_grain_crops: ImageGrainCrops | None
+    filename: str | None
+    pixel_to_nm_scaling: str | None
+    img_path: Path | str | None
+    image: npt.NDArray | None
+    image_original: npt.NDArray | None
+    topostats_version: str | None
 
     def __eq__(self, other: object) -> bool:
         """
@@ -130,6 +102,7 @@ class TopoStats:
         ImageGrainCrops
             Image Grain Crops.
         """
+        return self._image_grain_crops
 
     @image_grain_crops.setter
     def image_grain_crops(self, value: ImageGrainCrops):
@@ -153,6 +126,7 @@ class TopoStats:
         str
             Image filename.
         """
+        return self._filename
 
     @filename.setter
     def filename(self, value: str):
@@ -176,6 +150,7 @@ class TopoStats:
         str
             Image ''pixel_to_nm_scaling''.
         """
+        return self._pixel_to_nm_scaling
 
     @pixel_to_nm_scaling.setter
     def pixel_to_nm_scaling(self, value: str):
@@ -199,6 +174,7 @@ class TopoStats:
         str
             Image img_path.
         """
+        return self._img_path
 
     @img_path.setter
     def img_path(self, value: str):
@@ -210,7 +186,7 @@ class TopoStats:
         value : str
             Image Path for the image.
         """
-        self._img_path = value
+        self._img_path = Path(value)
 
     @property
     def image(self) -> str:
@@ -222,6 +198,7 @@ class TopoStats:
         str
             Image image.
         """
+        return self._image
 
     @image.setter
     def image(self, value: str):
@@ -245,6 +222,7 @@ class TopoStats:
         str
             Original image.
         """
+        return self._image_original
 
     @image_original.setter
     def image_original(self, value: str):
@@ -268,6 +246,7 @@ class TopoStats:
         str
             Version of TopoStats the class was created with.
         """
+        return self._topostats_version
 
     @topostats_version.setter
     def topostats_version(self, value: str):

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from importlib.metadata import version
 from pathlib import Path
 
+import numpy as np
 import numpy.typing as npt
 import snoop
 from matplotlib import colormaps
@@ -87,9 +88,9 @@ class TopoStats:
             and self.filename == other.filename
             and self.pixel_to_nm_scaling == other.pixel_to_nm_scaling
             and self.topostats_version == other.topostats_version
-            and self.img_path == other.image_path
-            and self.image == other.image
-            and self.image_original == other.image_original
+            and self.img_path == other.img_path
+            and np.all(self.image == other.image)
+            and np.all(self.image_original == other.image_original)
         )
 
     @property
@@ -105,7 +106,7 @@ class TopoStats:
         return self._image_grain_crops
 
     @image_grain_crops.setter
-    def image_grain_crops(self, value: ImageGrainCrops):
+    def image_grain_crops(self, value: ImageGrainCrops) -> None:
         """
         Setter for the ''image_grain_crops'' attribute.
 
@@ -129,7 +130,7 @@ class TopoStats:
         return self._filename
 
     @filename.setter
-    def filename(self, value: str):
+    def filename(self, value: str) -> None:
         """
         Setter for the ''filename'' attribute.
 
@@ -153,7 +154,7 @@ class TopoStats:
         return self._pixel_to_nm_scaling
 
     @pixel_to_nm_scaling.setter
-    def pixel_to_nm_scaling(self, value: str):
+    def pixel_to_nm_scaling(self, value: str) -> None:
         """
         Setter for the ''pixel_to_nm_scaling'' attribute.
 
@@ -165,25 +166,25 @@ class TopoStats:
         self._pixel_to_nm_scaling = value
 
     @property
-    def img_path(self) -> str:
+    def img_path(self) -> Path:
         """
         Getter for the ''img_path'' attribute.
 
         Returns
         -------
-        str
-            Image img_path.
+        Path
+            Path to original image on disk.
         """
         return self._img_path
 
     @img_path.setter
-    def img_path(self, value: str):
+    def img_path(self, value: str | Path) -> None:
         """
         Setter for the ''img_path'' attribute.
 
         Parameters
         ----------
-        value : str
+        value : str | Path
             Image Path for the image.
         """
         self._img_path = Path(value)
@@ -201,7 +202,7 @@ class TopoStats:
         return self._image
 
     @image.setter
-    def image(self, value: str):
+    def image(self, value: str) -> None:
         """
         Setter for the ''image'' attribute.
 
@@ -225,7 +226,7 @@ class TopoStats:
         return self._image_original
 
     @image_original.setter
-    def image_original(self, value: str):
+    def image_original(self, value: str) -> None:
         """
         Setter for the ''image_original'' attribute.
 
@@ -249,7 +250,7 @@ class TopoStats:
         return self._topostats_version
 
     @topostats_version.setter
-    def topostats_version(self, value: str):
+    def topostats_version(self, value: str) -> None:
         """
         Setter for the ''topostats_version'' attribute.
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -22,8 +22,7 @@ from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
-import topostats as TopoStats
-from topostats import grains
+from topostats import __release__, grains
 from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
@@ -1054,9 +1053,11 @@ def hdf5_to_dict(open_hdf5_file: h5py.File, group_path: str) -> dict:
     return data_dict
 
 
-def save_topostats_file(output_dir: Path, filename: str, topostats_object: grains.ImageGrainCrops) -> None:
+def save_topostats_file(
+    output_dir: Path, filename: str, topostats_object: grains.ImageGrainCrops, topostats_version: str = __release__
+) -> None:
     """
-    Save ''ImageGrainCrops'' object to a .topostats (hdf5 format) file.
+    Save ''ImageGrainCrops'' object to a ''.topostats'' (hdf5 format) file.
 
     Parameters
     ----------
@@ -1067,6 +1068,8 @@ def save_topostats_file(output_dir: Path, filename: str, topostats_object: grain
     topostats_object : dict
         Dictionary of the topostats data to save. Must include a flattened image and pixel to nanometre scaling
         factor. May also include grain masks.
+    topostats_version : str
+        Version to save as, defaults to ''__release__''.
     """
     LOGGER.info(f"[{filename}] : Saving image to .topostats file")
 
@@ -1080,11 +1083,11 @@ def save_topostats_file(output_dir: Path, filename: str, topostats_object: grain
         # Make sure that this is not the case.
         if topostats_object["image"] is not None:
             # Recursively save the topostats object dictionary to the .topostats file
-            if isinstance(topostats_object, dict) and float(".".join(TopoStats.__release__.split(".")[:1])) < 2.4:
-                topostats_object["topostats_file_version"] = TopoStats.__release__
+            if isinstance(topostats_object, dict) and float(".".join(topostats_version.split(".")[:1])) < 2.4:
+                topostats_object["topostats_file_version"] = topostats_version
                 dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary=topostats_object)
             else:
-                topostats_object["topostats_file_version"] = TopoStats.__release__
+                topostats_object["topostats_version"] = topostats_version
                 dict_to_hdf5(open_hdf5_file=f, group_path="/", dictionary=topostats_object.image_grain_crops_to_dict())
 
         else:

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -245,7 +245,6 @@ def run_grains(  # noqa: C901
                     )
 
                     if direction_grain_crops is not None:
-
                         full_mask_tensor = direction_grain_crops.full_mask_tensor
 
                         # Plot image with overlaid masks


### PR DESCRIPTION
As we look to move towards restructuring the `.topostats` HDF5 file I've taken the logical extension to the introduction of `ImageGrainCrops` dataclass and the nested dataclass/class by introducing a `TopoStats` dataclass which defines the top-level attributes and structure that we wish to have in `.topostats` files.

One of the disconnects at the moment is that when we run the whole processing pipeline we load whatever image using AFMReader which returns `image` and `pixel_to_nm_scale`. This is ok if we're running the whole pipeline but when it comes to later stages and attempting to load `.topostats` files which can be passed into `Grains`/`GrainStats`/`DisorderedTracing`/etc. then we will be loading a `.topostats` file which is stored as HDF5, initially loaded as a dictionary but we will want to convert all previous steps of processing to `ImageGrainCrops` and its nested structure.

That means that `LoadScans` would return different things which isn't a good idea, it should consistently return the _same_ thing each time it loads files with `LoadScans.get_data()`, to which end I think it should create a dictionary of `TopoStats` objects. If data is being loaded from anything other than `.topostats` files then each value of the
dictionary, which is a `TopoStats` object will have the following attributes...

- `image_original`
- `pixel_to_nm_scale`
- `filename`
- `topostats_version` (populated on the fly from the current version)
- `img_path`

...but the `image_grain_crops` attribute will be empty.

If loading a `.topostats` file then `image_grain_crops` will hold the results of all previously processed data.

Nothing has _yet_ changed in how files are saved, but I'm (hopefully) setting things up for these changes to be made but breaking it down into a smaller commits/pull requests to ease the review process.