### PR TITLE
refactor(TopoStats): handle img_path = None

### DIFF
--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -187,7 +187,7 @@ class TopoStats:
         value : str | Path
             Image Path for the image.
         """
-        self._img_path = Path(value)
+        self._img_path = Path.cwd() if value is None else Path(value)
 
     @property
     def image(self) -> str:


### PR DESCRIPTION
If `img_path` is `None` then `TypeError` was raised by `pathlib`. If that is the case it now defaults to `Path.cwd()`.