### PR TITLE
tests: run tests in parallel via pyproject.toml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
           pip install -e .[tests]
       - name: Test with pytest
         run: |
-          pytest --cov=topostats --mpl -x
+          pytest --cov=topostats --mpl --numprocesses=logical
       - name: Determine coverage
         run: |
           coverage xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ tests = [
   "pytest-github-actions-annotate-failures",
   "pytest-mpl",
   "pytest-regtest==2.3.1",
+  "pytest-xdist",
   "filetype",
 ]
 docs = [
@@ -86,7 +87,6 @@ dev = [
   "pytest-durations",
   "pytest-icdiff",
   "pytest-testmon",
-  "pytest-xdist",
 ]
 pypi = [
   "build",
@@ -124,7 +124,7 @@ write_to = "topostats/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = ["--cov", "--mpl", "-ra", "--strict-config", "--strict-markers"]
+addopts = ["--cov", "--mpl", "-ra", "--strict-config", "--strict-markers", "--numprocesses=auto"]
 log_level = "INFO"
 log_cli = true
 log_cli_level = "INFO"


### PR DESCRIPTION
Closes #1153

Runs tests in parallel and sets the number of jobs to be `auto` which is calculated as the number of _physical_ cores the CPU has.

Other options include using `logical` which, as the name suggests, is the number of logical CPU cores.

For example the `i9=9980HK` in my laptop has 8 physical cores but each one provides two logical CPU cores, i.e. 16 in total.

Since I don't want to tie up my, or anyone elses, system running the test suite I've opted to set the default to the lower of the two (via `auto`).

~~This should help speed up some of the tests run in CI too where the number of cores is unknown.~~

The `pyproject.toml` change _won't_ speed up CI tests since they are configured in `~/.github/workflows/test.yaml` where we invoke `pytest --cov=topostats --mpl -x` and it uses the default value. I've explicitly changed that to use `--numprocesses=logical`. The runners only have between 2 and 4 cores it seems and I'm unsure on the number of logical cores so whether this makes any difference there will remain to be seen, shouldn't do any harm at least!



- [x] Existing tests pass.
- [x] Pre-commit checks pass.
