### PR TITLE
Minimum Python >= 3.10

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# ruff/pylint 2025-05-15 post removal of support for Python 3.9
+69ae81af3318d50cc89a610461a5e5ee997a6e7a
+
 # nodestats codespell corrections
 f13f8d40d6768f14a46315d105b3d80beaa33aaf
 284f113cf8416eed43b88b4c438d7552456616e3

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Installing the package
         run: |
           pip3 install .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,4 +55,4 @@ jobs:
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 5
+        timeout-minutes: 25

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,4 +55,4 @@ jobs:
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 25
+        timeout-minutes: 90

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,4 +55,4 @@ jobs:
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 90
+        timeout-minutes: 5

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -15,5 +15,6 @@ globs:
 
 ignores:
   - "tmp/"
+  - "paper.md"
 
 fix: true

--- a/.pylintrc
+++ b/.pylintrc
@@ -542,10 +542,10 @@ exclude-too-few-public-methods=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=7  # Raised this from 5
+max-args=10  # Raised this from 5
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/.pylintrc
+++ b/.pylintrc
@@ -564,7 +564,7 @@ max-parents=7
 max-public-methods=20
 
 # Maximum number of return / yield for function / method body.
-max-returns=6
+max-returns=8
 
 # Maximum number of statements in function / method body.
 max-statements=50

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ pip install topostats
 For more on installation and how to upgrade please see the [installation
 instructions](https://afm-spm.github.io/TopoStats/main/installation.html).
 
+**NB** The minimum supported version of Python is >=3.10 and because of a constraint in a dependency the maximum
+supported version is <= 3.11 (for now, we hope to support newer versions in the near future).
+
 ## How to Use
 
 ### Tutorials and Examples
@@ -87,7 +90,7 @@ to run the processing again. See the documentation on
 
 ## Contributing
 
-See [contributing guidelines](https://afm-spm.github.io/TopoStats/main/contributing.html).
+Please refer to our [contributing guidelines](https://afm-spm.github.io/TopoStats/main/contributing.html) documentation.
 
 ## Licence
 
@@ -95,7 +98,8 @@ See [contributing guidelines](https://afm-spm.github.io/TopoStats/main/contribut
 
 ## Citation
 
-Please use the [Citation File Format](https://citation-file-format.github.io/) which is available in this repository.
+If you use TopoStats in your work or research please cite us. There is a [Citation File
+Format](https://citation-file-format.github.io/) in this repository to aid citation.
 
 ### Publications
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,12 +13,9 @@ issue](https://github.com/AFM-SPM/TopoStats/issues/new/choose) using one of the 
 
 ### Cloning the repository
 
-If you wish to make changes yourself you will have to
-[fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the repository to your own account and then [clone
-that](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) if you are not
-a member of AFM-SPM Organisation. If you are a member then you can [clone the
-repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) and make
-contributions directly.
+If you wish to make changes yourself you will have to [fork][git_fork] the repository to your own account and then
+[clone that][git_clone] if you are not a member of AFM-SPM Organisation. If you are a member then you can [clone the
+repository][git_clone] and make contributions directly.
 
 ```bash
 # Member of AFM-SPM Organisation
@@ -172,7 +169,9 @@ the file you wish to debug and use the `@snoop` decorator around the function/me
 
 As described in [Parameter Configuration](configuration) options are primarily passed to TopoStats via a
 [YAML](https://yaml.org) configuration file. When introducing new features that require configuration options you will
-have to ensure that the default configuration file (`topostats/default.yaml`) is updated to include your options.
+have to ensure that the default configuration file (`topostats/default.yaml`) is updated to include your options and
+that corresponding arguments are added to the entry point (please refer to [Adding Modules](contributing/adding_modules)
+page which covers this).
 
 Further the `topostats.validation.validate.config()` function, which checks a valid configuration file with all necessary
 fields has been passed when invoking `topostats` sub-commands, will also need updating to include new options in the
@@ -191,3 +190,6 @@ so are provided.
 - [Code Quality Assistance Tips and Tricks, or How to Make Your Code Look Pretty? |
   PyCharm](https://www.jetbrains.com/help/pycharm/tutorial-code-quality-assistance-tips-and-tricks.html#525ee883)
 - [Reformat and rearrange code | PyCharm](https://www.jetbrains.com/help/pycharm/reformat-and-rearrange-code.html)
+
+[git_clone]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository
+[git_fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,8 +10,8 @@ Windows you should use
 You may have Python installed on your system but should use a [Python Virtual
 Environment](https://realpython.com/python-virtual-environments-a-primer/) such as
 [Miniconda](https://docs.conda.io/en/latest/miniconda.html) and install and use TopoStats under the Virtual
-Environment. The versions of Python supported are Python >=3.8 and so when creating your virtual environment you should
-specify this `3.8` as the minimum.
+Environment. The versions of Python supported are Python >=3.10 and <= 3.11 and so when creating your virtual
+environment you should specify this `3.10` as the minimum.
 
 ## Setting up Conda
 
@@ -21,7 +21,7 @@ virtual environment for installing TopoStats for installing and running TopoStat
 as per the instructions printed out, activate the environment.
 
 ```bash
-conda create --name topostats python=3.10
+conda create --name topostats python=3.11
 conda activate topostats
 ```
 
@@ -32,7 +32,7 @@ You are now ready to install TopoStats.
 
 ## Installing TopoStats
 
-There are two options for installing TopoStats depending on your usage
+There are two options for installing TopoStats depending on your usage.
 
 1. [**Python Package Index**](https://pypi.org/) - appropriate if you are just using TopoStats and don't need to dig into
    the code.
@@ -55,7 +55,7 @@ command line. It has a number of sub-commands which can be displayed by invoking
 pip install --upgrade topostats
 ```
 
-You can always install a specific version from PyPI
+You can always install a specific version from PyPI.
 
 ```bash
 pip install topostats==2.0.0
@@ -71,15 +71,12 @@ You may wish to consider cloning and installing TopoStats from GitHub if...
 - You wish to try out new features that have been developed since the last release (if you find problems please create
   an [issue](https://github.com/AFM-SPM/TopoStats/issues)).
 - If you have found an issue in a released version and want to see if it has been fixed in the unreleased version.
-- If you wish to develop and extend TopoStats with new features yourself.
+- If you wish to contribute to the development and extend TopoStats with new features.
 
 There are two options to install from GitHub, which you use will depend on what you want to do.
 
-1. Using PyPI to install directly.
-2. Clone the repository and install from there.
-
-If all you want to do is use the development version of TopoStats then you can use option 1. If you wish to change the
-underlying code you should use option 2.
+1. **Using PyPI to install directly** - use this option if you have no intention of modifying code.
+2. **Clone the repository and install from there** - use this option if you wish to modify code and make contributions.
 
 #### Installing from GitHub using PyPI
 
@@ -91,7 +88,8 @@ pip install git+https://github.com/AFM-SPM/TopoStats.git@main
 ```
 
 You can install any branch on GitHub by modifying the last argument (`@main`) to the branch you wish to install,
-e.g. `@another_branch` would install the `another_branch` (if it existed).
+e.g. `@another_branch` would install the `another_branch` (if it existed). You can even specify specific commits if you
+wish.
 
 #### Cloning the Repository and installing
 
@@ -113,12 +111,12 @@ If you plan to contribute to development by adding features or address an existi
 [issue](https://github.com/AFM-SPM/TopoStats/issues) please refer to the [contributing](contributing) section and pay
 particular attention to the section about installing additional dependencies.
 
-We include [notebooks](notebooks) which show how to use different aspects of TopoStats. If you wish to try these out the
+We include [notebooks](notebooks) which show how to use different aspects of TopoStats. If you wish to try out the
 [Jupyter Noteooks](https://jupyter.org/) then you can install the dependencies that are required from the cloned
 TopoStats repository using...
 
 ```bash
-pip install ".[notebooks]"
+pip install .[notebooks]
 ```
 
 #### Cloning Using GitKraken
@@ -139,7 +137,7 @@ the tests. Install the necessary dependencies to do so with...
 ```bash
 cd TopoStats
 git checkout dev
-pip install ".[tests]"
+pip install .[tests]
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ authors = [
 ]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Natural Language :: English",
@@ -33,13 +32,13 @@ keywords = [
   "afm",
   "image processing"
 ]
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.10, <3.12"
 dependencies = [
   "art",
   "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@main",
   "h5py",
   "keras",
-  "matplotlib~=3.9.4",
+  "matplotlib",
   "numpy",
   "numpyencoder",
   "pandas",
@@ -123,7 +122,7 @@ write_to = "topostats/_version.py"
 
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "8.0"
 addopts = ["--cov", "--mpl", "-ra", "--strict-config", "--strict-markers", "--numprocesses=auto"]
 log_level = "INFO"
 log_cli = true
@@ -148,7 +147,7 @@ omit = [
 
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py310']
 exclude = '''
 
 (
@@ -191,6 +190,7 @@ exclude = [
 ]
 # per-file-ignores = []
 line-length = 120
+
 [tool.ruff.lint]
 select = [
   "A", # flake8-builtins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ dependencies = [
   "h5py",
   "keras",
   "matplotlib",
-  "numpy",
-  "numpyencoder",
+  "numpy~=2.0.0",  # Until TensorFlow supports newer versions
+  "numpyencoder @ git+https://github.com/AFM-SPM/numpyencoder@master",
   "pandas",
   "pyyaml",
   "ruamel.yaml",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@
 # ruff: noqa: S301
 """Fixtures for testing."""
 
-from __future__ import annotations
-
 import importlib.resources as pkg_resources
 import pickle
 from pathlib import Path

--- a/tests/measure/conftest.py
+++ b/tests/measure/conftest.py
@@ -1,7 +1,5 @@
 """Fixtures for testing the measure module."""
 
-from __future__ import annotations
-
 import networkx as nx
 import numpy as np
 import numpy.typing as npt

--- a/tests/measure/test_feret.py
+++ b/tests/measure/test_feret.py
@@ -1351,3 +1351,16 @@ def test_plot_feret(  # pylint: disable=too-many-arguments
         plot_max_feret,
     )
     return fig
+
+
+@pytest.mark.parametrize(
+    ("x", "y", "expected"),
+    [
+        pytest.param(np.array([1, 0]), np.array([1, 0]), np.array([0]), id="identical arrays"),
+        pytest.param(np.array([1, 0]), np.array([0, 1]), np.array([1]), id="inverse arrays"),
+        pytest.param(np.array([1, 2]), np.array([3, 4]), np.array([-2]), id="different arrays"),
+    ],
+)
+def test_cross2d(x: npt.NDArray, y: npt.NDArray, expected: npt.NDArray) -> None:
+    """Test for cross2d."""
+    np.testing.assert_array_equal(feret.cross2d(x, y), expected)

--- a/tests/measure/test_feret.py
+++ b/tests/measure/test_feret.py
@@ -1,7 +1,5 @@
 """Tests for feret functions."""
 
-from __future__ import annotations
-
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -12,6 +10,7 @@ from topostats.measure import feret
 # pylint: disable=protected-access
 # pylint: disable=too-many-lines
 # pylint: disable=fixme
+# pylint: disable=too-many-positional-arguments
 
 POINT1 = (0, 0)
 POINT2 = (1, 0)

--- a/tests/measure/test_height_profiles.py
+++ b/tests/measure/test_height_profiles.py
@@ -1,7 +1,5 @@
 """Tests for height profiles."""
 
-from __future__ import annotations
-
 import sys
 
 import numpy as np

--- a/tests/test_filters_minicircle.py
+++ b/tests/test_filters_minicircle.py
@@ -1,10 +1,13 @@
 """Tests of the filters module."""
 
+from collections import defaultdict
+
 # + pylint: disable=invalid-name
 import numpy as np
 import pytest
 
 from topostats.filters import Filters
+from topostats.io import dict_almost_equal
 
 
 def test_median_flatten_unmasked(minicircle_initial_median_flatten: Filters) -> None:
@@ -39,8 +42,8 @@ def test_get_threshold_otsu(minicircle_threshold_otsu: np.array) -> None:
 def test_get_threshold_stddev(minicircle_threshold_stddev: np.array) -> None:
     """Test calculation of threshold."""
     assert isinstance(minicircle_threshold_stddev.thresholds, dict)
-    assert minicircle_threshold_stddev.thresholds == pytest.approx(
-        {"below": [-7.484708050736529], "above": [0.4990958836019106]}
+    assert dict_almost_equal(
+        minicircle_threshold_stddev.thresholds, {"below": [-7.484708050736529], "above": [0.4990958836019106]}
     )
 
 

--- a/tests/test_filters_minicircle.py
+++ b/tests/test_filters_minicircle.py
@@ -1,7 +1,5 @@
 """Tests of the filters module."""
 
-from collections import defaultdict
-
 # + pylint: disable=invalid-name
 import numpy as np
 import pytest

--- a/tests/test_grains.py
+++ b/tests/test_grains.py
@@ -1,7 +1,5 @@
 """Test finding of grains."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 from unittest.mock import MagicMock, patch

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -282,6 +282,20 @@ def test_load_array() -> None:
             True,
             id="nan equal",
         ),
+        pytest.param(
+            {"a": [0.001, 0.002]},
+            {"a": [0.001, 0.002]},
+            0.001,
+            True,
+            id="Nested lists equal",
+        ),
+        pytest.param(
+            {"a": [0.01, 0.02]},
+            {"a": [0.02, 0.01]},
+            0.0001,
+            False,
+            id="Nested lists not equal",
+        ),
     ],
 )
 def test_dict_almost_equal(dict1: dict, dict2: dict, tolerance: float, expected: bool) -> None:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,7 +1,5 @@
 """Tests for the plotting module."""
 
-from __future__ import annotations
-
 from importlib import resources
 from pathlib import Path
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -11,10 +11,9 @@ import h5py
 import numpy as np
 import pandas as pd
 import pytest
-from test_io import dict_almost_equal
 
 from topostats.grains import GrainCrop, GrainCropsDirection, ImageGrainCrops
-from topostats.io import LoadScans, hdf5_to_dict
+from topostats.io import LoadScans, dict_almost_equal, hdf5_to_dict
 from topostats.processing import (
     LOGGER_NAME,
     check_run_steps,

--- a/tests/test_topostats.py
+++ b/tests/test_topostats.py
@@ -1,7 +1,5 @@
 """Tests for the main module components defined in ''__init__.py''."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import numpy as np

--- a/tests/test_unet_masking.py
+++ b/tests/test_unet_masking.py
@@ -1,7 +1,5 @@
 """Test unet masking methods."""
 
-from __future__ import annotations
-
 from unittest.mock import MagicMock
 
 import numpy as np

--- a/tests/tracing/test_disordered_tracing.py
+++ b/tests/tracing/test_disordered_tracing.py
@@ -2,8 +2,6 @@
 # ruff: noqa: S301
 """Test the disordered tracing module."""
 
-from __future__ import annotations
-
 import logging
 import pickle as pkl
 from pathlib import Path

--- a/tests/tracing/test_ordered_tracing.py
+++ b/tests/tracing/test_ordered_tracing.py
@@ -20,6 +20,7 @@ DISORDERED_TRACING_RESOURCES = BASE_DIR / "tests" / "resources" / "tracing" / "d
 # pylint: disable=unspecified-encoding
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 
 GRAINS = {}
 GRAINS["vertical"] = np.asarray(

--- a/tests/tracing/test_pruning.py
+++ b/tests/tracing/test_pruning.py
@@ -1,7 +1,5 @@
 """Test the skeletonize module."""
 
-from __future__ import annotations
-
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -17,6 +15,7 @@ from topostats.tracing.pruning import (
 # pylint: disable=too-many-lines
 # pylint: disable=protected-access
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 
 
 @pytest.mark.parametrize(

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -1,7 +1,5 @@
 """Topostats."""
 
-from __future__ import annotations
-
 import os
 import re
 from dataclasses import dataclass

--- a/topostats/__main__.py
+++ b/topostats/__main__.py
@@ -1,5 +1,0 @@
-"""Main Module."""
-
-import topostats.topotracing as topotracing
-
-topotracing.main()

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -515,7 +515,8 @@ processed, please refer to https://github.com/AFM-SPM/TopoStats/discussions for 
         Examples
         --------
         from topostats.io import LoadScan
-        from topostats.topotracing import Filter, process_scan
+        from topostats.filters import Filter
+        from topostats.processing import process_scan
 
         filter = Filter(image=load_scan.image,
         ...             pixel_to_nm_scaling=load_scan.pixel_to_nm_scaling,

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -1,7 +1,5 @@
 """Module for filtering 2D Numpy arrays."""
 
-from __future__ import annotations
-
 import logging
 
 import numpy as np

--- a/topostats/grains.py
+++ b/topostats/grains.py
@@ -1,7 +1,6 @@
 """Find grains in an image."""
 
 # pylint: disable=no-name-in-module
-from __future__ import annotations
 
 import logging
 import re

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -1,7 +1,5 @@
 """Contains class for calculating the statistics of grains - 2d raster images."""
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 from random import randint

--- a/topostats/grainstats.py
+++ b/topostats/grainstats.py
@@ -179,7 +179,7 @@ class GrainStats:
         rotation_matrix = np.asarray(((p_1[0], p_1[1], 1), (p_2[0], p_2[1], 1), (p_3[0], p_3[1], 1)))
         return not np.linalg.det(rotation_matrix) > 0
 
-    def calculate_stats(self) -> tuple(pd.DataFrame, dict):
+    def calculate_stats(self) -> tuple[pd.DataFrame, dict]:
         """
         Calculate the stats of grains in the labelled image.
 
@@ -471,7 +471,7 @@ class GrainStats:
         return np.array(edges) - centroid
 
     @staticmethod
-    def _calculate_radius(displacements: list[list]) -> npt.NDarray:
+    def _calculate_radius(displacements: list[list]) -> npt.NDArray:
         """
         Calculate the radius of each point from the centroid.
 
@@ -482,7 +482,7 @@ class GrainStats:
 
         Returns
         -------
-        npt.NDarray
+        npt.NDArray
             Array of radii of each point from the centroid.
         """
         return np.array([np.sqrt(radius[0] ** 2 + radius[1] ** 2) for radius in displacements])

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -966,16 +966,16 @@ def dict_to_hdf5(open_hdf5_file: h5py.File, group_path: str, dictionary: dict) -
         if isinstance(
             item,
             (
-                list,
-                str,
-                int,
-                float,
-                np.ndarray,
-                Path,
-                dict,
-                grains.GrainCrop,
-                grains.GrainCropsDirection,
-                grains.ImageGrainCrops,
+                list
+                | str
+                | int
+                | float
+                | np.ndarray
+                | Path
+                | dict
+                | grains.GrainCrop
+                | grains.GrainCropsDirection
+                | grains.ImageGrainCrops
             ),
         ):  # noqa: UP038
             # Lists need to be converted to numpy arrays

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -72,6 +72,8 @@ def dict_almost_equal(dict1: dict, dict2: dict, abs_tol: float = 1e-9):  # noqa:
     """
     Recursively check if two dictionaries are almost equal with a given absolute tolerance.
 
+    If the values of a dictionary are lists pairwise comparisons are made.
+
     Parameters
     ----------
     dict1 : dict
@@ -107,7 +109,14 @@ def dict_almost_equal(dict1: dict, dict2: dict, abs_tol: float = 1e-9):  # noqa:
                 if not np.isclose(dict1[key], dict2[key], atol=abs_tol):
                     LOGGER.debug(f"Key {key} type: {type(dict1[key])} not equal: {dict1[key]} != {dict2[key]}")
                     return False
-
+        elif isinstance(dict1[key], list) and isinstance(dict2[key], list):
+            for idx, _ in enumerate(dict1[key]):
+                if not np.isclose(dict1[key][idx], dict2[key][idx], atol=abs_tol):
+                    print(
+                        f"Key {key} type: {type(dict1[key])} not equal at element {idx} : "
+                        f"{dict1[key][idx]} != {dict2[key][idx]}"
+                    )
+                    return False
         elif dict1[key] != dict2[key]:
             LOGGER.debug(f"Key {key} not equal: {dict1[key]} != {dict2[key]}")
             return False

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1,7 +1,5 @@
 """Functions for reading and writing data."""
 
-from __future__ import annotations
-
 import io
 import json
 import logging

--- a/topostats/measure/curvature.py
+++ b/topostats/measure/curvature.py
@@ -1,7 +1,5 @@
 """Calculate various curvature metrics for traces."""
 
-from __future__ import annotations
-
 import logging
 
 import numpy as np

--- a/topostats/measure/feret.py
+++ b/topostats/measure/feret.py
@@ -232,7 +232,29 @@ def triangle_height(base1: npt.NDArray | list, base2: npt.NDArray | list, apex: 
     """
     base1_base2 = np.asarray(base1) - np.asarray(base2)
     base1_apex = np.asarray(base1) - np.asarray(apex)
-    return np.linalg.norm(np.cross(base1_base2, base1_apex)) / np.linalg.norm(base1_base2)
+    # Ensure arrays are 3-D see note in https://numpy.org/doc/2.0/reference/generated/numpy.cross.html
+    return np.linalg.norm(cross2d(base1_base2, base1_apex)) / np.linalg.norm(base1_base2)
+
+
+def cross2d(x: npt.NDArray, y: npt.NDArray) -> npt.NDArray:
+    """
+    Return the c$ross product of two 2-D arrays of vectors.
+
+    See https://numpy.org/doc/2.0/reference/generated/numpy.cross.html
+
+    Parameters
+    ----------
+    x : npt.NDArray
+        First 2-D array.
+    y : npt.NDArray
+        Second 2-D array.
+
+    Returns
+    -------
+    npt.NDArray
+        Cross product of the two vectors.
+    """
+    return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
 
 
 def _min_feret_coord(
@@ -425,7 +447,7 @@ def get_feret_from_labelim(label_image: npt.NDArray, labels: None | list | set =
     return results
 
 
-# pylint: disable=too-many-arguments,too-many-locals
+# pylint: disable=too-many-arguments,too-many-locals,too-many-positional-arguments
 def plot_feret(  # noqa: C901
     points: npt.NDArray,
     axis: int = 0,

--- a/topostats/measure/feret.py
+++ b/topostats/measure/feret.py
@@ -9,8 +9,6 @@ During testing it was discovered that sorting points prior to derivation of uppe
 so this step was removed.
 """
 
-from __future__ import annotations
-
 import logging
 import warnings
 from collections.abc import Generator
@@ -427,7 +425,8 @@ def get_feret_from_labelim(label_image: npt.NDArray, labels: None | list | set =
     return results
 
 
-def plot_feret(  # pylint: disable=too-many-arguments,too-many-locals # noqa: C901
+# pylint: disable=too-many-arguments,too-many-locals
+def plot_feret(  # noqa: C901
     points: npt.NDArray,
     axis: int = 0,
     plot_points: str | None = "k",

--- a/topostats/measure/geometry.py
+++ b/topostats/measure/geometry.py
@@ -1,7 +1,5 @@
 """Functions for measuring geometric properties of grains."""
 
-from __future__ import annotations
-
 import math
 
 import networkx
@@ -182,6 +180,7 @@ def calculate_shortest_branch_distances(
     return shortest_node_distances, shortest_distances_branch_indexes, shortest_distances_branch_coordinates
 
 
+# pylint: disable=too-many-positional-arguments
 def connect_best_matches(
     network_array_representation: npt.NDArray[np.int32],
     whole_skeleton_graph: networkx.classes.graph.Graph,

--- a/topostats/measure/height_profiles.py
+++ b/topostats/measure/height_profiles.py
@@ -1,7 +1,5 @@
 """Derive height profiles across the images."""
 
-from __future__ import annotations
-
 import logging
 import warnings
 

--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -344,8 +344,7 @@ for KDE plot being the same. KDE plots cannot be made as there is no variance, s
         """
         plt.savefig(self.output_dir / f"{outfile}.{self.savefig_format}")
         LOGGER.debug(
-            f"[plotting] Plotted {self.stat_to_sum} to : "
-            f"{str(self.output_dir / f'{outfile}.{self.savefig_format}')}"
+            f"[plotting] Plotted {self.stat_to_sum} to : {str(self.output_dir / f'{outfile}.{self.savefig_format}')}"
         )
 
     def _set_label(self, var: str):

--- a/topostats/plotting.py
+++ b/topostats/plotting.py
@@ -1,7 +1,5 @@
 """Plotting and summary of TopoStats output statistics."""
 
-from __future__ import annotations
-
 from collections import defaultdict
 
 from importlib import resources

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -1,7 +1,5 @@
 """Plotting data."""
 
-from __future__ import annotations
-
 import logging
 from importlib import resources
 from pathlib import Path

--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -94,7 +94,7 @@ class Images:
 
     Parameters
     ----------
-    data : npt.NDarray
+    data : npt.NDArray
         Numpy array to plot.
     output_dir : str | Path
         Output directory to save the file to.
@@ -104,7 +104,7 @@ class Images:
         Filename of matplotlibrc parameters.
     pixel_to_nm_scaling : float
         The scaling factor showing the real length of 1 pixel in nanometers (nm).
-    masked_array : npt.NDarray
+    masked_array : npt.NDArray
         Optional mask array to overlay onto an image.
     plot_coords : npt.NDArray
         ??? Needs defining.
@@ -148,12 +148,12 @@ class Images:
 
     def __init__(
         self,
-        data: npt.NDarray,
+        data: npt.NDArray,
         output_dir: str | Path,
         filename: str,
         style: str | Path = None,
         pixel_to_nm_scaling: float = 1.0,
-        masked_array: npt.NDarray = None,
+        masked_array: npt.NDArray = None,
         plot_coords: npt.NDArray = None,
         title: str = None,
         image_type: str = "non-binary",
@@ -178,13 +178,14 @@ class Images:
         Initialise the class.
 
         There are two key parameters that ensure whether an image is plotted that are passed in from the updated
-        plotting dictionary. These are the ``image_set`` which defines which images to plot. ``all`` images plots everything, or ``core`` only plots the core set.
+        plotting dictionary. These are the ``image_set`` which defines which images to plot. ``all`` images plots
+        everything, or ``core`` only plots the core set.
         There is then the 'core_set' which defines whether an individual images belongs to the 'core_set' or
         not. If it doesn't then it is not plotted when `image_set` is `["core"]`.
 
         Parameters
         ----------
-        data : npt.NDarray
+        data : npt.NDArray
             Numpy array to plot.
         output_dir : str | Path
             Output directory to save the file to.
@@ -194,7 +195,7 @@ class Images:
             Filename of matplotlibrc parameters.
         pixel_to_nm_scaling : float
             The scaling factor showing the real length of 1 pixel in nanometers (nm).
-        masked_array : npt.NDarray
+        masked_array : npt.NDArray
             Optional mask array to overlay onto an image.
         plot_coords : npt.NDArray
             ??? Needs defining.
@@ -347,7 +348,6 @@ class Images:
             for (_, grain_data_curvature), (_, grain_data_smoothed_trace), (_, grain_image_container) in zip(
                 grains_curvature_stats_dict.items(), all_grain_smoothed_data.items(), cropped_images.items()
             ):
-
                 # Get the coordinate for the grain to accurately position the points
                 min_row = grain_image_container["bbox"][0]
                 min_col = grain_image_container["bbox"][1]
@@ -359,7 +359,6 @@ class Images:
                     _,
                     molecule_data_smoothed_trace,
                 ) in zip(grain_data_curvature.items(), grain_data_smoothed_trace.items()):
-
                     # Normalise the curvature values to the colourmap bounds
                     normalised_curvature = np.array(molecule_data_curvature)
                     normalised_curvature = normalised_curvature - colourmap_normalisation_bounds[0]
@@ -430,7 +429,6 @@ class Images:
         fig, ax = None, None
         # Only plot if image_set is "all" (i.e. user wants all images) or an image is in the core_set
         if "all" in self.image_set or self.module in self.image_set or self.core_set:
-
             # Iterate over grains
             for (
                 (grain_index, grain_data_curvature),
@@ -453,7 +451,6 @@ class Images:
                 for (_, molecule_data_curvature), (_, molecule_data_smoothed_trace) in zip(
                     grain_data_curvature.items(), grain_data_smoothed_trace.items()
                 ):
-
                     molecule_trace_coords = molecule_data_smoothed_trace["spline_coords"]
 
                     # Normalise the curvature values to the colourmap bounds
@@ -468,7 +465,6 @@ class Images:
                     cmap = mpl.cm.coolwarm
 
                     for index, point in enumerate(molecule_trace_coords):
-
                         colour = cmap(normalised_curvature[index])
                         if index > 0:
                             previous_point = molecule_trace_coords[index - 1]

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1,7 +1,5 @@
 """Functions for processing data."""
 
-from __future__ import annotations
-
 import logging
 from collections import defaultdict
 from pathlib import Path

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -5,8 +5,6 @@ This provide entry points for running TopoStats as a command line programme. Eac
 wrapper which runs various functions from the ''processing'' module in parallel.
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import sys

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -1,7 +1,5 @@
 """Generates disordered traces (pruned skeletons) and metrics."""
 
-from __future__ import annotations
-
 import logging
 import warnings
 

--- a/topostats/tracing/nodestats.py
+++ b/topostats/tracing/nodestats.py
@@ -1,7 +1,5 @@
 """Perform Crossing Region Processing and Analysis."""
 
-from __future__ import annotations
-
 import logging
 from itertools import combinations
 from typing import TypedDict
@@ -28,6 +26,7 @@ from topostats.utils import ResolutionError, convolve_skeleton
 LOGGER = logging.getLogger(LOGGER_NAME)
 
 # pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-lines

--- a/topostats/tracing/nodestats.py
+++ b/topostats/tracing/nodestats.py
@@ -36,16 +36,6 @@ LOGGER = logging.getLogger(LOGGER_NAME)
 # pylint: disable=too-many-statements
 
 
-class NodeDict(TypedDict):
-    """Dictionary containing the node information."""
-
-    error: bool
-    pixel_to_nm_scaling: np.float64
-    branch_stats: dict[int, MatchedBranch] | None
-    node_coords: npt.NDArray[np.int32] | None
-    confidence: np.float64 | None
-
-
 class MatchedBranch(TypedDict):
     """
     Dictionary containing the matched branches.
@@ -65,6 +55,16 @@ class MatchedBranch(TypedDict):
     distances: npt.NDArray[np.number]
     fwhm: dict[str, np.float64 | tuple[np.float64]]
     angles: np.float64 | None
+
+
+class NodeDict(TypedDict):
+    """Dictionary containing the node information."""
+
+    error: bool
+    pixel_to_nm_scaling: np.float64
+    branch_stats: dict[int, MatchedBranch] | None
+    node_coords: npt.NDArray[np.int32] | None
+    confidence: np.float64 | None
 
 
 class ImageDict(TypedDict):

--- a/topostats/tracing/ordered_tracing.py
+++ b/topostats/tracing/ordered_tracing.py
@@ -1,7 +1,5 @@
 """Order single pixel skeletons with or without NodeStats Statistics."""
 
-from __future__ import annotations
-
 import logging
 from itertools import combinations
 

--- a/topostats/tracing/ordered_tracing.py
+++ b/topostats/tracing/ordered_tracing.py
@@ -15,6 +15,8 @@ from topostats.utils import convolve_skeleton, coords_2_img
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
+# pylint: disable=possibly-used-before-assignment
+
 
 class OrderedTraceNodestats:  # pylint: disable=too-many-instance-attributes
     """
@@ -670,7 +672,7 @@ class OrderedTraceNodestats:  # pylint: disable=too-many-instance-attributes
         writhe_string, node_to_writhes = self.identify_writhes()
         self.grain_tracing_stats["writhe_string"] = writhe_string
         for node_num, node_writhes in node_to_writhes.items():  # should self update as the dicts are linked
-            self.nodestats_dict[f"node_{node_num+1}"]["writhe"] = node_writhes
+            self.nodestats_dict[f"node_{node_num + 1}"]["writhe"] = node_writhes
 
         topology_flip = self.compile_trace(reverse_min_conf_crossing=True)[1]
 

--- a/topostats/tracing/pruning.py
+++ b/topostats/tracing/pruning.py
@@ -1,7 +1,5 @@
 """Prune branches from skeletons."""
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Callable
 
@@ -207,6 +205,7 @@ def _prune_topostats(img: npt.NDArray, skeleton: npt.NDArray, pixel_to_nm_scalin
 
 
 # Might be worth renaming this to reflect what it does which is prune by length and height
+# pylint: disable=too-many-instance-attributes
 class topostatsPrune:
     """
     Prune spurious skeletal branches based on their length and/or height.
@@ -236,6 +235,7 @@ class topostatsPrune:
     """
 
     # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         img: npt.NDArray,
@@ -410,6 +410,8 @@ class heightPruning:  # pylint: disable=too-many-instance-attributes
         Whether to only prune endpoints by height, or all skeleton segments. Default is True.
     """  # numpydoc: ignore=PR01
 
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
     def __init__(
         self,
         image: npt.NDArray,

--- a/topostats/tracing/splining.py
+++ b/topostats/tracing/splining.py
@@ -1,7 +1,5 @@
 """Order single pixel skeletons with or without NodeStats Statistics."""
 
-from __future__ import annotations
-
 import logging
 import math
 

--- a/topostats/tracing/tracingfuncs.py
+++ b/topostats/tracing/tracingfuncs.py
@@ -1,6 +1,5 @@
 """Miscellaneous tracing functions."""
 
-from __future__ import annotations
 import numpy as np
 import numpy.typing as npt
 import matplotlib.pyplot as plt

--- a/topostats/tracing/tracingfuncs.py
+++ b/topostats/tracing/tracingfuncs.py
@@ -466,9 +466,7 @@ def order_branch(binary_image: npt.NDArray, anchor: list):
     return np.array(ordered)
 
 
-def order_branch_from_start(
-    nodeless: npt.NDArray, start: npt.NDArray, max_length: float | np.inf = np.inf
-) -> npt.NDArray:
+def order_branch_from_start(nodeless: npt.NDArray, start: npt.NDArray, max_length: float = np.inf) -> npt.NDArray:
     """
     Order an unbranching skeleton from an end (startpoint) along a specified length.
 

--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -1,7 +1,5 @@
 """Segment grains using a U-Net model."""
 
-from __future__ import annotations
-
 import logging
 
 import keras
@@ -114,6 +112,7 @@ def mean_iou(y_true: npt.NDArray[np.float32], y_pred: npt.NDArray[np.float32]):
     return tf.reduce_mean((intersect + smooth) / (union - intersect + smooth))
 
 
+# pylint: disable=too-many-positional-arguments
 def predict_unet(
     image: npt.NDArray[np.float32],
     model: keras.Model,

--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -313,6 +313,7 @@ def make_bounding_box_square(
     return new_crop_min_row, new_crop_min_col, new_crop_max_row, new_crop_max_col
 
 
+# pylint: disable=too-many-positional-arguments
 def pad_bounding_box(
     crop_min_row: int,
     crop_min_col: int,
@@ -357,7 +358,7 @@ def pad_crop(
     bbox: tuple[int, int, int, int],
     image_shape: tuple[int, int],
     padding: int,
-) -> np.NDArray:
+) -> npt.NDArray:
     """
     Pad a crop.
 
@@ -374,7 +375,7 @@ def pad_crop(
 
     Returns
     -------
-    np.NDArray
+    npt.NDArray
         The padded crop.
     """
     new_bounding_box = pad_bounding_box(
@@ -400,7 +401,7 @@ def make_crop_square(
     crop: npt.NDArray,
     bbox: tuple[int, int, int, int],
     image_shape: tuple[int, int],
-) -> np.NDArray:
+) -> npt.NDArray:
     """
     Make a crop square.
 
@@ -415,7 +416,7 @@ def make_crop_square(
 
     Returns
     -------
-    np.NDArray
+    npt.NDArray
         The square crop.
     """
     new_bounding_box = make_bounding_box_square(

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -1,7 +1,5 @@
 """Utilities."""
 
-from __future__ import annotations
-
 import logging
 from argparse import Namespace
 from collections import defaultdict

--- a/topostats/utils.py
+++ b/topostats/utils.py
@@ -2,7 +2,6 @@
 
 import logging
 from argparse import Namespace
-from collections import defaultdict
 from pathlib import Path
 from pprint import pformat
 
@@ -266,7 +265,7 @@ def get_thresholds(  # noqa: C901
     dict[str, list[float]]
         Dictionary of thresholds, contains keys 'below' and optionally 'above'.
     """
-    thresholds: dict[str, list[float]] = defaultdict()
+    thresholds: dict[str, list[float]] = {}
     if threshold_method == "otsu":
         assert (
             otsu_threshold_multiplier is not None


### PR DESCRIPTION
Closes #1146
Closes #1155

- #1146 Drop support for Python 3.9 and set minimum version to Python 3.10.
- #1155 Remove reference to topotracing
- Upgrades minimum version of Numpy to >=2.0.0 in light of [topoly-1.1.0](https://github.com/ilbsm/topoly_tutorial/issues/4#issuecomment-2863318755) which works with Numpy >=2.0.0 and new versions of Matplotlib (removed restriction on versio of later previously).
- Switched to using a forked version of `numpyencoder` which I forked to the `AFM-SPM` organisation in light of a couple of minor bugs in their `0.3.0` version that occur when using Numpy >= 2.0.0 because of deprecated types.
- Addressed a number of linting and typehint issues that were raised as a consequence of these changes/the files being touched again (they perhaps crept through as when the changes were made `pre-commit` hooks weren't being used as `pylint` hook _doesn't_ run in CI, although some were throwing errors when running the test suite so unsure how they persisted!)

See comments in individual commits for greater details. Attempted to group changes into atomic commits and have added the linting commit to `.git-blame-ignore-revs` so that the stylistic changes aren't attributed to me and we can see who wrote the original code.


---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [X] Documentation has been updated and builds. Remember to update as required...
  - [X] `docs/configuration.md`
  - [X] `docs/usage.md`
  - [ ] ~`docs/data_dictionary.md`~
  - [ ] ~`docs/advanced.md` and new pages it should link to.~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~