### PR TITLE
Remove Python 3.9 from workflows

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Installing the package
         run: |
           pip3 install .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
As there appear to be some issues with the full purging of Python 3.9 from TopoStats support (see #1157 where these are currently failing/waiting to be addressed) the interim solution here is to simply remove Python 3.9 from the workflows defined under `.github/workflows`.

Once merged @llwiggins should be able to rebase onto this branch to update `llwiggins/multiclass_documentation` and push the changes. PR #1158 should then pass the test suite. :fingers_crossed_tone1: