### PR TITLE
chore: revert to upstream numpyencoder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "numpy~=2.0.0",  # Until TensorFlow supports newer versions
   "numpyencoder",
   "pandas",
+  "pillow<=11.1.0",
   "pyyaml",
   "ruamel.yaml",
   "schema",


### PR DESCRIPTION
The fix I submitted [upstream](https://github.com/hmallen/numpyencoder/pull/8) to detect the Numpy version being used and handle type deprecation whilst providing backwards compatibility has now been merged.

We can therefore revert to using upstream PyPI released version of `numpyencoder` and remove the use of the forked [AFM-SPM-numpyencoder](https://github.com/AFM-SPM/numpyencoder) version where the same fix had been applied.

This in turn means that releases to PyPI will work again (as you can't release to PyPI when you have dependencies that come from Git repos).

---

- [X] Existing tests pass.
- [ ] ~~Documentation has been updated and builds. Remember to update as required...~~
  - [ ] ~~`docs/configuration.md`~~
  - [ ] ~~`docs/usage.md`~~
  - [ ] ~~`docs/data_dictionary.md`~~
  - [ ] ~~`docs/advanced.md` and new pages it should link to.~~
- [X] Pre-commit checks pass.
- [ ] ~~New functions/methods have typehints and docstrings.~~
- [ ] ~~New functions/methods have tests which check the intended behaviour is correct.~~