### PR TITLE
Include error message and line numbers in GrainStats error reporting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.2
+    rev: v0.12.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1,6 +1,6 @@
 """Functions for processing data."""
 
-import logging
+import logging, sys
 from collections import defaultdict
 from pathlib import Path
 
@@ -384,9 +384,11 @@ def run_grainstats(
             LOGGER.info(f"[{filename}] : Calculated grainstats for {len(grainstats_df)} grains.")
             LOGGER.info(f"[{filename}] : Grainstats stage completed successfully.")
             return grainstats_df, height_profiles_dict, grainstats_calculator.grain_crops
-        except Exception:
-            LOGGER.info(
-                f"[{filename}] : Errors occurred whilst calculating grain statistics. Returning empty dataframe."
+        except Exception as e:
+            _, _, e_traceback = sys.exc_info()
+            e_line_no = e_traceback.tb_lineno
+            LOGGER.error(
+                f"[{filename}] : An error occurred whilst calculating grain statistics on line {e_line_no}: {e}\nReturning empty dataframe."
             )
             return create_empty_dataframe(column_set="grainstats"), height_profiles_dict, {}
     else:


### PR DESCRIPTION
An update to issue #1171 so now errors are logged along with the line number that caused the exception. This should make it easier to locate issues within the try: section.

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds. Remember to update as required...
  - [ ] `docs/configuration.md`
  - [ ] `docs/usage.md`
  - [ ] `docs/data_dictionary.md`
  - [ ] `docs/advanced.md` and new pages it should link to.
- [ ] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
