### PR TITLE
include topostats version in output config file

### DIFF
--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -23,6 +23,10 @@ LOGGER = setup_logger()
 __version__ = version("topostats")
 __release__ = ".".join(__version__.split(".")[:-2])
 
+TOPOSTATS_DETAILS = version("topostats").split("+g")
+TOPOSTATS_VERSION = TOPOSTATS_DETAILS[0]
+TOPOSTATS_COMMIT = TOPOSTATS_DETAILS[1].split(".d")[0]
+
 colormaps.register(cmap=Colormap("nanoscope").get_cmap())
 colormaps.register(cmap=Colormap("gwyddion").get_cmap())
 
@@ -269,3 +273,9 @@ class TopoStats:
             Dictionary of ''TopoStats'' object.
         """
         return {re.sub(r"^_", "", key): value for key, value in self.__dict__.items()}
+
+
+def log_topostats_version() -> None:
+    """Log the TopoStats version, commit and date to system logger."""
+    LOGGER.info(f"TopoStats version : {TOPOSTATS_VERSION}")
+    LOGGER.info(f"Commit            : {TOPOSTATS_COMMIT}")

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -8,7 +8,7 @@ import argparse as arg
 import sys
 from pathlib import Path
 
-from topostats import __version__, run_modules
+from topostats import __version__, log_topostats_version, run_modules
 from topostats.io import write_config_with_comments
 from topostats.plotting import run_toposum
 
@@ -1268,6 +1268,9 @@ def entry_point(manually_provided_args=None, testing=False) -> None:
     None
         Does not return anything.
     """
+    # Log topostats version and the commit id
+    log_topostats_version()
+
     # Parse command line options, load config (or default) and update with command line options
     parser = create_parser()
     args = parser.parse_args() if manually_provided_args is None else parser.parse_args(manually_provided_args)

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -21,7 +21,7 @@ from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
-from topostats import __release__, grains
+from topostats import TOPOSTATS_COMMIT, TOPOSTATS_DETAILS, __release__, grains
 from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
@@ -237,6 +237,10 @@ def write_yaml(
         header = f"# {header_message} : {get_date_time()}\n" + CONFIG_DOCUMENTATION_REFERENCE
     else:
         header = f"# Configuration from TopoStats run completed : {get_date_time()}\n" + CONFIG_DOCUMENTATION_REFERENCE
+
+    # Add comment to config with topostats version + commit
+    header += f"# TopoStats version: {TOPOSTATS_DETAILS[0]}\n"
+    header += f"# Commit: {TOPOSTATS_COMMIT}\n"
 
     output_config.write_text(header, encoding="utf-8")
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -9,6 +9,7 @@ import numpy.typing as npt
 import pandas as pd
 from art import tprint
 
+from topostats import TOPOSTATS_COMMIT, TOPOSTATS_VERSION
 from topostats.array_manipulation import re_crop_grain_image_and_mask_to_set_size_nm
 from topostats.filters import Filters
 from topostats.grains import GrainCrop, GrainCropsDirection, Grains, ImageGrainCrops
@@ -1625,6 +1626,8 @@ def completion_message(config: dict, img_files: list, summary_config: dict, imag
     tprint("TopoStats", font="twisted")
     LOGGER.info(
         f"\n\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
+        f"  TopoStats Version           : {TOPOSTATS_VERSION}\n"
+        f"  TopoStats Commit            : {TOPOSTATS_COMMIT}\n"
         f"  Base Directory              : {config['base_dir']}\n"
         f"  File Extension              : {config['file_ext']}\n"
         f"  Files Found                 : {len(img_files)}\n"


### PR DESCRIPTION
The config.yaml file generated and stored in /output/ now includes information in the header about the topostats version used along with the exact commit.

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds. Remember to update as required...
  - [ ] `docs/configuration.md`
  - [ ] `docs/usage.md`
  - [ ] `docs/data_dictionary.md`
  - [ ] `docs/advanced.md` and new pages it should link to.
- [x] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
