### PR TITLE
chore: fix ruff excludes; ignore notebook docstring linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,7 @@ repos:
     rev: v1.9.0
     hooks:
       - id: numpydoc-validation
+        exclude_files: "^notebooks/*.py$"
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/topostats/filters.py
+++ b/topostats/filters.py
@@ -6,7 +6,6 @@ import numpy as np
 import numpy.typing as npt
 from scipy.optimize import curve_fit
 
-# ruff: noqa: disable=no-name-in-module
 # pylint: disable=no-name-in-module
 from skimage.filters import gaussian
 
@@ -16,8 +15,7 @@ from topostats.utils import get_mask, get_thresholds
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
-# ruff: noqa: disable=too-many-instance-attributes
-# ruff: noqa: disable=too-many-arguments
+# noqa: PLR0913
 # pylint: disable=fixme
 # pylint: disable=broad-except
 # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
Partially addresses #1215

- Fixes ruff `# noqa` directives in `topostats/filters.py`.
- Excludes `^notebooks/*.py$` from [numpydoc-validation](https://numpydoc.readthedocs.io/en/latest/validation.html#docstring-validation-using-pre-commit-hook).

---

- [ ] Pre-commit checks pass (and they won't as there are linting errors in the Notebooks that aren't addressed in this PR).

EDIT : The `numpydoc-validation` doesn't ignore the Notebooks, because `pre-commit.ci` is using the rules defined in `.pre-commit-configy.yaml` from the `main` branch rather than the changes in `ns-rse/1215-linting-notebooks` that are being merged in.