### PR TITLE
Fix arrays used in np.cross to now be 3d

### DIFF
--- a/topostats/measure/feret.py
+++ b/topostats/measure/feret.py
@@ -232,13 +232,16 @@ def triangle_height(base1: npt.NDArray | list, base2: npt.NDArray | list, apex: 
     """
     base1_base2 = np.asarray(base1) - np.asarray(base2)
     base1_apex = np.asarray(base1) - np.asarray(apex)
-    # Ensure arrays are 3-D see note in https://numpy.org/doc/2.0/reference/generated/numpy.cross.html
-    return np.linalg.norm(cross2d(base1_base2, base1_apex)) / np.linalg.norm(base1_base2)
+    # np.cross requires 3d arrays so append a new dimension before calculating
+    # See https://numpy.org/doc/2.0/reference/generated/numpy.cross.html
+    base1_base2_3d = np.append(base1_base2, 0)
+    base1_apex_3d = np.append(base1_apex, 0)
+    return np.linalg.norm(np.cross(base1_base2_3d, base1_apex_3d)) / np.linalg.norm(base1_base2_3d)
 
 
 def cross2d(x: npt.NDArray, y: npt.NDArray) -> npt.NDArray:
     """
-    Return the c$ross product of two 2-D arrays of vectors.
+    Return the cross product of two 2-D arrays of vectors.
 
     See https://numpy.org/doc/2.0/reference/generated/numpy.cross.html
 


### PR DESCRIPTION
NumPy 2 requires arrays used in the function `np.cross` to be 3d whereas `triangle_height()` previously used 2d variables which caused grainstats to fail. This update just appends a new axis to each array used, appeasing `np.cross`.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.
