### PR TITLE
fix(create_config): Corrects generalised configuration file writing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -235,15 +235,33 @@ want to make to the default configuration and how to make them.
 TopoStats will use some reasonable default parameters by default, but typically you will want to customise the
 parameters that are used. This is achieved using a [configuration](configuration) file. This is a
 [YAML](https://yaml.org) file that contains parameters for different settings. For convenience you can generate
-a sample configuration file in your current working directory using the `topostats create-config` sub-command. It
-takes a single argument, the name of the file to save the configuration to (e.g. `config.yaml` or `settings.yaml`), and
-it will write the current default configuration to that file.
+a sample configuration file in your current working directory using the `topostats create-config` sub-command. There are
+a number of arguments available. They key one is `--config` which defines what configuration file is written and
+currently has three possible options `default`, `simple`, `mplstyle` or `var_to_label`. See `topostats create-config ---help`
+for descriptions of other available options. **NB** if `--filename` is omitted then the value of `--config` determines
+the filename the configuration is written to as shown below.
 
 ```bash
-topostats create-config --filename my_config.yaml
-ls -l
-my_config.yaml
-sample_image_scan_2022-12-08-1204.spm
+topostats create-config --config default --filename my_default_config.yaml
+[Tue, 28 Oct 2025 16:12:16] [INFO    ] [topostats] TopoStats version : 2.3.2.dev600
+[Tue, 28 Oct 2025 16:12:16] [INFO    ] [topostats] Commit            : 54e4b940a
+[Tue, 28 Oct 2025 16:12:16] [INFO    ] [topostats] A sample configuration has been written to : my_default_config.yaml
+topostats create-config --config default
+[Tue, 28 Oct 2025 16:12:18] [INFO    ] [topostats] TopoStats version : 2.3.2.dev600
+[Tue, 28 Oct 2025 16:12:18] [INFO    ] [topostats] Commit            : 54e4b940a
+[Tue, 28 Oct 2025 16:12:18] [INFO    ] [topostats] A sample configuration has been written to : default_config.yaml
+❱ topostats create-config --config simple
+[Tue, 28 Oct 2025 16:12:22] [INFO    ] [topostats] TopoStats version : 2.3.2.dev600
+[Tue, 28 Oct 2025 16:12:22] [INFO    ] [topostats] Commit            : 54e4b940a
+[Tue, 28 Oct 2025 16:12:22] [INFO    ] [topostats] A sample configuration has been written to : simple_config.yaml
+❱ topostats create-config --config mplstyle
+[Tue, 28 Oct 2025 16:12:47] [INFO    ] [topostats] TopoStats version : 2.3.2.dev600
+[Tue, 28 Oct 2025 16:12:47] [INFO    ] [topostats] Commit            : 54e4b940a
+[Tue, 28 Oct 2025 16:12:47] [INFO    ] [topostats] A sample configuration has been written to : topostats.mplstyle
+topostats create-config --config var_to_label
+[Tue, 28 Oct 2025 16:13:03] [INFO    ] [topostats] TopoStats version : 2.3.2.dev600
+[Tue, 28 Oct 2025 16:13:03] [INFO    ] [topostats] Commit            : 54e4b940a
+[Tue, 28 Oct 2025 16:13:03] [INFO    ] [topostats] A sample configuration has been written to : var_to_label.yaml
 ```
 
 You can now edit and/or rename the `my_config.yaml`. It can be called anything you want,
@@ -276,8 +294,10 @@ ones you may want to change are....
 - `plotting` : `image_set` (default `core`) specifies which steps of the processing to plot images of. The value `all`
   gets images for all stages, `core` saves only a subset of images.
 
-Most of the other configuration options can be left on their default values for now. Once you have made any changes save
-the file and return to your terminal.
+Most of the other configuration options can be left on their default values for now but the file is fully commented and
+should you wish to change settings you should read these comments.
+
+Once you have made any changes save the file and return to your terminal.
 
 ### Running TopoStats with `my_config.yaml`
 
@@ -309,7 +329,9 @@ On successful completion you should see the same message noted above.
 Older Bruker devices output files with somewhat uninformative numerical file extensions (e.g. `.001`, `.002`, `.003`
 etc.). TopoStats will automatically detect and process these if the configuration file is `file_ext: .spm` (or on the
 command line the `--file-ext/-f .spm` option is used). However, for convenience a sub-processor is provided which will
-append the suffix `.spm` to all files found recursively with numerical extensions in the specified directory.
+append the suffix `.spm` to all files found recursively with numerical extensions in the specified directory. You can
+specify the `--base-dir /path/to/a/directory` if you are not already in the same directory as the files, otherwise it
+will use the current directory. You then use the sub-command `bruker-rename`.
 
 ```bash
 topostats --base-dir /path/to/a/directory bruker-rename

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -663,8 +663,6 @@ def test_entry_point_subprocess_help(capsys, argument: str, option: str) -> None
                 "dummy/config/dir/var_to_label.yaml",
                 "--create-config-file",
                 "/tmp/new_config_file.yaml",  # noqa: S108
-                "--create-label-file",
-                "/tmp/new_label_file.yaml",  # noqa: S108
                 "--savefig-format",
                 ".png",
             ],
@@ -674,7 +672,6 @@ def test_entry_point_subprocess_help(capsys, argument: str, option: str) -> None
                 "config_file": Path("/tmp/dummy_config.yaml"),  # noqa: S108
                 "var_to_label": Path("dummy/config/dir/var_to_label.yaml"),
                 "create_config_file": Path("/tmp/new_config_file.yaml"),  # noqa: S108
-                "create_label_file": Path("/tmp/new_label_file.yaml"),  # noqa: S108
                 "savefig_format": ".png",
             },
             id="Summary with input csv (long) and label file (short).",
@@ -693,30 +690,34 @@ def test_entry_points(options: list, expected_function: Callable, expected_args:
         assert returned_args_dict[argument] == value
 
 
-def test_entry_point_create_config_file(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("config", "target_file"),
+    [
+        pytest.param(None, "default_config.yaml", id="default config no --config option"),
+        pytest.param("default", "default_config.yaml", id="default config with --config option"),
+        pytest.param("simple", "simple_config.yaml", id="simple config option"),
+        pytest.param("mplstyle", "topostats.mplstyle", id="mplstyle config option"),
+        pytest.param("var_to_label", "var_to_label.yaml", id="var_to_label config option"),
+    ],
+)
+def test_entry_point_create_config_file(config: str, target_file: str, tmp_path: Path) -> None:
     """Test that the entry point is able to produce a default config file when asked to."""
-    entry_point(
-        manually_provided_args=[
-            "create-config",
-            "--filename",
-            "test_create_config.yaml",
-            "--output-dir",
-            f"{tmp_path}",
-        ]
-    )
-    assert Path(f"{tmp_path}/test_create_config.yaml").is_file()
-
-
-def test_entry_point_create_simple_config_file(tmp_path: Path) -> None:
-    """Test that the entry point is able to produce a simple config file when asked to."""
-    entry_point(
-        manually_provided_args=[
-            "create-config",
-            "--filename",
-            "test_create_simple_config.yaml",
-            "--output-dir",
-            f"{tmp_path}",
-            "--simple",
-        ]
-    )
-    assert Path(f"{tmp_path}/test_create_simple_config.yaml").is_file()
+    if config is None:
+        entry_point(
+            manually_provided_args=[
+                "create-config",
+                "--output-dir",
+                f"{tmp_path}",
+            ]
+        )
+    else:
+        entry_point(
+            manually_provided_args=[
+                "create-config",
+                "--config",
+                f"{config}",
+                "--output-dir",
+                f"{tmp_path}",
+            ]
+        )
+    assert Path(f"{tmp_path}/{target_file}").is_file()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,17 +1,13 @@
 """Tests for the plotting module."""
 
-from importlib import resources
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pytest
-import yaml
 from matplotlib.figure import Figure
 
-import topostats
-from topostats.entry_point import entry_point
 from topostats.plotting import TopoSum, _pad_array, plot_height_profiles, toposum
 
 # pylint: disable=protected-access
@@ -76,28 +72,6 @@ def test_outfile(toposum_object_multiple_directories: TopoSum) -> None:
 def test_args_input_csv() -> None:
     """Test modifying the configuration value for the input CSV to be summarised."""
     assert True
-
-
-def test_var_to_label_config(tmp_path: Path) -> None:
-    """Test the var_to_label configuration file is created correctly."""
-    with pytest.raises(SystemExit):
-        entry_point(
-            manually_provided_args=[
-                "summary",
-                "--create-label-file",
-                f"{tmp_path / 'var_to_label_config.yaml'}",
-                "--input-csv",
-                f"{str(RESOURCES / 'minicircle_default_all_statistics.csv')}",
-            ]
-        )
-    var_to_label_config = tmp_path / "var_to_label_config.yaml"
-    with var_to_label_config.open("r", encoding="utf-8") as f:
-        var_to_label_str = f.read()
-    var_to_label = yaml.safe_load(var_to_label_str)
-    plotting_yaml = (resources.files(topostats.__package__) / "var_to_label.yaml").read_text()
-    expected_var_to_label = yaml.safe_load(plotting_yaml)
-
-    assert var_to_label == expected_var_to_label
 
 
 @pytest.mark.parametrize(

--- a/topostats/entry_point.py
+++ b/topostats/entry_point.py
@@ -1164,13 +1164,6 @@ def create_parser() -> arg.ArgumentParser:
         help="Filename to write a sample YAML configuration file to (should end in '.yaml').",
     )
     summary_parser.add_argument(
-        "--create-label-file",
-        dest="create_label_file",
-        type=Path,
-        required=False,
-        help="Filename to write a sample YAML label file to (should end in '.yaml').",
-    )
-    summary_parser.add_argument(
         "--savefig-format",
         dest="savefig_format",
         type=str,
@@ -1190,7 +1183,6 @@ def create_parser() -> arg.ArgumentParser:
         dest="filename",
         type=Path,
         required=False,
-        default="config.yaml",
         help="Name of YAML file to save configuration to (default 'config.yaml').",
     )
     create_config_parser.add_argument(
@@ -1207,49 +1199,10 @@ def create_parser() -> arg.ArgumentParser:
         "--config",
         dest="config",
         type=str,
-        default=None,
-        help="Configuration to use, currently 'default' and 'simple' are supported.",
-    )
-    create_config_parser.add_argument(
-        "-s",
-        "--simple",
-        dest="simple",
-        action="store_true",
-        help="Create a simple configuration file with only the most common options.",
+        default="default",
+        help="Configuration to use, currently 'default', 'simple', 'mplstyle' and 'var_to_label' are supported.",
     )
     create_config_parser.set_defaults(func=write_config_with_comments)
-
-    create_matplotlibrc_parser = subparsers.add_parser(
-        "create-matplotlibrc",
-        description="Create a Matplotlibrc parameters file.",
-        help="Create a Matplotlibrc parameters file using the defaults.",
-    )
-    create_matplotlibrc_parser.add_argument(
-        "-f",
-        "--filename",
-        dest="filename",
-        type=Path,
-        required=False,
-        default="topostats.mplstyle",
-        help="Name of file to save Matplotlibrc configuration to (default 'topostats.mplstyle').",
-    )
-    create_matplotlibrc_parser.add_argument(
-        "-o",
-        "--output-dir",
-        dest="output_dir",
-        type=Path,
-        required=False,
-        default="./",
-        help="Path to where the YAML file should be saved (default './' the current directory).",
-    )
-    create_matplotlibrc_parser.add_argument(
-        "-c",
-        "--config",
-        dest="config",
-        default="topostats.mplstyle",
-        help="Matplotlibrc style file to use, currently only one is supported, the 'topostats.mplstyle'.",
-    )
-    create_matplotlibrc_parser.set_defaults(func=write_config_with_comments)
 
     # Rename old Bruker files
     bruker_rename = subparsers.add_parser(


### PR DESCRIPTION
Closes  #1229

- Correctly decode bytes to string when writing configuration file.
- Update parameter names for `test_reconcile_config_args_partial_config_with_overrides()`.
- Removes extra '# ' from header of some configuration files.
- Sets a the `default="default"` for the `--config` option to `create-config` sub-parser.
- Removes option `--simple` from the `create-config` sub-parser in favour of `--config simple`
- Removes the `create-matplotlibrc` sub-parser completely now handled by in favour of `--config mplstyle` which writes
  `topostats.mplstyle`.
- Removes the option `--create-label-file` from the `summary` sub-parser and instead we now create this as `topostats
  create-config --config var_to_label` as its less code and more consistent.
- Updates `docs/usage.md` to reflect these changes (it was outdated anyway).
- Removes redundant tests from `tests/test_plotting.py`
- Updates tests of `tests/test_config.py` with all combinatinos of parameters for the four supported configuration
  files. 
- Updates all necessary tests of `test/test_entry_points.py` removing one and instead parameterising another as well as
  updating `tests_config.py`.
- Adds `create-config` to the list of modules in `update_module()` function which sets `args.module` to `topostats` so
  that the correct configuration file is loaded for the given package and calls `update_module()` priort to attempting
  to load the file for writing.

The last step will need revising in the future if/when we introduce sub-sub-parsers (as proposed in the docstring for
`update_module()`) to allow the flexibility of working with different pipelines.

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [ ] ~Documentation has been updated and builds. Remember to update as required...~
- [X] Pre-commit checks pass.
- [ ] ~New functions/methods have typehints and docstrings.~
- [ ] ~New functions/methods have tests which check the intended behaviour is correct.~