### PR TITLE
ci(gh-pages): build & deploy on closing PRs on main

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -3,6 +3,8 @@ name: Sphinx docs to gh-pages
 
 on:
   pull_request:
+    types:
+      - [closed]
     branches:
       - main
     # Uncomment if only tagged releases are to have documentation built


### PR DESCRIPTION
The `.github/workflows/sphinx_docs_to_gh_pages.yaml` workflow was triggered on each pull request that targeted `main`. This is unnecessary as we only want it to run _after_ we merge changes in.

I've therefore added a [`type`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) to restrict this to when `pull_request` is `closed` which happens on merging.

Hopefully we will now use less resources as the action will run less frequently and it will always build the merged changes.
