### PR TITLE
ci: correct pypi workflow to run on tagged releases

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,9 +2,9 @@ name: Publish package to PyPi
 # See https://docs.pypi.org/trusted-publishers/adding-a-publisher/
 
 on:
-  pull_request:
-    branches:
-      - main
+  push:
+    tags:
+      - v*
   workflow_dispatch: # Uncomment line if you also want to trigger action manually
 
 jobs:


### PR DESCRIPTION
Mistakenly changed this to run on pushes to `main` rather than on tagged releases. Reverting so it runs on commits tagged with `v*`
