### PR TITLE
chore: Remove dependency on AFMReader `main`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,16 +26,17 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+  "License :: OSI Approved :: GNU General Public License v3.0 only",
 ]
 keywords = [
   "afm",
-  "image processing"
+  "atomic force microscopy",
+  "image processing",
 ]
 requires-python = ">=3.10, <3.12"
 dependencies = [
   "art",
-  "AFMReader @ git+https://github.com/AFM-SPM/AFMReader@main",
+  "AFMReader",
   "h5py",
   "keras",
   "matplotlib",


### PR DESCRIPTION
Can't publish to PyPI with dependencies that are installed from GitHub.

`AFMReader-v0.0.6` (commit `ac06413`; tag `v0.0.6`) was released 2025-06-24 and since we have only updated `pre-commit`
hooks since then `main` has the same functionality.