### PR TITLE
fix: no commit in released versions to report

### DIFF
--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -10,6 +10,7 @@ import numpy as np
 import numpy.typing as npt
 import snoop
 from matplotlib import colormaps
+from packaging.version import Version
 
 from .grains import ImageGrainCrops
 from .logs.logs import setup_logger
@@ -23,9 +24,13 @@ LOGGER = setup_logger()
 __version__ = version("topostats")
 __release__ = ".".join(__version__.split(".")[:-2])
 
-TOPOSTATS_DETAILS = version("topostats").split("+g")
-TOPOSTATS_VERSION = TOPOSTATS_DETAILS[0]
-TOPOSTATS_COMMIT = TOPOSTATS_DETAILS[1].split(".d")[0]
+TOPOSTATS_VERSION = Version(__version__)
+if TOPOSTATS_VERSION.is_prerelease and TOPOSTATS_VERSION.is_devrelease:
+    TOPOSTATS_BASE_VERSION = str(TOPOSTATS_VERSION.base_version)
+    TOPOSTATS_COMMIT = str(TOPOSTATS_VERSION).split("+g")[1]
+else:
+    TOPOSTATS_BASE_VERSION = str(TOPOSTATS_VERSION)
+    TOPOSTATS_COMMIT = ""
 CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and how to use it:
 # https://afm-spm.github.io/TopoStats/main/configuration.html\n"""
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -19,7 +19,7 @@ from AFMReader import asd, gwy, ibw, jpk, spm, stp, top, topostats
 from numpyencoder import NumpyEncoder
 from ruamel.yaml import YAML, YAMLError
 
-from topostats import CONFIG_DOCUMENTATION_REFERENCE, TOPOSTATS_COMMIT, TOPOSTATS_VERSION, __release__, grains
+from topostats import CONFIG_DOCUMENTATION_REFERENCE, TOPOSTATS_BASE_VERSION, TOPOSTATS_COMMIT, __release__, grains
 from topostats.logs.logs import LOGGER_NAME
 
 LOGGER = logging.getLogger(LOGGER_NAME)
@@ -201,7 +201,7 @@ def write_yaml(
         header = f"# Configuration from TopoStats run completed : {get_date_time()}\n" + CONFIG_DOCUMENTATION_REFERENCE
 
     # Add comment to config with topostats version + commit
-    header += f"# TopoStats version: {TOPOSTATS_VERSION}\n"
+    header += f"# TopoStats version: {TOPOSTATS_BASE_VERSION}\n"
     header += f"# Commit: {TOPOSTATS_COMMIT}\n"
 
     output_config.write_text(header, encoding="utf-8")

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -9,7 +9,7 @@ import numpy.typing as npt
 import pandas as pd
 from art import tprint
 
-from topostats import TOPOSTATS_COMMIT, TOPOSTATS_VERSION
+from topostats import TOPOSTATS_BASE_VERSION, TOPOSTATS_COMMIT
 from topostats.array_manipulation import re_crop_grain_image_and_mask_to_set_size_nm
 from topostats.filters import Filters
 from topostats.grains import GrainCrop, GrainCropsDirection, Grains, ImageGrainCrops
@@ -1626,7 +1626,7 @@ def completion_message(config: dict, img_files: list, summary_config: dict, imag
     tprint("TopoStats", font="twisted")
     LOGGER.info(
         f"\n\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ COMPLETE ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
-        f"  TopoStats Version           : {TOPOSTATS_VERSION}\n"
+        f"  TopoStats Version           : {TOPOSTATS_BASE_VERSION}\n"
         f"  TopoStats Commit            : {TOPOSTATS_COMMIT}\n"
         f"  Base Directory              : {config['base_dir']}\n"
         f"  File Extension              : {config['file_ext']}\n"


### PR DESCRIPTION
Closes #1246

When instantiating the module we extract the release and commit to report in the logs and YAML file that are reported.

This was done by splitting the string, development versions will have the from `#.#.#dev###+g<hash>` and released
versions do not contain the `dev###+g<hash>` component to extract.

We now switch to using the [packaging.version](https://packaging.pypa.io/en/stable/version.html) module to check if we
this is a `dev` (`#.#.#dev###+g<hash>`) or `prerelease` (`#.#.#rc#`) version and set the `TOPOSTATS_BASE_VERSION` and
`TOPOSTATS_COMMIT` conditional on that.