### PR TITLE
Require users to run on main before submitting bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -21,6 +21,8 @@ body:
       label: Checklist
       description: A Checklist is provided below for you to track each of the subsequent tasks.
       options:
+        - label: Run using the `main` branch to check if the issue persists. Instructions on how to do this can be found [here](https://afm-spm.github.io/TopoStats/main/installation.html#installing-from-github).
+          required: true
         - label: Find the offending file in the output. If processing halts, re-run analysis with `topostats --core 1 process`.
           required: true
         - label: Describe the bug.
@@ -76,6 +78,12 @@ body:
         - 2.1.0
         - 2.1.1
         - 2.1.2
+        - 2.2.0
+        - 2.2.1
+        - 2.3.0
+        - 2.3.1
+        - 2.3.2rc1
+        - 2.3.2rc2
         - Git main branch
       default: 3
     validations:
@@ -87,11 +95,8 @@ body:
       description: |
         What version of Python are you running? If unsure type `python --version`.
       options:
-        - 3.8
-        - 3.9
         - 3.10
         - 3.11
-        - 3.12
       default: 3
     validations:
       required: true


### PR DESCRIPTION
Closes #1228

There have been cases where an bug report was submitted that had already been solved in `main` but not included in a full release. Whilst keeping semi-regular releases standard can help avoid this it would be helpful to prompt users to check their issue against the current state of `main` in case it has already been addressed.

This PR adds a checkbox to the issue template asking the user to do so, along with a link to instructions on how to do it.
