### PR TITLE
fix(plotting): create missing output directory when image_set is set to core and grain_crops included

### DIFF
--- a/topostats/plottingfuncs.py
+++ b/topostats/plottingfuncs.py
@@ -604,7 +604,7 @@ class Images:
                         self.pixel_to_nm_scaling,
                         (2, -2),
                     )
-                self.output_dir.mkdir(parents=True, exist_ok=True)
+            self.output_dir.mkdir(parents=True, exist_ok=True)
             if not self.axes and not self.colorbar:
                 plt.title("")
                 fig.frameon = False


### PR DESCRIPTION
Fixes #1267 
FileNotFoundError caused by output directory path not having been created when the plots are attempted to be saved in a subdirectory of the main output directory. This updates adds a small check to create the subdirectory at the failure point if it doesn't already exist.
