### PR TITLE
fix: Use filename w/extension

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,7 +313,7 @@ def test_filters(load_scan: LoadScans, filter_config: dict) -> Filters:
     """Filters class for testing."""
     load_scan.get_data()
     return Filters(
-        topostats_object=load_scan.img_dict["minicircle_small"],
+        topostats_object=load_scan.img_dict["minicircle_small.topostats"],
         **filter_config,
     )
 
@@ -760,7 +760,7 @@ def small_array_filters(small_array: np.ndarray, load_scan: LoadScans, filter_co
     """Filters object based on small_array."""
     load_scan.get_data()
     filter_obj = Filters(
-        topostats_object=load_scan.img_dict["minicircle_small"],
+        topostats_object=load_scan.img_dict["minicircle_small.topostats"],
         **filter_config,
     )
     filter_obj.pixel_to_nm_scaling = 0.5
@@ -862,7 +862,7 @@ def minicircle(load_scan: LoadScans, filter_config: dict) -> Filters:
     """Instantiate a Filters object, creates the output directory and loads the image."""
     load_scan.get_data()
     return Filters(
-        topostats_object=load_scan.img_dict["minicircle_small"],
+        topostats_object=load_scan.img_dict["minicircle_small.topostats"],
         **filter_config,
     )
 
@@ -1403,7 +1403,6 @@ def mock_model_5_by_5_single_class() -> MagicMock:
         assert input_array.dtype == np.float32, "Input data type is not as expected"
 
         input_array_without_batch_and_channel = input_array[0, :, :, 0]
-        print(input_array_without_batch_and_channel)
 
         # Different output for different input
         if np.array_equal(
@@ -1527,7 +1526,7 @@ def minicircle_small_topostats(default_config: dict[str, Any]) -> TopoStats:
     default_config["file_ext"] = ".topostats"
     load_scan = LoadScans([RESOURCES / "test_image" / "minicircle_small.topostats"], config=default_config)
     load_scan.get_data()
-    return load_scan.img_dict["minicircle_small"]
+    return load_scan.img_dict["minicircle_small.topostats"]
 
 
 # In addition to `minicircles.spm` (and derivatives) we have three sets of pickled TopoStats objects (as file sizes blow
@@ -1566,8 +1565,8 @@ def post_processing_minicircle_topostats_object(default_config: dict[str, Any]) 
     """
     load_scans = LoadScans([RESOURCES / "post_process" / "post_processing_minicircle.topostats"], config=default_config)
     load_scans.get_data()
-    topostats_object = load_scans.img_dict["post_processing_minicircle"]
-    topostats_object.filename = "minicircle"
+    topostats_object = load_scans.img_dict["post_processing_minicircle.topostats"]
+    topostats_object.filename = "minicircle.topostats"
     return topostats_object
 
 
@@ -1582,8 +1581,8 @@ def post_processing_minicircle_topostats_object(default_config: dict[str, Any]) 
 #     load_scans = LoadScans([RESOURCES / "post_process" / "post_processing_minicircle_small.topostats"],
 #                              config=default_config)
 #     load_scans.get_data()
-#     topostats_object = load_scans.img_dict["minicircle_small"]
-#     topostats_object.filename = "minicircle_small"
+#     topostats_object = load_scans.img_dict["minicircle_small.topostats"]
+#     topostats_object.filename = "minicircle_small.topostats"
 #     return topostats_object
 
 # @pytest.fixture()

--- a/tests/measure/test_geometry.py
+++ b/tests/measure/test_geometry.py
@@ -209,7 +209,6 @@ def test_calculate_shortest_branch_distances(
 
     np.testing.assert_array_equal(shortest_node_distances, expected_shortest_node_distances)
     np.testing.assert_array_equal(shortest_distances_branch_indexes, expected_shortest_distances_branch_indexes)
-    print(shortest_distances_branch_coordinates)
     np.testing.assert_array_equal(shortest_distances_branch_coordinates, expected_shortest_distances_branch_coordinates)
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -456,68 +456,68 @@ def test_convert_basename_to_relative_paths():
 @pytest.mark.parametrize(
     ("base_dir", "image_path", "output_dir", "expected"),
     [
-        # Absolute path, nested under base_dir, with file suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("/some/random/path/images/test.spm"),
             Path("output/here"),
-            Path("output/here/images/test/"),
+            Path("output/here/images/test.spm/"),
+            id="Absolute path, nested under base_dir, with file suffix",
         ),
-        # Absolute path, nested under base_dir, with file suffix and multiple periods
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("/some/random/path/images/to.at.spm"),
             Path("output/here"),
-            Path("output/here/images/to.at/"),
+            Path("output/here/images/to.at.spm/"),
+            id="Absolute path, nested under base_dir, with file suffix and multiple periods",
         ),
-        # Absolute path, nested under base_dir, with file suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("/some/random/path/images/today/test.spm"),
             Path("output/here"),
-            Path("output/here/images/today/test/"),
+            Path("output/here/images/today/test.spm/"),
+            id="Absolute path, nested under base_dir, with file suffix",
         ),
-        # Relative path, nested under base_dir, with file_suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("images/test.spm"),
             Path("output/here"),
-            Path("output/here/images/test"),
+            Path("output/here/images/test.spm"),
+            id="Relative path, nested under base_dir, with file_suffix",
         ),
-        # Relative path, nested (two deep) under base_dir, with file_suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("images/today/test.spm"),
             Path("output/here"),
-            Path("output/here/images/today/test"),
+            Path("output/here/images/today/test.spm"),
+            id="Relative path, nested (two deep) under base_dir, with file_suffix",
         ),
-        # Relative path, nested under base_dir, no file suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("images/"),
             Path("output/here"),
             Path("output/here/images/"),
+            id="Relative path, nested under base_dir, no file suffix",
         ),
-        # Absolute path, nested under base_dir, output not nested under base_dir, with file_suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("/some/random/path/images/test.spm"),
             Path("/different/absolute/path"),
-            Path("/different/absolute/path/images/test"),
+            Path("/different/absolute/path/images/test.spm"),
+            id="Absolute path, nested under base_dir, output not nested under base_dir, with file_suffix",
         ),
-        # Absolute path, nested under base_dir, output not nested under base_dir, no file file_suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("/some/random/path/images/"),
             Path("/different/absolute/path"),
             Path("/different/absolute/path/images/"),
+            id="Absolute path, nested under base_dir, output not nested under base_dir, no file file_suffix",
         ),
-        # Relative path, nested under base_dir, output not nested under base_dir, with file_suffix
-        (
+        pytest.param(
             Path("/some/random/path"),
             Path("images/test.spm"),
             Path("/an/absolute/path"),
-            Path("/an/absolute/path/images/test"),
+            Path("/an/absolute/path/images/test.spm"),
+            id="Relative path, nested under base_dir, output not nested under base_dir, with file_suffix",
         ),
     ],
 )
@@ -526,16 +526,6 @@ def test_get_out_path(image_path: Path, base_dir: Path, output_dir: Path, expect
     out_path = get_out_path(image_path, base_dir, output_dir)
     assert isinstance(out_path, Path)
     assert out_path == expected
-
-
-def test_get_out_path_attributeerror() -> None:
-    """Test get_out_path() raises AttribteError when passed a string instead of a Path() for image_path."""
-    with pytest.raises(AttributeError):
-        get_out_path(
-            image_path="images/test.spm",
-            base_dir=Path("/some/random/path"),
-            output_dir=Path("output/here"),
-        )
 
 
 def test_save_image_grainstats(tmp_path: Path) -> None:
@@ -671,26 +661,26 @@ def test_load_scan_asd(load_scan_asd: LoadScans) -> None:
 @pytest.mark.parametrize(
     ("load_scan_object", "length", "image_shape", "image_sum", "filename", "pixel_to_nm_scaling"),
     [
-        pytest.param("load_scan_spm", 1, (1024, 1024), 30695369.188316286, "minicircle", 0.4940029296875, id="spm"),
-        pytest.param("load_scan_ibw", 1, (512, 512), -218091520.0, "minicircle2", 1.5625, id="ibw"),
-        pytest.param("load_scan_jpk", 1, (256, 256), 219242202.8256843, "file", 1.2770176335964876, id="jpk"),
-        pytest.param("load_scan_gwy", 1, (512, 512), 33836850.232917726, "file", 0.8468632812499975, id="gwy"),
+        pytest.param("load_scan_spm", 1, (1024, 1024), 30695369.188316286, "minicircle.spm", 0.4940029296875, id="spm"),
+        pytest.param("load_scan_ibw", 1, (512, 512), -218091520.0, "minicircle2.ibw", 1.5625, id="ibw"),
+        pytest.param("load_scan_jpk", 1, (256, 256), 219242202.8256843, "file.jpk", 1.2770176335964876, id="jpk"),
+        pytest.param("load_scan_gwy", 1, (512, 512), 33836850.232917726, "file.gwy", 0.8468632812499975, id="gwy"),
         pytest.param(
             "load_scan_topostats",
             1,
             (1024, 1024),
             30695369.188316286,
-            "file",
+            "file.topostats",
             0.4940029296875,
             id="topostats",
         ),
-        pytest.param("load_scan_asd", 197, (200, 200), -12843725.967220962, "file_122", 2.0, id="asd"),
+        pytest.param("load_scan_asd", 197, (200, 200), -12843725.967220962, "file.asd_122", 2.0, id="asd"),
         pytest.param(
             "load_scan_topostats_240",
             1,
             (1024, 1024),
             30695369.188316286,
-            "minicircle_240",
+            "minicircle_240.topostats",
             0.4940029296875,
             id="topostats (version 2.4.0)",
         ),

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -39,7 +39,7 @@ def test_process_scan(tmp_path, process_scan_config: dict, load_scan_data: LoadS
     """Regression test for checking the process_scan functions correctly."""
     img_dic = load_scan_data.img_dict
     _, grain_stats, _, img_stats, _, _, _ = process_scan(
-        topostats_object=img_dic["minicircle_small"],
+        topostats_object=img_dic["minicircle_small.topostats"],
         base_dir=BASE_DIR,
         filter_config=process_scan_config["filter"],
         grains_config=process_scan_config["grains"],
@@ -58,11 +58,11 @@ def test_process_scan(tmp_path, process_scan_config: dict, load_scan_data: LoadS
     assert grain_stats.to_string(float_format="{:.4e}".format) == snapshot
 
     # Regtest for the topostats file
-    assert Path.exists(tmp_path / "tests/resources/test_image/processed/minicircle_small.topostats")
+    assert Path.exists(tmp_path / "tests/resources/test_image/processed/topostats/minicircle_small.topostats")
     # Load the results, note that we use AFMReader.topostats.load_topostats() here which simply loads the data as
     # dictionaries and means it is easy to compare to syrupy snapshots
     saved_topostats = load_topostats(
-        file_path=tmp_path / "tests/resources/test_image/processed/minicircle_small.topostats"
+        file_path=tmp_path / "tests/resources/test_image/processed/topostats/minicircle_small.topostats"
     )
     # Drop the config, img_path and topostats_version from top level of dictionary and and basename from
     # disorded_trace.stats_dict) as we don't want to compare configuration nor test absolute paths.
@@ -134,7 +134,7 @@ def test_save_cropped_grains(
     process_scan_config["plotting"]["savefig_dpi"] = 50
     img_dic = load_scan_data.img_dict
     _, _, _, _, _, _, _ = process_scan(
-        topostats_object=img_dic["minicircle_small"],
+        topostats_object=img_dic["minicircle_small.topostats"],
         base_dir=BASE_DIR,
         filter_config=process_scan_config["filter"],
         grains_config=process_scan_config["grains"],
@@ -350,7 +350,7 @@ def test_image_set(
     process_scan_config["plotting"]["savefig_dpi"] = 50
     img_dic = load_scan_data.img_dict
     process_scan(
-        topostats_object=img_dic["minicircle_small"],
+        topostats_object=img_dic["minicircle_small.topostats"],
         base_dir=BASE_DIR,
         filter_config=process_scan_config["filter"],
         grains_config=process_scan_config["grains"],
@@ -387,9 +387,8 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
     process_scan_config["plotting"]["image_set"] = "all"
     process_scan_config["plotting"]["savefig_format"] = extension
     process_scan_config["plotting"] = update_plotting_config(process_scan_config["plotting"])
-    img_dic = load_scan_data.img_dict
     _, _, _, _, _, _, _ = process_scan(
-        topostats_object=img_dic["minicircle_small"],
+        topostats_object=load_scan_data.img_dict["minicircle_small.topostats"],
         base_dir=BASE_DIR,
         filter_config=process_scan_config["filter"],
         grains_config=process_scan_config["grains"],
@@ -788,7 +787,7 @@ def test_process_stages(
     later stages can run and do not disable earlier stages.
     """
     caplog.set_level(logging.DEBUG, LOGGER_NAME)
-    topostats_object = load_scan_data.img_dict["minicircle_small"]
+    topostats_object = load_scan_data.img_dict["minicircle_small.topostats"]
     # Remove existing data so its calculated anew
     topostats_object.grain_crops = None
     process_scan_config["filter"]["run"] = filter_run
@@ -819,7 +818,7 @@ def test_process_stages(
 
 def test_process_scan_no_grains(process_scan_config: dict, load_scan_data: LoadScans, tmp_path: Path, caplog) -> None:
     """Test handling no grains found during grains.find_grains()."""
-    topostats_object = load_scan_data.img_dict["minicircle_small"]
+    topostats_object = load_scan_data.img_dict["minicircle_small.topostats"]
     topostats_object.grain_crops = None
     process_scan_config["grains"]["threshold_std_dev"]["above"] = 1000
     process_scan_config["filter"]["remove_scars"]["run"] = False

--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -127,7 +127,7 @@ def test_filters(attributes: dict, caplog) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Filtering completed." in caplog.text
     # Load the output file with AFMReader check its a dictionary and convert to TopoStats
-    data = topostats.load_topostats("output/processed/minicircle_small.topostats")
+    data = topostats.load_topostats("output/processed/topostats/minicircle_small.topostats")
     assert isinstance(data, dict)
     topostats_object = dict_to_topostats(dictionary=data)
     assert isinstance(topostats_object, TopoStats)
@@ -176,7 +176,7 @@ def test_grains(attributes: dict, caplog, tmp_path: Path) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Grain detection completed (NB - Filtering was *not* re-run)." in caplog.text
     # Load the output file with AFMReader check its a dictionary and convert to TopoStats
-    data = topostats.load_topostats(tmp_path / "output/processed/minicircle_small.topostats")
+    data = topostats.load_topostats(tmp_path / "output/processed/topostats/minicircle_small.topostats")
     assert isinstance(data, dict)
     topostats_object = dict_to_topostats(dictionary=data)
     assert isinstance(topostats_object, TopoStats)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -401,7 +401,6 @@ def test_bound_padded_coordinates_to_image(image: npt.NDArray, padding: int, exp
 def test_convolve_skeleton(skeleton: npt.NDArray, target: npt.NDArray) -> None:
     """Test convolve_skeleton() function."""
     skeleton_convolved = convolve_skeleton(skeleton)
-    print(f"{skeleton_convolved=}")
     np.testing.assert_array_equal(skeleton_convolved, target)
 
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -990,6 +990,8 @@ def get_out_paths(
     LOGGER.info(f"Processing : {filename}")
     core_out_path = get_out_path(image_path, base_dir, output_dir).parent / "processed"
     core_out_path.mkdir(parents=True, exist_ok=True)
+    topostats_out_path = core_out_path / "topostats"
+    topostats_out_path.mkdir(parents=True, exist_ok=True)
     filter_out_path = core_out_path / filename / "filters"
     grain_out_path = core_out_path / filename / "grains"
     tracing_out_path = core_out_path / filename / "dnatracing"
@@ -1000,7 +1002,7 @@ def get_out_paths(
         Path.mkdir(tracing_out_path / "curvature", parents=True, exist_ok=True)
         Path.mkdir(tracing_out_path / "splining", parents=True, exist_ok=True)
 
-    return core_out_path, filter_out_path, grain_out_path, tracing_out_path
+    return core_out_path, filter_out_path, grain_out_path, tracing_out_path, topostats_out_path
 
 
 def process_scan(
@@ -1072,7 +1074,7 @@ def process_scan(
     output_dir = config["output_dir"] if output_dir is None else output_dir
 
     # Get output paths
-    core_out_path, filter_out_path, grain_out_path, tracing_out_path = get_out_paths(
+    core_out_path, filter_out_path, grain_out_path, tracing_out_path, topostats_out_path = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1248,8 +1250,7 @@ def process_scan(
 
     # Save the topostats object to .topostats file.
     save_topostats_file(
-        output_dir=core_out_path,
-        filename=str(topostats_object.filename),
+        output_dir=topostats_out_path,
         topostats_object=topostats_object,
     )
     # Return filename and dataframes
@@ -1303,7 +1304,7 @@ def process_filters(
     filter_config = config["filter"] if filter_config is None else filter_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, filter_out_path, _, _ = get_out_paths(
+    core_out_path, filter_out_path, _, _, topostats_out_path = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1323,8 +1324,7 @@ def process_filters(
         )
         # Save the topostats dictionary object to .topostats file.
         save_topostats_file(
-            output_dir=core_out_path,
-            filename=str(topostats_object.filename),
+            output_dir=topostats_out_path,
             topostats_object=topostats_object,
         )
         return (topostats_object.filename, True)
@@ -1372,7 +1372,7 @@ def process_grains(
     grains_config = config["grains"] if grains_config is None else grains_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, _, grain_out_path, _ = get_out_paths(
+    core_out_path, _, grain_out_path, _, topostats_out_path = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1391,8 +1391,7 @@ def process_grains(
         )
         # Save the topostats dictionary object to .topostats file.
         save_topostats_file(
-            output_dir=core_out_path,
-            filename=str(topostats_object.filename),
+            output_dir=topostats_out_path,
             topostats_object=topostats_object,
         )
         return (topostats_object.filename, True)
@@ -1439,7 +1438,7 @@ def process_grainstats(
     grainstats_config = config["grainstats"] if grainstats_config is None else grainstats_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, _, grain_out_path, _ = get_out_paths(
+    core_out_path, _, grain_out_path, _, topostats_out_path = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1447,7 +1446,6 @@ def process_grainstats(
         plotting_config=plotting_config,
     )
     plotting_config = add_pixel_to_nm_to_plotting_config(plotting_config, topostats_object.pixel_to_nm_scaling)
-
     # Calculate grainstats if there are any to be detected
     if topostats_object.grain_crops is not None:
         try:
@@ -1460,8 +1458,7 @@ def process_grainstats(
             )
             # Save the topostats dictionary object to .topostats file.
             save_topostats_file(
-                output_dir=core_out_path,
-                filename=str(topostats_object.filename),
+                output_dir=topostats_out_path,
                 topostats_object=topostats_object,
             )
         except:  # noqa: E722  # pylint: disable=bare-except


### PR DESCRIPTION
Closes #1290
Closes #1287

Because of problems that arise with the old format of Bruker files where the filenames have numerical extensions there
was scope for data being over-written as `TopoStats.filename` uses the "stem", the part upto the file extension and so
`file1.001`, `file1.002` and `file1.003` all write output to the same (nested) directory `file1`. To solve this we now
include the file-extension in `TopoStats.filename`.

However, this presents a problem when processing `.topostats` files as you can't have a directory and a file with the
same name in the same location (manifested in the tests where we use `minicircle_small.topostats`). The solution is
therefore to write output files (the `.topostats` version of every file) to the directory
`<output_dir>/processed/topostats/<filename_without_extension>.topostats`.

In doing so we also modify `io.save_topostats_file()` and drop the `filename` parameter as it can be obtained directly
from the `topostats_object.filename` parameter passed in. We also introduce a step when saving files that don't already
carry the `.topostats` extension (i.e. `.spm`, `.ibw`, `.006` etc.) to remove the last file extension from the filename
and replace with `.topostats` for the target that is to be written to.

This hopefully also addressed #1290 at the same time @tcatley if you are able to check with the
`20240411_60ngTop2a_6ngpuc19_1mMATP_mgni.0_00024` file that uncovered the problem please that would be really useful and
appreciated.

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [X] Pre-commit checks pass.