### PR TITLE
fix(run_modules): Handle missing moleucule_stats

### DIFF
--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -258,8 +258,12 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
         )
         grain_stats_additions.columns = ["total_contour_length", "mean_end_to_end_distance"]
     except ValueError as error:
-        LOGGER.error("No molecules found in any images, consider adjusting ordered tracing / splining parameters.")
+        LOGGER.error(
+            "No molecules found in any images."
+            "Either enable tracing or consider adjusting ordered tracing / splining parameters."
+        )
         LOGGER.error(error)
+        grain_stats_additions = None
 
     # ns-rse 2025-12-23 - there is a common pattern here, could we abstract this to a factory method?
     if len(grain_stats_all) > 0:
@@ -270,7 +274,7 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
         except ValueError as error:
             LOGGER.error("No grains found in any images, consider adjusting your thresholds.")
             LOGGER.error(error)
-        if grain_stats_additions.shape[0] > 0:
+        if grain_stats_additions is not None:
             grain_stats_all = grain_stats_all.merge(grain_stats_additions, on=["image", "grain_number"])
         else:
             LOGGER.warning("No molecule statistics to merge with grain statistics.")


### PR DESCRIPTION
When tracing stages are disabled we do not have `molecule_stats_df` to subset to `grain_stats_additions` and merge
with `grain_stats_all`. As a consequence the attempt to merge the dataframes failed as there was no
`grain_stats_addition` to assess the shape of before merging.

The solution here is when attempting to create `grain_stats_additions` fails and raises an exception we set
`grain_stats_additions = None`. We therefore switch the clause to check `grain_stats_additions is not None` rather than
checking the `grain_stats_all.shape[0] > 0`.

Closes #1297

---

Before submitting a Pull Request please check the following.

- [X] Existing tests pass.
- [X] Pre-commit checks pass.