### PR TITLE
Removed `save_image_grainstats()`

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -44,7 +44,6 @@ from topostats.io import (
     read_u32i,
     read_yaml,
     save_array,
-    save_image_grainstats,
     save_pkl,
     write_csv,
     write_yaml,
@@ -526,18 +525,6 @@ def test_get_out_path(image_path: Path, base_dir: Path, output_dir: Path, expect
     out_path = get_out_path(image_path, base_dir, output_dir)
     assert isinstance(out_path, Path)
     assert out_path == expected
-
-
-def test_save_image_grainstats(tmp_path: Path) -> None:
-    """Test a folder-wide grainstats file is made."""
-    test_df = pd.DataFrame({"dummy1": [1, 2, 3], "dummy2": ["a", "b", "c"]})
-    input_path = tmp_path / "minicircle"
-    test_df["basename"] = input_path
-    out_path = tmp_path / "output"
-    Path.mkdir(out_path, parents=True)
-    assert out_path.exists()
-    save_image_grainstats(out_path, input_path, test_df, "grainstats")
-    assert Path(out_path / "processed" / "image_grainstats.csv").exists()
 
 
 def test_load_scan_spm(load_scan_spm: LoadScans) -> None:
@@ -1416,7 +1403,7 @@ def test_write_csv(
     df: pd.DataFrame, dataset: str, names: list[str], index: list[str], filename: str, tmp_path: Path
 ) -> None:
     """Test of write_csv() function."""
-    _ = write_csv(df=df, dataset=dataset, names=names, index=index, output_dir=tmp_path, base_dir="tests/")
+    _ = write_csv(df=df, dataset=dataset, names=names, index=index, output_dir=tmp_path)
     assert Path(tmp_path / filename).is_file()
 
 

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -372,45 +372,6 @@ def _find_old_bruker_files(base_dir: Path) -> list[Path]:
     return [p for p in base_dir.glob("**/*") if OLD_BRUKER_RE.match(p.suffix)]
 
 
-def save_image_grainstats(
-    output_dir: str | Path, base_dir: str | Path, all_stats_df: pd.DataFrame, stats_filename: str
-) -> None:
-    """
-    Save a data frame of grain and tracing statistics at the folder level.
-
-    Parameters
-    ----------
-    output_dir : Union[str, Path]
-        Path of the output directory head.
-    base_dir : Union[str, Path]
-        Path of the base directory where files were found.
-    all_stats_df : pd.DataFrame
-        The dataframe containing all sample statistics run.
-    stats_filename : str
-        The name of the type of statistics dataframe to be saved.
-
-    Returns
-    -------
-    None
-        This only saves the dataframes and does not retain them.
-    """
-    dirs = set(all_stats_df["basename"].values)
-    if output_dir.stem != "processed":
-        output_dir_processed = Path(str(output_dir)) / "processed"
-        output_dir_processed.mkdir(parents=True, exist_ok=True)
-    LOGGER.debug(f"Statistics :\n{all_stats_df}")
-    for _dir in dirs:
-        LOGGER.debug(f"Statistics ({_dir}) :\n{all_stats_df}")
-        try:
-            # Ensure "output/processed" directory exists at the stem of out_path, creating if needed
-            out_path = get_out_path(Path(_dir), base_dir, output_dir_processed)
-            out_path.mkdir(parents=True, exist_ok=True)
-            all_stats_df[all_stats_df["basename"] == _dir].to_csv(out_path / f"image_{stats_filename}.csv", index=True)
-            LOGGER.info(f"Image-wise statistics saved to: {str(out_path)}/image_{stats_filename}.csv")
-        except TypeError:
-            LOGGER.info(f"No image-wise statistics for image {_dir}, no grains detected.")
-
-
 def read_null_terminated_string(open_file: io.TextIOWrapper, encoding: str = "utf-8") -> str:
     """
     Read an open file from the current position in the open binary file, until the next null value.
@@ -1240,7 +1201,6 @@ def write_csv(
     names: list[str] | None,
     index: list[str],
     output_dir: str | Path,
-    base_dir: str | Path,
 ) -> pd.DataFrame:
     """
     Write summary statistics files to CSV.
@@ -1258,8 +1218,6 @@ def write_csv(
         List of columns to set index to.
     output_dir : str | Path
         Output directory.
-    base_dir : str | Path
-        Base directory.
 
     Returns
     -------
@@ -1288,8 +1246,6 @@ def write_csv(
     df.set_index(index, inplace=True)
     # Write to CSV
     df.to_csv(Path(output_dir) / dataset_to_csv[dataset], index=True)
-    # Write statistics on per-folder basis
-    save_image_grainstats(output_dir=output_dir, base_dir=base_dir, all_stats_df=df, stats_filename=dataset)
     # Return dataframe with index reset
     df.reset_index(inplace=True)
     return df

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -291,7 +291,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                 names=["image", "grain_number"],
                 index=["image", "grain_number", "class", "subgrain"],
                 output_dir=config["output_dir"],
-                base_dir=config["base_dir"],
             )
             LOGGER.info(f"Saved grain stats to : {config['output_dir']}/grain_statistics.csv.")
     else:
@@ -314,7 +313,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=["grain_number", "node", "branch"],
                     index=["image", "grain_number", "node", "branch"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved matched branch stats to : {config['output_dir']}/matched_branch_statistics.csv.")
         else:
@@ -333,7 +331,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=["grain_number", "index"],
                     index=["image", "grain_number", "index"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved disordered tracing stats to : {config['output_dir']}/branch_statistics.csv.")
         else:
@@ -348,7 +345,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=None,
                     index=["image", "grain_number"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved molecule stats to : {config['output_dir']}/molecule_statistics.csv.")
         else:


### PR DESCRIPTION
# TopoStats Pull Requests

Closes #1308, closes #1293 

A function (`save_image_grainstats()`) was left over from the refactor which was previously used to export grainstats on a per-image basis. This is now redundant as a single `.csv` is exported with can and is regularly filtered by image by users. This PR removes the function responsible for this outdated `.csv`. This also means `base_dir` is no longer required to be passed into `write_csv()` so this parameter has been removed from the function and its calls.

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.