### PR TITLE
Use a left join when adding splining stats to avoid row deletion

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1416,7 +1416,7 @@ def test_write_csv(
     df: pd.DataFrame, dataset: str, names: list[str], index: list[str], filename: str, tmp_path: Path
 ) -> None:
     """Test of write_csv() function."""
-    _ = write_csv(df=df, dataset=dataset, names=names, index=index, output_dir=tmp_path, base_dir="tests/")
+    _ = write_csv(df=df, dataset=dataset, names=names, index=index, output_dir=tmp_path)
     assert Path(tmp_path / filename).is_file()
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -421,6 +421,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
         "nodestats_run",
         "ordered_tracing_run",
         "splining_run",
+        "curvature_run",
         "log_msg",
     ),
     [
@@ -432,6 +433,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             True,
             True,
+            False,
             "Splining enabled but NodeStats disabled. Tracing will use the 'old' method.",
             id="Splining, Ordered Tracing, Disordered Tracing, Grainstats, Grains and Filters no Nodestats",
         ),
@@ -443,6 +445,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             True,
             True,
+            False,
             "Splining enabled but Grainstats disabled. Please check your configuration file.",
             id="Splining, Ordered Tracing, Disordered Tracing, Grains and Filters enabled but no Grainstats or "
             + "NodeStats",
@@ -455,6 +458,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             True,
             True,
+            False,
             "Splining enabled but Disordered Tracing disabled. Please check your configuration file.",
             id="Splining, Ordered Tracing and Filters enabled but no NodeStats, Disordered Tracing or Grainstats",
         ),
@@ -466,6 +470,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             True,
             True,
+            False,
             "Splining enabled but Grains disabled. Please check your configuration file.",
             id="Splining, Ordered Tracing, Disordered Tracing, and Grainstats enabled but no NodeStats, Grains or "
             + "Filters",
@@ -476,6 +481,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             True,
+            False,
             False,
             False,
             "NodeStats enabled but Disordered Tracing disabled. Please check your configuration file.",
@@ -489,6 +495,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             False,
             False,
+            False,
             "NodeStats enabled but Grainstats disabled. Please check your configuration file.",
             id="Nodestats, Disordered Tracing enabled but no Grainstats, Grains or Filters",
         ),
@@ -498,6 +505,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             True,
             True,
+            False,
             False,
             False,
             "NodeStats enabled but Grains disabled. Please check your configuration file.",
@@ -511,6 +519,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             False,
             False,
+            False,
             "NodeStats enabled but Filters disabled. Please check your configuration file.",
             id="Nodestats, Disordered Tracing, Grainstats Grains enabled but no Filters",
         ),
@@ -519,6 +528,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             True,
+            False,
             False,
             False,
             False,
@@ -533,6 +543,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Disordered Tracing enabled but Grains disabled. Please check your configuration file.",
             id="Disordered tracing and Grainstats enabled but no Grains or Filters",
         ),
@@ -544,6 +555,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Disordered Tracing enabled but Filters disabled. Please check your configuration file.",
             id="Disordered tracing, Grains and Grainstats enabled but no Filters",
         ),
@@ -551,6 +563,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             True,
+            False,
             False,
             False,
             False,
@@ -566,6 +579,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Grainstats enabled but Filters disabled. Please check your configuration file.",
             id="Grains enabled and Grainstats but no Filters",
         ),
@@ -577,11 +591,13 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Grains enabled but Filters disabled. Please check your configuration file.",
             id="Grains enabled but not Filters",
         ),
         pytest.param(
             True,
+            False,
             False,
             False,
             False,
@@ -599,6 +615,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Configuration run options are consistent, processing can proceed.",
             id="Consistent configuration upto Grains",
         ),
@@ -606,6 +623,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             True,
             True,
+            False,
             False,
             False,
             False,
@@ -621,6 +639,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             False,
             False,
             False,
+            False,
             "Configuration run options are consistent, processing can proceed.",
             id="Consistent configuration upto DNA tracing",
         ),
@@ -630,6 +649,7 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             True,
             True,
+            False,
             False,
             False,
             "Configuration run options are consistent, processing can proceed.",
@@ -643,8 +663,33 @@ def test_save_format(process_scan_config: dict, load_scan_data: LoadScans, tmp_p
             True,
             True,
             True,
+            False,
             "Configuration run options are consistent, processing can proceed.",
             id="Consistent configuration upto Splining",
+        ),
+        pytest.param(
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            "Configuration run options are consistent, processing can proceed.",
+            id="Consistent configuration upto Curvature",
+        ),
+        pytest.param(
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+            "Curvature enabled but Ordered Tracing disabled. Please check your configuration file.",
+            id="Curvature enabled but ordered tracing disabled",
         ),
     ],
 )
@@ -656,6 +701,7 @@ def test_check_run_steps(
     nodestats_run: bool,
     ordered_tracing_run: bool,
     splining_run: bool,
+    curvature_run: bool,
     log_msg: str,
     caplog,
 ) -> None:
@@ -668,6 +714,7 @@ def test_check_run_steps(
         nodestats_run,
         ordered_tracing_run,
         splining_run,
+        curvature_run,
     )
     assert log_msg in caplog.text
 
@@ -751,6 +798,19 @@ def test_check_run_steps(
             "Processing grain",
             "Calculation of curvature statistics disabled.",
             id="All but curvature enabled",
+        ),
+        pytest.param(
+            True,  # Filter
+            True,  # Grains
+            True,  # Grainstats
+            True,  # Disordered Tracing
+            True,  # Nodestats
+            True,  # Ordered tracing
+            False,  # Splining
+            True,  # Curvature
+            "Processing grain",
+            "Calculation of curvature statistics disabled.",
+            id="Curvature enabled, no splining",
         ),
         # @ns-rse 2024-09-13 : Parameters need updating so test is performed.
         # pytest.param(

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1312,6 +1312,7 @@ def extract_height_profiles(
         height_profile_all[image] = {}
         if topostats_object.grain_crops is not None:
             for grain_number, grain_crop in topostats_object.grain_crops.items():
-                height_profile_all[image][grain_number] = grain_crop.height_profiles
+               if grain_crop.height_profiles is not None:
+                   height_profile_all[image][grain_number] = grain_crop.height_profiles
     dict_to_json(data=height_profile_all, output_dir=output_dir, filename=filename)
     LOGGER.info(f"Saved all height profiles to {output_dir}/{filename}.")

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1240,7 +1240,6 @@ def write_csv(
     names: list[str] | None,
     index: list[str],
     output_dir: str | Path,
-    base_dir: str | Path,
 ) -> pd.DataFrame:
     """
     Write summary statistics files to CSV.
@@ -1258,8 +1257,6 @@ def write_csv(
         List of columns to set index to.
     output_dir : str | Path
         Output directory.
-    base_dir : str | Path
-        Base directory.
 
     Returns
     -------
@@ -1288,8 +1285,6 @@ def write_csv(
     df.set_index(index, inplace=True)
     # Write to CSV
     df.to_csv(Path(output_dir) / dataset_to_csv[dataset], index=True)
-    # Write statistics on per-folder basis
-    save_image_grainstats(output_dir=output_dir, base_dir=base_dir, all_stats_df=df, stats_filename=dataset)
     # Return dataframe with index reset
     df.reset_index(inplace=True)
     return df
@@ -1315,7 +1310,8 @@ def extract_height_profiles(
     height_profile_all = {}
     for image, topostats_object in topostats_object_all.items():
         height_profile_all[image] = {}
-        for grain_number, grain_crop in topostats_object.grain_crops.items():
-            height_profile_all[image][grain_number] = grain_crop.height_profiles
+        if topostats_object.grain_crops is not None:
+            for grain_number, grain_crop in topostats_object.grain_crops.items():
+                height_profile_all[image][grain_number] = grain_crop.height_profiles
     dict_to_json(data=height_profile_all, output_dir=output_dir, filename=filename)
     LOGGER.info(f"Saved all height profiles to {output_dir}/{filename}.")

--- a/topostats/io.py
+++ b/topostats/io.py
@@ -1312,7 +1312,7 @@ def extract_height_profiles(
         height_profile_all[image] = {}
         if topostats_object.grain_crops is not None:
             for grain_number, grain_crop in topostats_object.grain_crops.items():
-               if grain_crop.height_profiles is not None:
-                   height_profile_all[image][grain_number] = grain_crop.height_profiles
+                if grain_crop.height_profiles is not None:
+                    height_profile_all[image][grain_number] = grain_crop.height_profiles
     dict_to_json(data=height_profile_all, output_dir=output_dir, filename=filename)
     LOGGER.info(f"Saved all height profiles to {output_dir}/{filename}.")

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -772,6 +772,7 @@ def run_splining(  # noqa: C901
     core_out_path: Path,
     splining_config: dict | None = None,
     plotting_config: dict | None = None,
+    curvature_config: dict | None = None,
     tracing_out_path: str | Path | None = None,
 ) -> None:
     """
@@ -787,6 +788,8 @@ def run_splining(  # noqa: C901
         Dictionary configuration for obtaining an ordered trace representation of the skeletons.
     plotting_config : dict
         Dictionary configuration for plotting images.
+    curvature_config : dict
+        Dictionary configuration for curvature statistics.
     tracing_out_path : str | Path
         Directory to save images from splining to. The ``splining`` directory will be created within and images saved
         there.
@@ -856,6 +859,11 @@ def run_splining(  # noqa: C901
                     )
         return
     LOGGER.info(f"[{topostats_object.filename}] : Calculation of splining disabled.")
+    if curvature_config["run"]:
+        LOGGER.warning(
+            f"[{topostats_object.filename}] : Automatically disabled curvature due to splining being disabled."
+        )
+        curvature_config["run"] = False
     return
 
 
@@ -896,7 +904,7 @@ def run_curvature_stats(
     )
     if curvature_config["run"]:
         if topostats_object.grain_crops is None:
-            LOGGER.warning(f"[{topostats_object.filename}] : No grains exist. Skipping splining.")
+            LOGGER.warning(f"[{topostats_object.filename}] : No grains exist. Skipping curvature.")
             return
         try:
             curvature_config.pop("run")
@@ -1142,6 +1150,7 @@ def process_scan(
             core_out_path=core_out_path,
             plotting_config=plotting_config,
             splining_config=splining_config,
+            curvature_config=curvature_config,
         )
 
         # Curvature Stats

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1505,6 +1505,7 @@ def check_run_steps(  # noqa: C901
     nodestats_run: bool,
     ordered_tracing_run: bool,
     splining_run: bool,
+    curvature_run: bool,
 ) -> None:
     """
     Check options for running steps (Filter, Grain, Grainstats and DNA tracing) are logically consistent.
@@ -1514,19 +1515,21 @@ def check_run_steps(  # noqa: C901
     Parameters
     ----------
     filter_run : bool
-        Flag for running Filtering.
+        Flag for running filtering.
     grains_run : bool
-        Flag for running Grains.
+        Flag for running grains.
     grainstats_run : bool
-        Flag for running GrainStats.
+        Flag for running grainstats.
     disordered_tracing_run : bool
-        Flag for running Disordered Tracing.
+        Flag for running disordered tracing.
     nodestats_run : bool
-        Flag for running NodeStats.
+        Flag for running nodestats.
     ordered_tracing_run : bool
-        Flag for running Ordered Tracing.
+        Flag for running ordered tracing.
     splining_run : bool
-        Flag for running DNA Tracing.
+        Flag for running splining of DNA traces.
+    curvature_run : bool
+        Flag for running curvature calculations of splined DNA traces.
     """
     LOGGER.debug(f"{filter_run=}")
     LOGGER.debug(f"{grains_run=}")
@@ -1535,7 +1538,25 @@ def check_run_steps(  # noqa: C901
     LOGGER.debug(f"{nodestats_run=}")
     LOGGER.debug(f"{ordered_tracing_run=}")
     LOGGER.debug(f"{splining_run=}")
-    if splining_run:
+    LOGGER.debug(f"{curvature_run=}")
+    if curvature_run:
+        if splining_run is False:
+            LOGGER.error("Curvature enabled but Splining disabled. Please check your configuration file.")
+        if ordered_tracing_run is False:
+            LOGGER.error("Curvature enabled but Ordered Tracing disabled. Please check your configuration file.")
+        if nodestats_run is False:
+            LOGGER.error("Curvature enabled but NodeStats disabled. Tracing will use the 'old' method.")
+        if disordered_tracing_run is False:
+            LOGGER.error("Curvature enabled but Disordered Tracing disabled. Please check your configuration file.")
+        elif grainstats_run is False:
+            LOGGER.error("Curvature enabled but Grainstats disabled. Please check your configuration file.")
+        elif grains_run is False:
+            LOGGER.error("Curvature enabled but Grains disabled. Please check your configuration file.")
+        elif filter_run is False:
+            LOGGER.error("Curvature enabled but Filters disabled. Please check your configuration file.")
+        else:
+            LOGGER.info("Configuration run options are consistent, processing can proceed.")
+    elif splining_run:
         if ordered_tracing_run is False:
             LOGGER.error("Splining enabled but Ordered Tracing disabled. Please check your configuration file.")
         if nodestats_run is False:

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -245,31 +245,33 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
 
     # Molecule statistics - required as we need to average end-to-end and contour length across grains, even if not
     # being explicitly written to CSV themselves
-    try:
-        molecule_stats_all = pd.concat(molecule_stats_all.values())
-        grain_stats_additions = pd.concat(
-            [
-                # Sum the contour length of molecules within each grain
-                molecule_stats_all[["image", "grain_number", "contour_length"]]
-                .groupby(["image", "grain_number"])
-                .sum(),
-                # Mean end to end distance across molecules within each grain
-                molecule_stats_all[["image", "grain_number", "end_to_end_distance"]]
-                .groupby(["image", "grain_number"])
-                .mean(),
-            ],
-            axis=1,
-        )
-        grain_stats_additions.columns = ["total_contour_length", "mean_end_to_end_distance"]
-    except ValueError as error:
-        LOGGER.error(
-            "No molecules found in any images."
-            "Either enable tracing or consider adjusting ordered tracing / splining parameters."
-        )
-        LOGGER.error(error)
-        grain_stats_additions = None
-    # Set additions to none if splining was not run
-    except KeyError:
+    if config["splining"]["run"]:
+        try:
+            molecule_stats_all = pd.concat(molecule_stats_all.values())
+            grain_stats_additions = pd.concat(
+                [
+                    # Sum the contour length of molecules within each grain
+                    molecule_stats_all[["image", "grain_number", "contour_length"]]
+                    .groupby(["image", "grain_number"])
+                    .sum(),
+                    # Mean end to end distance across molecules within each grain
+                    molecule_stats_all[["image", "grain_number", "end_to_end_distance"]]
+                    .groupby(["image", "grain_number"])
+                    .mean(),
+                ],
+                axis=1,
+            )
+            grain_stats_additions.columns = ["total_contour_length", "mean_end_to_end_distance"]
+        except ValueError as error:
+            LOGGER.error(
+                "No molecules found in any images."
+                "Either enable tracing or consider adjusting ordered tracing / splining parameters."
+            )
+            LOGGER.error(error)
+            grain_stats_additions = None
+    else:
+        # Skip additional stats merger if splining was not run
+        LOGGER.warning("Splining has been disabled, skipping grain stats additions.")
         grain_stats_additions = None
 
     # ns-rse 2025-12-23 - there is a common pattern here, could we abstract this to a factory method?
@@ -294,7 +296,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                 names=["image", "grain_number"],
                 index=["image", "grain_number", "class", "subgrain"],
                 output_dir=config["output_dir"],
-                base_dir=config["base_dir"],
             )
             LOGGER.info(f"Saved grain stats to : {config['output_dir']}/grain_statistics.csv.")
     else:
@@ -303,12 +304,11 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
 
     # Optional output files
     if output_full_stats:
-        if branch_stats_all is not None:
+        if branch_stats_all:
             # Matched branch statistics
             try:
                 branch_stats_all = pd.concat(branch_stats_all.values())
             except ValueError as error:
-                LOGGER.error("No skeletons found in any images, consider adjusting disordered tracing parameters.")
                 LOGGER.error(error)
             if isinstance(branch_stats_all, pd.DataFrame) and not branch_stats_all.isna().values.all():
                 branch_stats_all = write_csv(
@@ -317,7 +317,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=["grain_number", "node", "branch"],
                     index=["image", "grain_number", "node", "branch"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved matched branch stats to : {config['output_dir']}/matched_branch_statistics.csv.")
         else:
@@ -336,7 +335,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=["grain_number", "index"],
                     index=["image", "grain_number", "index"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved disordered tracing stats to : {config['output_dir']}/branch_statistics.csv.")
         else:
@@ -351,7 +349,6 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
                     names=None,
                     index=["image", "grain_number"],
                     output_dir=config["output_dir"],
-                    base_dir=config["base_dir"],
                 )
                 LOGGER.info(f"Saved molecule stats to : {config['output_dir']}/molecule_statistics.csv.")
         else:

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -268,6 +268,9 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
         )
         LOGGER.error(error)
         grain_stats_additions = None
+    # Set additions to none if splining was not run
+    except KeyError:
+        grain_stats_additions = None
 
     # ns-rse 2025-12-23 - there is a common pattern here, could we abstract this to a factory method?
     if len(grain_stats_all) > 0:
@@ -279,7 +282,7 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
             LOGGER.error("No grains found in any images, consider adjusting your thresholds.")
             LOGGER.error(error)
         if grain_stats_additions is not None:
-            grain_stats_all = grain_stats_all.merge(grain_stats_additions, on=["image", "grain_number"])
+            grain_stats_all = grain_stats_all.merge(grain_stats_additions, on=["image", "grain_number"], how="left")
         else:
             LOGGER.warning("No molecule statistics to merge with grain statistics.")
         # Write statistics to CSV if there is data.

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -154,6 +154,7 @@ def _parse_configuration(args: argparse.Namespace | None = None) -> tuple[dict, 
         nodestats_run=config["nodestats"]["run"],
         ordered_tracing_run=config["ordered_tracing"]["run"],
         splining_run=config["splining"]["run"],
+        curvature_run=config["curvature"]["run"],
     )
     # Ensures each image has all plotting options which are passed as **kwargs
     config["plotting"] = update_plotting_config(config["plotting"])


### PR DESCRIPTION
Closes #1304 


#### When splining is enabled and some grains do not have molecules these grains would be omitted from the grain_stats `.csv` in error.
- This was because `grain_stats_additions` was merged with `grain_stats_all` with an inner join with the keys `image` and `grain_number`. If a grain did not have a molecule then the `image` and `grain_number` keys did not exist in `grain_stats_additions` causing that row to be removed from the merged DataFrame. Switching this join to a left join rather than an inner solves this issue.

#### I also discovered an issue in this process where not running splining causes a `KeyError` which in turn means `grain_stats_additions` never get defined (the existance of which is required further down the process).
- This was because the grain's `molecule_stats_all` entry did not contain the keys `contour_length` or `end_to_end_distance` even though their existence is then assumed by `run_modules.py process()`. I have added a catch for `KeyError`s which sets `grain_stats_additions` to None which lets the program run smoothly after this point.


As far as I can see these changes won't cause any problems, the program runs as expected whether splining is turned on or not and all existing tests pass, but if anyone can see potential issues with these changes please let me know.

---
Side note:
In `grain_statistics.csv` when splining is enabled and some grains don't have molecules the `total_contour_length` and `mean_end_to_end_distance` columns exist, grains with molecules have these fields filled and grains without molecules just have these fields empty. Is this the right way to go about it or would we specifically want to assign some sort of `n/a` indicator to these empty fields to avoid user confusion?

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.
