### PR TITLE
Updates for automating docs deployment

### DIFF
--- a/.github/workflows/deploy-mkdocs.yaml
+++ b/.github/workflows/deploy-mkdocs.yaml
@@ -24,7 +24,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 
           ref: ${{ github.event_name == 'pull_request' && 'main' || github.ref }}

--- a/.github/workflows/deploy-mkdocs.yaml
+++ b/.github/workflows/deploy-mkdocs.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Configure Git user
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin gh-pages --depth=1 || true
 
       - name: Deploy Development Docs


### PR DESCRIPTION
The workflow added in PR #1340 fails because the bot doesn't have permissions to write to the repo.
I suspect that the info for the bot in the original PR is wrong.

This PR updates that info and also uses the latest version of the checkout action.