### PR TITLE
Move .topostats output files + remove filename from basename

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -58,11 +58,11 @@ def test_process_scan(tmp_path, process_scan_config: dict, load_scan_data: LoadS
     assert grain_stats.to_string(float_format="{:.4e}".format) == snapshot
 
     # Regtest for the topostats file
-    assert Path.exists(tmp_path / "tests/resources/test_image/processed/topostats/minicircle_small.topostats")
+    assert Path.exists(tmp_path / "tests/resources/test_image/processed/minicircle_small.topostats")
     # Load the results, note that we use AFMReader.topostats.load_topostats() here which simply loads the data as
     # dictionaries and means it is easy to compare to syrupy snapshots
     saved_topostats = load_topostats(
-        file_path=tmp_path / "tests/resources/test_image/processed/topostats/minicircle_small.topostats"
+        file_path=tmp_path / "tests/resources/test_image/processed/minicircle_small.topostats"
     )
     # Drop the config, img_path and topostats_version from top level of dictionary and and basename from
     # disorded_trace.stats_dict) as we don't want to compare configuration nor test absolute paths.

--- a/tests/test_run_modules.py
+++ b/tests/test_run_modules.py
@@ -127,7 +127,7 @@ def test_filters(attributes: dict, caplog) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Filtering completed." in caplog.text
     # Load the output file with AFMReader check its a dictionary and convert to TopoStats
-    data = topostats.load_topostats("output/processed/topostats/minicircle_small.topostats")
+    data = topostats.load_topostats("output/processed/minicircle_small.topostats")
     assert isinstance(data, dict)
     topostats_object = dict_to_topostats(dictionary=data)
     assert isinstance(topostats_object, TopoStats)
@@ -176,7 +176,7 @@ def test_grains(attributes: dict, caplog, tmp_path: Path) -> None:
     assert "Looking for images with extension   : .topostats" in caplog.text
     assert "[minicircle_small] Grain detection completed (NB - Filtering was *not* re-run)." in caplog.text
     # Load the output file with AFMReader check its a dictionary and convert to TopoStats
-    data = topostats.load_topostats(tmp_path / "output/processed/topostats/minicircle_small.topostats")
+    data = topostats.load_topostats(tmp_path / "output/processed/minicircle_small.topostats")
     assert isinstance(data, dict)
     topostats_object = dict_to_topostats(dictionary=data)
     assert isinstance(topostats_object, TopoStats)

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -998,8 +998,6 @@ def get_out_paths(
     LOGGER.info(f"Processing : {filename}")
     core_out_path = get_out_path(image_path, base_dir, output_dir).parent / "processed"
     core_out_path.mkdir(parents=True, exist_ok=True)
-    topostats_out_path = core_out_path / "topostats"
-    topostats_out_path.mkdir(parents=True, exist_ok=True)
     filter_out_path = core_out_path / filename / "filters"
     grain_out_path = core_out_path / filename / "grains"
     tracing_out_path = core_out_path / filename / "dnatracing"
@@ -1010,7 +1008,7 @@ def get_out_paths(
         Path.mkdir(tracing_out_path / "curvature", parents=True, exist_ok=True)
         Path.mkdir(tracing_out_path / "splining", parents=True, exist_ok=True)
 
-    return core_out_path, filter_out_path, grain_out_path, tracing_out_path, topostats_out_path
+    return core_out_path, filter_out_path, grain_out_path, tracing_out_path
 
 
 def process_scan(
@@ -1082,7 +1080,7 @@ def process_scan(
     output_dir = config["output_dir"] if output_dir is None else output_dir
 
     # Get output paths
-    core_out_path, filter_out_path, grain_out_path, tracing_out_path, topostats_out_path = get_out_paths(
+    core_out_path, filter_out_path, grain_out_path, tracing_out_path = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1197,7 +1195,7 @@ def process_scan(
             molecule_stats_df.index.set_names(["grain_number", "molecule_number"], inplace=True)
             molecule_stats_df.reset_index(inplace=True)
             molecule_stats_df["image"] = topostats_object.filename
-            molecule_stats_df["basename"] = topostats_object.img_path
+            molecule_stats_df["basename"] = str(Path(topostats_object.img_path).parent)
         else:
             molecule_stats_df = None
         # Disordered Tracing Statistics - convert nested dictionary to dataframe
@@ -1217,7 +1215,7 @@ def process_scan(
             data={
                 (grain_number, node_number, branch_number): matched_branch.collate_branch_statistics(
                     image=topostats_object.filename,
-                    basename=topostats_object.img_path,
+                    basename=str(Path(topostats_object.img_path).parent),
                 )
                 for grain_number, grain_crop in topostats_object.grain_crops.items()
                 if grain_crop.nodes is not None and len(grain_crop.nodes) > 0
@@ -1245,7 +1243,7 @@ def process_scan(
         )
         if grain_stats_df.shape != (0, 0):
             grain_stats_df["image"] = topostats_object.filename
-            grain_stats_df["basename"] = topostats_object.img_path
+            grain_stats_df["basename"] = str(Path(topostats_object.img_path.name).parent)
             grain_stats_df.index.set_names(["grain_number", "class", "subgrain"], inplace=True)
         else:
             grain_stats_df = None
@@ -1259,7 +1257,7 @@ def process_scan(
 
     # Save the topostats object to .topostats file.
     save_topostats_file(
-        output_dir=topostats_out_path,
+        output_dir=core_out_path,
         topostats_object=topostats_object,
     )
     # Return filename and dataframes
@@ -1313,7 +1311,7 @@ def process_filters(
     filter_config = config["filter"] if filter_config is None else filter_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, filter_out_path, _, _, topostats_out_path = get_out_paths(
+    core_out_path, filter_out_path, _, _ = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1333,7 +1331,7 @@ def process_filters(
         )
         # Save the topostats dictionary object to .topostats file.
         save_topostats_file(
-            output_dir=topostats_out_path,
+            output_dir=core_out_path,
             topostats_object=topostats_object,
         )
         return (topostats_object.filename, True)
@@ -1381,7 +1379,7 @@ def process_grains(
     grains_config = config["grains"] if grains_config is None else grains_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, _, grain_out_path, _, topostats_out_path = get_out_paths(
+    core_out_path, _, grain_out_path, _ = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1400,7 +1398,7 @@ def process_grains(
         )
         # Save the topostats dictionary object to .topostats file.
         save_topostats_file(
-            output_dir=topostats_out_path,
+            output_dir=core_out_path,
             topostats_object=topostats_object,
         )
         return (topostats_object.filename, True)
@@ -1447,7 +1445,7 @@ def process_grainstats(
     grainstats_config = config["grainstats"] if grainstats_config is None else grainstats_config
     plotting_config = config["plotting"] if plotting_config is None else plotting_config
     output_dir = config["output_dir"]
-    core_out_path, _, grain_out_path, _, topostats_out_path = get_out_paths(
+    core_out_path, _, grain_out_path, _ = get_out_paths(
         image_path=topostats_object.img_path,
         base_dir=base_dir,
         output_dir=output_dir,
@@ -1467,7 +1465,7 @@ def process_grainstats(
             )
             # Save the topostats dictionary object to .topostats file.
             save_topostats_file(
-                output_dir=topostats_out_path,
+                output_dir=core_out_path,
                 topostats_object=topostats_object,
             )
         except:  # noqa: E722  # pylint: disable=bare-except
@@ -1488,7 +1486,7 @@ def process_grainstats(
         )
         if grain_stats_df.shape != (0, 0):
             grain_stats_df["image"] = topostats_object.filename
-            grain_stats_df["basename"] = topostats_object.img_path
+            grain_stats_df["basename"] = str(Path(topostats_object.img_path.name).parent)
             grain_stats_df.index.set_names(["grain_number", "class", "subgrain"], inplace=True)
         else:
             grain_stats_df = None

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -2,6 +2,7 @@
 
 import logging
 import warnings
+from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
@@ -472,7 +473,7 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
                         ]
                     )
                     topostats_object.grain_crops[grain_number].disordered_trace.stats[index]["basename"] = str(
-                        topostats_object.img_path
+                        Path(topostats_object.img_path).parent
                     )
                 # remap the cropped images back onto the original, there are many image crops that we want to
                 #  remap back onto the original image so we iterate over them, as passed by the function


### PR DESCRIPTION
# TopoStats Pull Requests

Closes #1338 and #1339

There are two changes in this PR, they are both very small though so have been put together

1) `.topostats` files are now saved to the parent directory of their previous location (`processed/output/file.topostats` rather than `/processed/output/file.spm/file.topostats`)

2) the basename field in output `.csv`s no longer has the filename included; only the directory the file is stored in is shown (`tests/resources/` rather than `tests/resources/minicircles.spm` for example). This should make it easier for users to sort + filter by basename after batch processing without having to filter one file at a time.


### Note:

During testing all `.csv`s containing a `basename` field have `tests/resources` (as expected) except for `grain_statistics.csv` which just has a '`.`'. Is this correct? I can't see any specific difference in the changes I made to `grain_statistics.csv` over other output sheets but I'm confused as to why there is a difference

---

Before submitting a Pull Request please check the following.

- [x] Existing tests pass.
- [x] Pre-commit checks pass.

(documentation/ new tests not required)