### PR TITLE
Remove now deprecated references to height_profiles in the docs

### DIFF
--- a/docs/advanced/classes.md
+++ b/docs/advanced/classes.md
@@ -47,21 +47,21 @@ constructed, for example when first creating a `TopoStats` object after reading 
 
 ## `GrainCrop`
 
-| Attribute             | Type                                        | Description                                                     |
-| --------------------- | ------------------------------------------- | --------------------------------------------------------------- |
-| `image`               | `npt.NDArray[np.float32]`                   | 2-D Numpy array of the cropped image.                           |
-| `mask`                | `npt.NDArray[np.bool_]`                     | 3-D Numpy tensor of the cropped mask.                           |
-| `padding`             | `int`                                       | Padding added to the bounding box of the grain during cropping. |
-| `bbox`                | `tuple[int, int, int, int]`                 | Bounding box of the crop including padding.                     |
-| `pixel_to_nm_scaling` | `float`                                     | Pixel to nanometre scaling factor for the crop.                 |
-| `thresholds`          | `float`                                     | Thresholds used to find the grain.                              |
-| `filename`            | `str`                                       | Filename of the image from which the crop was taken.            |
-| `skeleton`            | `npt.NDArray[np.bool_]`                     | 3-D Numpy tensor of the skeletonised mask.                      |
-| `stats`               | `dict[int, dict[int, Any]]`                 | Dictionary of grain statistics.                                 |
-| `disordered_trace`    | `DisorderedTrace`                           | A disordered trace for the grain.                               |
-| `nodes`               | `dict[str, Nodes]`                          | Dictionary of grain nodes.                                      |
-| `ordered_trace`       | `OrderedTrace`                              | An ordered trace for the grain.                                 |
-| `threshold_method`    | `str`                                       | Threshold method used to find grains.`                          |
+| Attribute             | Type                        | Description                                                     |
+| --------------------- | --------------------------- | --------------------------------------------------------------- |
+| `image`               | `npt.NDArray[np.float32]`   | 2-D Numpy array of the cropped image.                           |
+| `mask`                | `npt.NDArray[np.bool_]`     | 3-D Numpy tensor of the cropped mask.                           |
+| `padding`             | `int`                       | Padding added to the bounding box of the grain during cropping. |
+| `bbox`                | `tuple[int, int, int, int]` | Bounding box of the crop including padding.                     |
+| `pixel_to_nm_scaling` | `float`                     | Pixel to nanometre scaling factor for the crop.                 |
+| `thresholds`          | `float`                     | Thresholds used to find the grain.                              |
+| `filename`            | `str`                       | Filename of the image from which the crop was taken.            |
+| `skeleton`            | `npt.NDArray[np.bool_]`     | 3-D Numpy tensor of the skeletonised mask.                      |
+| `stats`               | `dict[int, dict[int, Any]]` | Dictionary of grain statistics.                                 |
+| `disordered_trace`    | `DisorderedTrace`           | A disordered trace for the grain.                               |
+| `nodes`               | `dict[str, Nodes]`          | Dictionary of grain nodes.                                      |
+| `ordered_trace`       | `OrderedTrace`              | An ordered trace for the grain.                                 |
+| `threshold_method`    | `str`                       | Threshold method used to find grains.`                          |
 
 ## `DisorderedTrace`
 

--- a/docs/advanced/classes.md
+++ b/docs/advanced/classes.md
@@ -57,7 +57,6 @@ constructed, for example when first creating a `TopoStats` object after reading 
 | `thresholds`          | `float`                                     | Thresholds used to find the grain.                              |
 | `filename`            | `str`                                       | Filename of the image from which the crop was taken.            |
 | `skeleton`            | `npt.NDArray[np.bool_]`                     | 3-D Numpy tensor of the skeletonised mask.                      |
-| `height_profiles`     | `dict[int, [int, npt.NDArray[np.float32]]]` | 3-D Numpy tensor of the height profiles.                        |
 | `stats`               | `dict[int, dict[int, Any]]`                 | Dictionary of grain statistics.                                 |
 | `disordered_trace`    | `DisorderedTrace`                           | A disordered trace for the grain.                               |
 | `nodes`               | `dict[str, Nodes]`                          | Dictionary of grain nodes.                                      |
@@ -219,9 +218,6 @@ output/processed/minicircle.topostats
 │ │ │ │   └stdev_pixel_value
 │ │ │ └total_branch_length
 │ │ ├filename
-│ │ ├height_profiles
-│ │ │ └1
-│ │ │   └0
 │ │ ├image
 │ │ ├mask
 │ │ ├nodes

--- a/docs/api/measure/height_profiles.md
+++ b/docs/api/measure/height_profiles.md
@@ -1,3 +1,0 @@
-# Height Profiles Modules
-
-::: topostats.measure.height_profiles

--- a/docs/api/measure/index.md
+++ b/docs/api/measure/index.md
@@ -3,4 +3,3 @@
 [`curvature.py`](curvature.md)
 [`feret.py`](feret.md)
 [`geometry.py`](geometry.md)
-[`height_profiles.py`](height_profiles.md)

--- a/docs/usage/workflow.md
+++ b/docs/usage/workflow.md
@@ -96,7 +96,6 @@ graph TB
     click VL "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/validation.py"
     click GM "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/measure/geometry.py"
     click CM2 "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/measure/curvature.py"
-    click HP "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/measure/height_profiles.py"
     click FA "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/measure/feret.py"
     click PS "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/plotting.py"
     click TM "https://github.com/AFM-SPM/TopoStats/blob/main/topostats/theme.py"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,6 @@ nav:
           - Curvature: api/measure/curvature.md
           - Feret: api/measure/feret.md
           - Geometry: api/measure/geometry.md
-          - Height Profiles: api/measure/height_profiles.md
       - Plotting: api/plotting.md
       - PlottingFuncs: api/plottingfuncs.md
       - Processing: api/processing.md


### PR DESCRIPTION
As described - still getting used to the new docs system.

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds. Remember to update as required...
  - [ ] `docs/usage/configuration.md`
  - [ ] `docs/usage/data_dictionary.md`
  - [ ] `docs/usage/advanced.md` and new pages it should link to.
- [ ] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
