### PR TITLE
Updated link to config docs

### DIFF
--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -27,7 +27,7 @@ else:
     TOPOSTATS_BASE_VERSION = str(TOPOSTATS_VERSION)
     TOPOSTATS_COMMIT = ""
 CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and how to use it:
-# https://afm-spm.github.io/TopoStats/main/configuration.html\n"""
+# https://afm-spm.github.io/TopoStats/dev/usage/configuration/\n"""
 
 colormaps.register(cmap=Colormap("nanoscope").get_cmap())
 colormaps.register(cmap=Colormap("gwyddion").get_cmap())

--- a/topostats/__init__.py
+++ b/topostats/__init__.py
@@ -27,7 +27,7 @@ else:
     TOPOSTATS_BASE_VERSION = str(TOPOSTATS_VERSION)
     TOPOSTATS_COMMIT = ""
 CONFIG_DOCUMENTATION_REFERENCE = """# For more information on configuration and how to use it:
-# https://afm-spm.github.io/TopoStats/dev/usage/configuration/\n"""
+# https://afm-spm.github.io/TopoStats/latest/usage/configuration/\n"""
 
 colormaps.register(cmap=Colormap("nanoscope").get_cmap())
 colormaps.register(cmap=Colormap("gwyddion").get_cmap())


### PR DESCRIPTION
Closes #1350 

When updating docs a link in `__init__.py` was missed that points to the configuration documentation, this has been fixed.