### PR TITLE
Correctly save basename to grain_stats.csv

### DIFF
--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1243,7 +1243,7 @@ def process_scan(
         )
         if grain_stats_df.shape != (0, 0):
             grain_stats_df["image"] = topostats_object.filename
-            grain_stats_df["basename"] = str(Path(topostats_object.img_path.name).parent)
+            grain_stats_df["basename"] = str(Path(topostats_object.img_path).parent)
             grain_stats_df.index.set_names(["grain_number", "class", "subgrain"], inplace=True)
         else:
             grain_stats_df = None
@@ -1486,7 +1486,7 @@ def process_grainstats(
         )
         if grain_stats_df.shape != (0, 0):
             grain_stats_df["image"] = topostats_object.filename
-            grain_stats_df["basename"] = str(Path(topostats_object.img_path.name).parent)
+            grain_stats_df["basename"] = str(Path(topostats_object.img_path).parent)
             grain_stats_df.index.set_names(["grain_number", "class", "subgrain"], inplace=True)
         else:
             grain_stats_df = None


### PR DESCRIPTION
Recently how `basename` is used was changed, and an error has been discovered that when creating the dataframe for `grain_statistics.csv` `basename` is always `.`.

This was because `.name` was being incorrectly used, `.name` strips all directory info from the variable and only keeps the filename, which then can't give a parent so the output is just `.`.

I think during the recent changes to basename functionality I must've missed changing the `grain_statistics.csv` basename to the final version as all other `.csv`s have working basename fields. Apologies!