### PR TITLE
Add time taken to the completion message

### DIFF
--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -1644,7 +1644,9 @@ def check_run_steps(  # noqa: C901
         LOGGER.info("Configuration run options are consistent, processing can proceed.")
 
 
-def completion_message(config: dict, img_files: list, summary_config: dict, images_processed: int, start_time: datetime) -> None:
+def completion_message(
+    config: dict, img_files: list, summary_config: dict, images_processed: int, start_time: datetime
+) -> None:
     """
     Print a completion message summarising images processed.
 

--- a/topostats/processing.py
+++ b/topostats/processing.py
@@ -2,6 +2,7 @@
 
 import logging
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 
 import numpy as np
@@ -1643,7 +1644,7 @@ def check_run_steps(  # noqa: C901
         LOGGER.info("Configuration run options are consistent, processing can proceed.")
 
 
-def completion_message(config: dict, img_files: list, summary_config: dict, images_processed: int) -> None:
+def completion_message(config: dict, img_files: list, summary_config: dict, images_processed: int, start_time: datetime) -> None:
     """
     Print a completion message summarising images processed.
 
@@ -1657,11 +1658,16 @@ def completion_message(config: dict, img_files: list, summary_config: dict, imag
         Configuration for plotting summary statistics.
     images_processed : int
         Pandas DataFrame of results.
+    start_time : datetime
+        Datetime for start of processing.
     """
     if summary_config is not None:
         distribution_plots_message = str(summary_config["output_dir"])
     else:
         distribution_plots_message = "Disabled. Enable in config 'summary_stats/run' if needed."
+
+    end_time = datetime.now(timezone.utc)
+    elapsed = end_time - start_time
     print(
         "\n\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n\n"
     )
@@ -1674,6 +1680,7 @@ def completion_message(config: dict, img_files: list, summary_config: dict, imag
         f"  File Extension              : {config['file_ext']}\n"
         f"  Files Found                 : {len(img_files)}\n"
         f"  Successfully Processed^1    : {images_processed} ({(images_processed * 100) / len(img_files)}%)\n"
+        f"  Time taken                  : {datetime.fromtimestamp(elapsed.seconds, timezone.utc).strftime('%H:%M:%S')} (HH-MM-SS))\n"
         f"  All statistics              : {str(config['output_dir'])}/grain_statistics.csv\n"
         f"  Distribution Plots          : {distribution_plots_message}\n\n"
         f"  Configuration               : {config['output_dir']}/config.yaml\n\n"

--- a/topostats/run_modules.py
+++ b/topostats/run_modules.py
@@ -10,6 +10,7 @@ import logging
 import re
 import sys
 from collections import defaultdict
+from datetime import datetime, timezone
 from functools import partial
 from importlib import resources
 from multiprocessing import Pool
@@ -171,6 +172,8 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
     args : None
         Arguments.
     """
+    start_time: datetime = datetime.now(timezone.utc)
+
     config, img_files = _parse_configuration(args)
     processing_function = partial(
         process_scan,
@@ -420,7 +423,7 @@ def process(args: argparse.Namespace | None = None) -> None:  # noqa: C901
         summary_config = None
 
     # Update config with plotting defaults for printing
-    completion_message(config, img_files, summary_config, images_processed)
+    completion_message(config, img_files, summary_config, images_processed, start_time=start_time)
 
 
 # WIP these will be added from args once the dictionary keys have been wrangled
@@ -437,6 +440,8 @@ def filters(args: argparse.Namespace | None = None) -> None:
     args : None
         Arguments.
     """
+    start_time: datetime = datetime.now(timezone.utc)
+
     config, img_files = _parse_configuration(args)
     # If loading existing .topostats files the images need filtering again so we need to extract the raw image
     if config["file_ext"] == ".topostats":
@@ -473,7 +478,9 @@ def filters(args: argparse.Namespace | None = None) -> None:
     write_yaml(config, output_dir=config["output_dir"])
     LOGGER.debug(f"Images processed : {len(results)}")
     # Update config with plotting defaults for printing
-    completion_message(config, img_files, summary_config=None, images_processed=sum(results.values()))
+    completion_message(
+        config, img_files, summary_config=None, images_processed=sum(results.values()), start_time=start_time
+    )
 
 
 def grains(args: argparse.Namespace | None = None) -> None:
@@ -485,6 +492,8 @@ def grains(args: argparse.Namespace | None = None) -> None:
     args : None
         Arguments.
     """
+    start_time: datetime = datetime.now(timezone.utc)
+
     config, img_files = _parse_configuration(args)
     # Triggers extraction of filtered images from existing .topostats files
     if config["file_ext"] == ".topostats":
@@ -520,7 +529,9 @@ def grains(args: argparse.Namespace | None = None) -> None:
     write_yaml(config, output_dir=config["output_dir"])
     LOGGER.debug(f"Images processed : {len(results)}")
     # Update config with plotting defaults for printing
-    completion_message(config, img_files, summary_config=None, images_processed=sum(results.values()))
+    completion_message(
+        config, img_files, summary_config=None, images_processed=sum(results.values()), start_time=start_time
+    )
 
 
 def grainstats(args: argparse.Namespace | None = None) -> None:
@@ -532,6 +543,8 @@ def grainstats(args: argparse.Namespace | None = None) -> None:
     args : None
         Arguments.
     """
+    start_time: datetime = datetime.now(timezone.utc)
+
     config, img_files = _parse_configuration(args)  # pylint: disable=unused-variable
     # Triggers extraction of filtered images from existing .topostats files
     if config["file_ext"] == ".topostats":
@@ -581,7 +594,9 @@ def grainstats(args: argparse.Namespace | None = None) -> None:
     write_yaml(config, output_dir=config["output_dir"])
     LOGGER.debug(f"Images processed : {len(grain_stats_all)}")
     # Update config with plotting defaults for printing
-    completion_message(config, img_files, summary_config=None, images_processed=grain_stats_all_df.shape[0])
+    completion_message(
+        config, img_files, summary_config=None, images_processed=grain_stats_all_df.shape[0], start_time=start_time
+    )
 
 
 def disordered_tracing(args: argparse.Namespace | None = None) -> None:


### PR DESCRIPTION
An attempt to resolve #1294 

This records the `datetime` for each function in `run_modules` that later calls `completion_message`, and then passes it when `completion_message` is called to calculate the duration elapsed.

It doesn't break any tests but it would be good if someone else could test it on a real run.