### PR TITLE
Update docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-mkdocs.yaml
+++ b/.github/workflows/deploy-mkdocs.yaml
@@ -10,6 +10,11 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      is_release:
+        description: 'Deploy as a Release version (using most recent release)?'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,6 +31,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: ${{ github.event_name == 'pull_request' && 'main' || github.ref }}
 
       - name: Set up Python from pyproject.toml
@@ -44,22 +50,45 @@ jobs:
           git fetch origin gh-pages --depth=1 || true
 
       - name: Deploy Development Docs
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' &&
+          (github.event_name != 'workflow_dispatch' || inputs.is_release == false)
         run: mike deploy --push dev
 
       - name: Deploy Release Docs
-        if: github.event_name == 'release'
-        env:
-          TAG: ${{ github.event.release.tag_name }}
+        if: github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && inputs.is_release == true)
         run: |
+
+          # Auto-detect tag from release event or latest git tag
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            TAG=$(git tag -l | sort -V | tail -1)
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "Error: No release tag found"
+            exit 1
+          fi
+
+          echo "Deploying release docs for tag: $TAG"
+
+          # Check if docs for this version already exist
+          if mike list | grep -q "\"$TAG\""; then
+            echo "Docs for $TAG already exist. Skipping deploy."
+            exit 0
+          fi
+
           # Clean up the title of the previous 'latest' version
-          PREV_LATEST=$(mike list | grep "(latest)" | awk '{print $1}')
+          PREV_LATEST=$(mike list | grep "(latest)" | awk '{print $1}' | sed 's/"//g')
 
           # Probably overkill but leaving in as fallback - check versions.json if mike list is empty
           if [ -z "$PREV_LATEST" ]; then
+            echo "Previous latest not found, checking versions.json"
             git checkout origin/gh-pages -- versions.json 2>/dev/null || echo "[]" > versions.json
             PREV_LATEST=$(jq -r '.[] | select(.aliases[]? == "latest") | .version' versions.json)
           fi
+
+          echo "Previous latest found: $PREV_LATEST"
 
           if [ -n "$PREV_LATEST" ] && [ "$PREV_LATEST" != "null" ] && [ "$PREV_LATEST" != "$TAG" ]; then
             echo "Stripping (latest) suffix from $PREV_LATEST"


### PR DESCRIPTION
This fixes the issue with deploying a new release of the docs.
It also adds the option to manually deploy a new 'latest' version of the docs based on the most recent release tag (and will error if that version already exists or a tag can't be found).

Plus there are a few more messages to help with debugging, which can't hurt.