### PR TITLE
Sylvia whittle/extend branches to mask edge

### DIFF
--- a/tests/__snapshots__/test_classes.ambr
+++ b/tests/__snapshots__/test_classes.ambr
@@ -795,6 +795,8 @@
       }),
       'disordered_tracing': dict({
         'class_index': 1,
+        'endpoint_vector_follow_distance_nm': 5.0,
+        'extend_endpoints_to_mask_edge': False,
         'mask_smoothing_params': dict({
           'dilation_iterations': 2,
           'gaussian_sigma': 2,
@@ -2373,6 +2375,8 @@
       }),
       'disordered_tracing': dict({
         'class_index': 1,
+        'endpoint_vector_follow_distance_nm': 5.0,
+        'extend_endpoints_to_mask_edge': False,
         'mask_smoothing_params': dict({
           'dilation_iterations': 2,
           'gaussian_sigma': 2,

--- a/tests/tracing/test_disordered_tracing.py
+++ b/tests/tracing/test_disordered_tracing.py
@@ -1311,6 +1311,8 @@ def test_check_pixel_touching_edge(
         "image_filename",
         "topostats_object_fixture",
         "min_skeleton_size",
+        "extend_endpoints_to_mask_edge",
+        "endpoint_vector_follow_distance_nm",
         "mask_smoothing_params",
         "skeletonisation_params",
         "pruning_params",
@@ -1321,6 +1323,10 @@ def test_check_pixel_touching_edge(
             "topostats_catenanes_2_4_0",
             # Min skeleton size
             10,
+            # Extend endpoints to mask edge
+            False,
+            # Endpoint vector follow distance in nm
+            5.0,
             # Mask smoothing parameters
             {
                 "gaussian_sigma": 2,
@@ -1347,6 +1353,10 @@ def test_check_pixel_touching_edge(
             "topostats_rep_int_2_4_0",
             # Min skeleton size
             10,
+            # Extend endpoints to mask edge
+            False,
+            # Endpoint vector follow distance in nm
+            5.0,
             # Mask smoothing parameters
             {
                 "gaussian_sigma": 2,
@@ -1374,6 +1384,8 @@ def test_trace_image_disordered(
     image_filename: str,
     topostats_object_fixture: str,
     min_skeleton_size: int,
+    extend_endpoints_to_mask_edge: bool,
+    endpoint_vector_follow_distance_nm: float,
     mask_smoothing_params: dict,
     skeletonisation_params: dict,
     pruning_params: dict,
@@ -1390,6 +1402,8 @@ def test_trace_image_disordered(
         topostats_object=topostats_object,
         class_index=1,
         min_skeleton_size=min_skeleton_size,
+        extend_endpoints_to_mask_edge=extend_endpoints_to_mask_edge,
+        endpoint_vector_follow_distance_nm=endpoint_vector_follow_distance_nm,
         mask_smoothing_params=mask_smoothing_params,
         skeletonisation_params=skeletonisation_params,
         pruning_params=pruning_params,
@@ -1410,6 +1424,8 @@ def test_trace_image_disordered(
         "filename",
         "topostats_object",
         "min_skeleton_size",
+        "extend_endpoints_to_mask_edge",
+        "endpoint_vector_follow_distance_nm",
         "mask_smoothing_params",
         "skeletonisation_params",
         "pruning_params",
@@ -1421,6 +1437,10 @@ def test_trace_image_disordered(
             "topostats_catenanes_2_4_0",
             # Min skeleton size
             10,
+            # Extend endpoints to mask edge
+            False,
+            # Endpoint vector follow distance in nm
+            5.0,
             # Mask smoothing parameters
             {
                 "gaussian_sigma": 2,
@@ -1448,6 +1468,10 @@ def test_trace_image_disordered(
             "topostats_rep_int_2_4_0",
             # Min skeleton size
             10,
+            # Extend endpoints to mask edge
+            False,
+            # Endpoint vector follow distance in nm
+            5.0,
             # Mask smoothing parameters
             {
                 "gaussian_sigma": 2,
@@ -1476,6 +1500,8 @@ def test_trace_image_disordered_dataframes(
     filename: str,
     topostats_object: str,
     min_skeleton_size: int,
+    extend_endpoints_to_mask_edge: bool,
+    endpoint_vector_follow_distance_nm: float,
     mask_smoothing_params: dict,
     skeletonisation_params: dict,
     pruning_params: dict,
@@ -1492,6 +1518,8 @@ def test_trace_image_disordered_dataframes(
         topostats_object=topostats_object,
         class_index=1,
         min_skeleton_size=min_skeleton_size,
+        extend_endpoints_to_mask_edge=extend_endpoints_to_mask_edge,
+        endpoint_vector_follow_distance_nm=endpoint_vector_follow_distance_nm,
         mask_smoothing_params=mask_smoothing_params,
         skeletonisation_params=skeletonisation_params,
         pruning_params=pruning_params,

--- a/topostats/default_config.yaml
+++ b/topostats/default_config.yaml
@@ -80,6 +80,8 @@ disordered_tracing:
   run: true # Options : true, false
   class_index: 1 # The class index to trace. This is the class index of the grains.
   min_skeleton_size: 10 # Minimum number of pixels in a skeleton for it to be retained.
+  extend_endpoints_to_mask_edge: False # Whether to extend skeleton endpoints to the edge of the grain mask.
+  endpoint_vector_follow_distance_nm: 5.0 # The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
   mask_smoothing_params:
     gaussian_sigma: 2 # Gaussian smoothing parameter 'sigma' in pixels.
     dilation_iterations: 2 # Number of dilation iterations to use for grain smoothing.

--- a/topostats/mask_manipulation.py
+++ b/topostats/mask_manipulation.py
@@ -506,9 +506,7 @@ def find_hard_connected_endpoints(  # noqa: C901
     return hard_connected_endpoints
 
 
-def get_neighbouring_true_pixels(
-    mask: npt.NDArray[np.bool_], coord: npt.NDArray[np.integer]
-) -> list[npt.NDArray[np.integer]]:
+def get_neighbouring_true_pixels(mask: npt.NDArray[np.bool_], coord: npt.NDArray[int]) -> list[npt.NDArray[int]]:
     """
     Get the coordinates of neighbouring true pixels in a binary mask.
 
@@ -516,12 +514,12 @@ def get_neighbouring_true_pixels(
     ----------
     mask : npt.NDArray[np.bool_]
         The binary mask.
-    coord : npt.NDArray[np.integer]
+    coord : npt.NDArray[int]
         The coordinate to get neighbours for.
 
     Returns
     -------
-    list[npt.NDArray[np.integer]]
+    list[npt.NDArray[int]]
         A list of coordinates of neighbouring true pixels.
     """
     neighbours = []
@@ -542,7 +540,7 @@ def get_neighbouring_true_pixels(
 
 
 def get_point_along_branch(
-    skeleton: npt.NDArray[np.bool_], start_coord: npt.NDArray[np.integer], distance_px: float
+    skeleton: npt.NDArray[np.bool_], start_coord: npt.NDArray[np.int32], distance_px: float
 ) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
     """
     Get the coordinate and path taken of a point along a branch at a specified distance from a starting coordinate.
@@ -551,14 +549,14 @@ def get_point_along_branch(
     ----------
     skeleton : npt.NDArray[np.bool_]
         The skeleton image.
-    start_coord : npt.NDArray[np.integer]
+    start_coord : npt.NDArray[np.int32]
         The starting coordinate.
     distance_px : float
         The distance in pixels.
 
     Returns
     -------
-    tuple[npt.NDArray[np.integer], npt.NDArray[np.integer]]
+    tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]
         The coordinate of the point along the branch at the specified distance, and the path taken to get there.
     """
     skeleton_tracker = skeleton.copy()
@@ -586,8 +584,8 @@ def get_point_along_branch(
 
 
 def ray_cast(
-    point: npt.NDArray[np.integer],
-    direction: npt.NDArray[np.integer],
+    point: npt.NDArray[np.int32],
+    direction: npt.NDArray[np.int32],
     mask: npt.NDArray[np.bool_],
 ) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
     """
@@ -595,12 +593,18 @@ def ray_cast(
 
     Parameters
     ----------
-    point : npt.NDArray[np.integer]
+    point : npt.NDArray[np.int32]
         The starting point of the ray.
-    direction : npt.NDArray[np.integer]
+    direction : npt.NDArray[np.int32]
         The direction of the ray (should be a unit vector).
     mask : npt.NDArray[np.bool_]
         The binary mask to ray cast against.
+
+    Returns
+    -------
+    tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]
+        The coordinate of the first true pixel hit by the ray, and the path taken by the ray as a numpy array of shape
+        (N, 2).
     """
     # Normalize the direction to ensure it's a unit vector
     direction = direction / np.linalg.norm(direction)

--- a/topostats/mask_manipulation.py
+++ b/topostats/mask_manipulation.py
@@ -506,6 +506,119 @@ def find_hard_connected_endpoints(  # noqa: C901
     return hard_connected_endpoints
 
 
+def get_neighbouring_true_pixels(
+    mask: npt.NDArray[np.bool_], coord: npt.NDArray[np.integer]
+) -> list[npt.NDArray[np.integer]]:
+    """
+    Get the coordinates of neighbouring true pixels in a binary mask.
+
+    Parameters
+    ----------
+    mask : npt.NDArray[np.bool_]
+        The binary mask.
+    coord : npt.NDArray[np.integer]
+        The coordinate to get neighbours for.
+
+    Returns
+    -------
+    list[npt.NDArray[np.integer]]
+        A list of coordinates of neighbouring true pixels.
+    """
+    neighbours = []
+    for dx in [-1, 0, 1]:
+        for dy in [-1, 0, 1]:
+            if dx == 0 and dy == 0:
+                continue
+            neighbour_coord = coord + np.array([dx, dy])
+            if (
+                neighbour_coord[0] >= 0
+                and neighbour_coord[0] < mask.shape[0]
+                and neighbour_coord[1] >= 0
+                and neighbour_coord[1] < mask.shape[1]
+            ):
+                if mask[neighbour_coord[0], neighbour_coord[1]]:
+                    neighbours.append(neighbour_coord)
+    return neighbours
+
+
+def get_point_along_branch(
+    skeleton: npt.NDArray[np.bool_], start_coord: npt.NDArray[np.integer], distance_px: float
+) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
+    """
+    Get the coordinate and path taken of a point along a branch at a specified distance from a starting coordinate.
+
+    Parameters
+    ----------
+    skeleton : npt.NDArray[np.bool_]
+        The skeleton image.
+    start_coord : npt.NDArray[np.integer]
+        The starting coordinate.
+    distance_px : float
+        The distance in pixels.
+
+    Returns
+    -------
+    tuple[npt.NDArray[np.integer], npt.NDArray[np.integer]]
+        The coordinate of the point along the branch at the specified distance, and the path taken to get there.
+    """
+    skeleton_tracker = skeleton.copy()
+    distance_travelled_px = 0.0
+    path_taken = [start_coord]
+    current_coord = start_coord
+    skeleton_tracker[current_coord[0], current_coord[1]] = False
+    neighbours = get_neighbouring_true_pixels(skeleton_tracker, current_coord)
+    # note: if we ever encounter more than one neighbour, we stop and return that point, as it's
+    # a crossing / node, and we don't want to have to define how to deicde where to go from there.
+    while distance_travelled_px < distance_px:
+        if len(neighbours) == 0:
+            # we've reached the end of the branch before reaching the desired distance, so we return the last point
+            break
+        if len(neighbours) > 1:
+            # we've reached a crossing / node before reaching the desired distance, so we return the current point
+            break
+        next_coord = neighbours[0]
+        distance_travelled_px += np.linalg.norm(next_coord - current_coord)
+        current_coord = next_coord
+        path_taken.append(current_coord)
+        skeleton_tracker[current_coord[0], current_coord[1]] = False
+        neighbours = get_neighbouring_true_pixels(skeleton_tracker, current_coord)
+    return np.array(current_coord, dtype=np.int32), np.array(path_taken, dtype=np.int32)
+
+
+def ray_cast(
+    point: npt.NDArray[np.integer],
+    direction: npt.NDArray[np.integer],
+    mask: npt.NDArray[np.bool_],
+) -> tuple[npt.NDArray[np.int32], npt.NDArray[np.int32]]:
+    """
+    Ray cast from a point in a given direction until hitting a true pixel in the mask.
+
+    Parameters
+    ----------
+    point : npt.NDArray[np.integer]
+        The starting point of the ray.
+    direction : npt.NDArray[np.integer]
+        The direction of the ray (should be a unit vector).
+    mask : npt.NDArray[np.bool_]
+        The binary mask to ray cast against.
+    """
+    # Normalize the direction to ensure it's a unit vector
+    direction = direction / np.linalg.norm(direction)
+    current_point = point.copy()
+    current_point_int = np.round(current_point).astype(int)
+    ray_cast_path = [current_point_int.copy()]
+    # Keep stepping in the direction until we hit a true pixel or go out of bounds
+    while (
+        0 <= current_point_int[0] < mask.shape[0]
+        and 0 <= current_point_int[1] < mask.shape[1]
+        and not mask[current_point_int[0], current_point_int[1]]
+    ):
+        current_point = current_point.astype(float) + direction
+        current_point_int = np.round(current_point).astype(int)
+        ray_cast_path.append(current_point_int.copy())
+    return current_point_int, np.array(ray_cast_path, dtype=np.int32)
+
+
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-locals
 # pylint: disable=too-many-statements

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -11,12 +11,14 @@ import skan
 from scipy import ndimage
 from skimage import filters
 from skimage.morphology import label
+from skimage.draw import line
 
 from topostats.classes import DisorderedTrace, TopoStats
 from topostats.logs.logs import LOGGER_NAME
 from topostats.tracing.pruning import prune_skeleton
 from topostats.tracing.skeletonize import getSkeleton
 from topostats.utils import convolve_skeleton
+from topostats.mask_manipulation import get_point_along_branch, ray_cast
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 
@@ -61,6 +63,8 @@ class disorderedTrace:  # pylint: disable=too-many-instance-attributes
         filename: str,
         pixel_to_nm_scaling: float,
         min_skeleton_size: int = 10,
+        extend_endpoints_to_mask_edge: bool = False,
+        endpoint_vector_follow_distance_nm: float = 5.0,
         mask_smoothing_params: dict | None = None,
         skeletonisation_params: dict | None = None,
         pruning_params: dict | None = None,
@@ -98,6 +102,8 @@ class disorderedTrace:  # pylint: disable=too-many-instance-attributes
         self.filename = filename
         self.pixel_to_nm_scaling = pixel_to_nm_scaling
         self.min_skeleton_size = min_skeleton_size
+        self.extend_endpoints_to_mask_edge = extend_endpoints_to_mask_edge
+        self.endpoint_vector_follow_distance_nm = endpoint_vector_follow_distance_nm
         self.mask_smoothing_params = mask_smoothing_params
         self.skeletonisation_params = (
             skeletonisation_params if skeletonisation_params is not None else {"method": "zhang"}
@@ -135,6 +141,15 @@ class disorderedTrace:  # pylint: disable=too-many-instance-attributes
         self.pruned_skeleton = prune_skeleton(
             self.image, self.skeleton, self.pixel_to_nm_scaling, **self.pruning_params.copy()
         )
+        # extend endpoints to the edge of the mask
+        if self.extend_endpoints_to_mask_edge:
+            self.pruned_skeleton = extend_branch_ends_to_mask_edge(
+                skeleton=self.pruned_skeleton,
+                mask=self.smoothed_mask,
+                pixel_to_nm_scaling=self.pixel_to_nm_scaling,
+                endpoint_vector_follow_distance_nm=self.endpoint_vector_follow_distance_nm,
+            )
+
         self.pruned_skeleton = self.remove_touching_edge(self.pruned_skeleton)
         self.disordered_trace = np.argwhere(self.pruned_skeleton == 1)
 
@@ -327,6 +342,8 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
     topostats_object: TopoStats,
     class_index: int,
     min_skeleton_size: int,
+    extend_endpoints_to_mask_edge: bool,
+    endpoint_vector_follow_distance_nm: float,
     mask_smoothing_params: dict,
     skeletonisation_params: dict,
     pruning_params: dict,
@@ -342,6 +359,10 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
         Index of the class to trace.
     min_skeleton_size : int
         Minimum size of grain in pixels after skeletonisation.
+    extend_endpoints_to_mask_edge : bool
+        Whether to extend skeleton endpoints to the edge of the grain mask.
+    endpoint_vector_follow_distance_nm : float
+        The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
     mask_smoothing_params : dict
         Dictionary of parameters to smooth the grain mask for better quality skeletonisation results. Contains
         a gaussian 'sigma' and number of dilation iterations.
@@ -382,6 +403,8 @@ def trace_image_disordered(  # pylint: disable=too-many-arguments,too-many-local
                 skeletonisation_params=skeletonisation_params,
                 pruning_params=pruning_params,
                 min_skeleton_size=min_skeleton_size,
+                extend_endpoints_to_mask_edge=extend_endpoints_to_mask_edge,
+                endpoint_vector_follow_distance_nm=endpoint_vector_follow_distance_nm,
                 n_grain=grain_number,
             )
             LOGGER.debug(f"[{grain_crop.filename}] : Disordered Traced grain {grain_number + 1} of {number_of_grains}")
@@ -614,6 +637,8 @@ def disordered_trace_grain(  # pylint: disable=too-many-arguments
     filename: str = None,
     min_skeleton_size: int = 10,
     n_grain: int = None,
+    extend_endpoints_to_mask_edge: bool = False,
+    endpoint_vector_follow_distance_nm: float = 5.0,
 ) -> dict:
     """
     Trace an individual grain.
@@ -647,6 +672,10 @@ def disordered_trace_grain(  # pylint: disable=too-many-arguments
         Minimum size of grain in pixels after skeletonisation.
     n_grain : int
         Grain number being processed.
+    extend_endpoints_to_mask_edge : bool
+        Whether to extend skeleton endpoints to the edge of the grain mask.
+    endpoint_vector_follow_distance_nm : float
+        The distance in nanometres to follow the branch back for calculating the direction of the endpoint
 
     Returns
     -------
@@ -660,6 +689,8 @@ def disordered_trace_grain(  # pylint: disable=too-many-arguments
         filename=filename,
         pixel_to_nm_scaling=pixel_to_nm_scaling,
         min_skeleton_size=min_skeleton_size,
+        extend_endpoints_to_mask_edge=extend_endpoints_to_mask_edge,
+        endpoint_vector_follow_distance_nm=endpoint_vector_follow_distance_nm,
         mask_smoothing_params=mask_smoothing_params,
         skeletonisation_params=skeletonisation_params,
         pruning_params=pruning_params,
@@ -779,6 +810,64 @@ def pad_bounding_box(array_shape: tuple, bounding_box: list, pad_width: int) -> 
     # Right Column : Make this the last column if too close
     bounding_box[3] = array_shape[1] if bounding_box[3] + pad_width > array_shape[1] else bounding_box[3] + pad_width
     return bounding_box
+
+
+def extend_branch_ends_to_mask_edge(
+    skeleton: npt.NDArray,
+    mask: npt.NDArray,
+    pixel_to_nm_scaling: float,
+    endpoint_vector_follow_distance_nm: float,
+) -> npt.NDArray[np.bool_]:
+    """
+    Extend the ends of a skeleton to the edge of a mask.
+
+    Parameters
+    ----------
+    skeleton : npt.NDArray
+        A binary array representing the skeleton of a grain.
+    mask : npt.NDArray
+        A binary array representing the mask of a grain.
+
+    Returns
+    -------
+    npt.NDArray[np.bool_]
+        A binary array representing the extended skeleton.
+    """
+    # Convolve the skeleton
+    conv_skeleton = convolve_skeleton(skeleton)
+    endpoints = np.argwhere(conv_skeleton == 2)
+    extended_skeleton = skeleton.copy()
+
+    print(f"endpoins: {endpoints} px | {endpoints * pixel_to_nm_scaling} nm")
+
+    for endpoint in endpoints:
+        y, x = endpoint
+        # find the direction of the endpoint by backtracking along the skeleton and getting the vector
+        follow_distance_px = int(endpoint_vector_follow_distance_nm / pixel_to_nm_scaling)
+        backtracked_point, _path = get_point_along_branch(
+            skeleton=extended_skeleton,
+            start_coord=np.array([y, x]),
+            distance_px=follow_distance_px,
+        )
+        print(f"backtracked point: {backtracked_point}")
+        print(f"endpoint: {endpoint}")
+        vector = np.array([y, x]) - backtracked_point
+
+        # follow the vector from the endpoint until the edge of the mask is reached by sending out a ray
+        _mask_edge_point, ray_cast_path = ray_cast(
+            point=np.array([y, x]),
+            direction=vector,
+            mask=~mask.astype(np.bool),
+        )
+
+        # Use the point just before the edge of the mask to draw a line from the endpoint to the edge of the mask
+        penultimate_mask_edge_point = ray_cast_path[-2]
+
+        # draw a line from the endpoint to the edge of the mask
+        rows, cols = line(y, x, penultimate_mask_edge_point[0], penultimate_mask_edge_point[1])
+        extended_skeleton[rows, cols] = 1
+
+    return extended_skeleton
 
 
 # 2023-06-09 - Code that runs dnatracing in parallel across grains, left deliberately for use when we remodularise the

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -835,6 +835,10 @@ def extend_branch_ends_to_mask_edge(
         A binary array representing the skeleton of a grain.
     mask : npt.NDArray
         A binary array representing the mask of a grain.
+    pixel_to_nm_scaling : float
+        The scaling factor to convert pixels to nanometers.
+    endpoint_vector_follow_distance_nm : float
+        The distance in nanometers to follow the branch back for calculating the direction of the endpoint.
 
     Returns
     -------

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -43,6 +43,10 @@ class disorderedTrace:  # pylint: disable=too-many-instance-attributes
         Pixel to nm scaling.
     min_skeleton_size : int
         Minimum skeleton size below which tracing statistics are not calculated.
+    extend_endpoints_to_mask_edge : bool
+        Whether to extend skeleton endpoints to the edge of the grain mask.
+    endpoint_vector_follow_distance_nm : float
+        The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
     mask_smoothing_params : dict
         Dictionary of parameters to smooth the grain mask for better quality skeletonisation results. Contains
         a gaussian 'sigma' and number of dilation iterations.
@@ -85,6 +89,10 @@ class disorderedTrace:  # pylint: disable=too-many-instance-attributes
             Pixel to nm scaling.
         min_skeleton_size : int
             Minimum skeleton size below which tracing statistics are not calculated.
+        extend_endpoints_to_mask_edge : bool
+            Whether to extend skeleton endpoints to the edge of the grain mask.
+        endpoint_vector_follow_distance_nm : float
+            The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
         mask_smoothing_params : dict
             Dictionary of parameters to smooth the grain mask for better quality skeletonisation results. Contains
             a gaussian 'sigma' and number of dilation iterations.
@@ -675,7 +683,7 @@ def disordered_trace_grain(  # pylint: disable=too-many-arguments
     extend_endpoints_to_mask_edge : bool
         Whether to extend skeleton endpoints to the edge of the grain mask.
     endpoint_vector_follow_distance_nm : float
-        The distance in nanometres to follow the branch back for calculating the direction of the endpoint
+        The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
 
     Returns
     -------

--- a/topostats/tracing/disordered_tracing.py
+++ b/topostats/tracing/disordered_tracing.py
@@ -10,15 +10,15 @@ import pandas as pd
 import skan
 from scipy import ndimage
 from skimage import filters
-from skimage.morphology import label
 from skimage.draw import line
+from skimage.morphology import label
 
 from topostats.classes import DisorderedTrace, TopoStats
 from topostats.logs.logs import LOGGER_NAME
+from topostats.mask_manipulation import get_point_along_branch, ray_cast
 from topostats.tracing.pruning import prune_skeleton
 from topostats.tracing.skeletonize import getSkeleton
 from topostats.utils import convolve_skeleton
-from topostats.mask_manipulation import get_point_along_branch, ray_cast
 
 LOGGER = logging.getLogger(LOGGER_NAME)
 

--- a/topostats/validation.py
+++ b/topostats/validation.py
@@ -305,6 +305,12 @@ DEFAULT_CONFIG_SCHEMA = Schema(
             ),
             "class_index": int,
             "min_skeleton_size": lambda n: n > 0.0,
+            "extend_endpoints_to_mask_edge": Or(
+                True,
+                False,
+                error="Invalid value in config for 'disordered_tracing.pruning_params.extend_endpoints_to_mask_edge', valid values are 'True' or 'False'",
+            ),
+            "endpoint_vector_follow_distance_nm": lambda n: n > 0.0,
             "mask_smoothing_params": {
                 "gaussian_sigma": Or(
                     float,


### PR DESCRIPTION
Does as it says on the tin.

Before:
<img width="122" height="100" alt="image" src="https://github.com/user-attachments/assets/79df68ca-ec59-4325-8030-3618d31f4677" />


After:
<img width="113" height="96" alt="image" src="https://github.com/user-attachments/assets/3e617f2b-32db-467a-879a-40b5213aed25" />


New config parameters:
```yaml
  extend_endpoints_to_mask_edge: False # Whether to extend skeleton endpoints to the edge of the grain mask.
  endpoint_vector_follow_distance_nm: 5.0 # The distance in nanometres to follow the branch back for calculating the direction of the endpoint.
```

It's optional.

Test it out, let me know how it goes.

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds. Remember to update as required...
  - [ ] `docs/usage/configuration.md`
  - [ ] `docs/usage/data_dictionary.md`
  - [ ] `docs/usage/advanced.md` and new pages it should link to.
- [ ] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
