### PR TITLE
Add patch to allow using laura's unet

### DIFF
--- a/topostats/unet_masking.py
+++ b/topostats/unet_masking.py
@@ -166,8 +166,16 @@ def predict_unet(
 
     # Predict the mask
     LOGGER.info("Running Unet & predicting mask")
-    prediction: npt.NDArray[np.float32] = model.predict(np.expand_dims(image_resized_np, axis=(0, 3)))
-    LOGGER.info(f"Unet finished predicted mask. Prediction shape: {prediction.shape}")
+    try:
+        prediction: npt.NDArray[np.float32] = model.predict(np.expand_dims(image_resized_np, axis=(0, 3)))
+        LOGGER.info(f"Unet finished predicted mask. Prediction shape: {prediction.shape}")
+    except Exception as e:
+        LOGGER.error(f"Unet failed to predict a mask, trying padding the image with RGB channels... Error: {e}")
+        # If the model fails to predict, try padding the image with RGB channels
+        image_resized_np_rgb = np.repeat(image_resized_np[:, :, np.newaxis], 3, axis=2)
+        # axis = 2 since the image is now 3D with 3 channels
+        prediction: npt.NDArray[np.float32] = model.predict(np.expand_dims(image_resized_np_rgb, axis=0))
+        LOGGER.info(f"Unet finished predicted mask. Prediction shape: {prediction.shape}")
 
     # Threshold the predicted mask
     predicted_mask: npt.NDArray[np.bool_] = prediction > confidence


### PR DESCRIPTION
Patch to allow an old unet model to run in our code.

TLDR:
- The model was trained weird, and so expects (B, RGB(R), RGB(G), RGB(B), W, H) RGB data as opposed to what we are invariably working with (B, C(arbitrary channels, not RGB), W, H) since we work with height map data.

This simply tries running the model and if it crashes because of input shape mismatch it tries again after repeating the input data channel across the RGB channels.

It's a frantic patch just to get the model working on main for a paper.

Probably wants removing at some point in the future, it's messy.

---

Before submitting a Pull Request please check the following.

- [ ] Existing tests pass.
- [ ] Documentation has been updated and builds. Remember to update as required...
  - [ ] `docs/usage/configuration.md`
  - [ ] `docs/usage/data_dictionary.md`
  - [ ] `docs/usage/advanced.md` and new pages it should link to.
- [ ] Pre-commit checks pass.
- [ ] New functions/methods have typehints and docstrings.
- [ ] New functions/methods have tests which check the intended behaviour is correct.

## Optional

### `topostats/default_config.yaml`

If adding options to `topostats/default_config.yaml` please ensure.

- [ ] There is a comment adjacent to the option explaining what it is and the valid values.
- [ ] A check is made in `topostats/validation.py` to ensure entries are valid.
- [ ] Add the option to the relevant sub-parser in `topostats/entry_point.py`.
